### PR TITLE
Remove the test_get_platform_info tests whichis not present in

### DIFF
--- a/src/sonic-py-common/tests/device_info_test.py
+++ b/src/sonic-py-common/tests/device_info_test.py
@@ -141,27 +141,6 @@ class TestDeviceInfo(object):
         assert device_info.is_packet_chassis() == False
         assert device_info.is_chassis() == False
 
-    @mock.patch("sonic_py_common.device_info.ConfigDBConnector", autospec=True)
-    @mock.patch("sonic_py_common.device_info.get_sonic_version_info")
-    @mock.patch("sonic_py_common.device_info.get_machine_info")
-    @mock.patch("sonic_py_common.device_info.get_hwsku")
-    def test_get_platform_info(self, mock_hwsku, mock_machine_info, mock_sonic_ver, mock_cfg_db):
-        mock_cfg_inst = mock_cfg_db.return_value
-        mock_cfg_inst.get_table.return_value = {"localhost": {"switch_type": "npu"}}
-        mock_sonic_ver.return_value = SONIC_VERISON_YML_RESULT
-        mock_machine_info.return_value = {"onie_platform" : "x86_64-mlnx_msn2700-r0"}
-        mock_hwsku.return_value = "Mellanox-SN2700"
-        for _ in range(0,5):
-            hw_info_dict = device_info.get_platform_info()
-            assert hw_info_dict["asic_type"] == "mellanox"
-            assert hw_info_dict["platform"] == "x86_64-mlnx_msn2700-r0"
-            assert hw_info_dict["hwsku"] == "Mellanox-SN2700"
-            assert hw_info_dict["switch_type"] == "npu"
-        assert mock_sonic_ver.called_once()
-        assert mock_machine_info.called_once()
-        assert mock_hwsku.called_once()
-        mock_cfg_inst.get_table.assert_called_once_with("DEVICE_METADATA")
-
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")


### PR DESCRIPTION
sonic-buildimage/202205.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

