### PR TITLE
Revert "Update cisco-8000.ini to use 202205-v0.1"

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202205-v0.1
+ref=v0.1


### PR DESCRIPTION
Reverts Azure/sonic-buildimage-msft#12
This change should go to public branch and not this branch.