### PR TITLE
Fix Secureboot causing image load issue on pizzabox platforms

### DIFF
--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -758,7 +758,7 @@ echo "EXTRA_CMDLINE_LINUX=$extra_cmdline_linux"
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX $extra_cmdline_linux"
 GRUB_CFG_LINUX_CMD=""
 GRUB_CFG_INITRD_CMD=""
-if [ "$firmware" = "uefi" ] ; then
+if [ "$firmware" = "uefi" ] &&  expr "$secure_boot_state" : '[[:digit:]]\{1,\}' >/dev/null && [ "$secure_boot_state" -eq "$ENABLED" ]; then
     # grub.cfg when BIOS is UEFI and support Secure Boot
     GRUB_CFG_LINUX_CMD="linuxefi"
     GRUB_CFG_INITRD_CMD="initrdefi"


### PR DESCRIPTION

This is to fix a cherry-pick error where some changes got left out which causes the image not able to load on pizzabox platforms failling with following messages:
```
Loading SONiC-OS OS kernel ...Loading SONiC-OS OS kernel ...



error: can't find command `linuxefi'.
error: can't find command `linuxefi'.
Loading SONiC-OS OS initial ramdisk ...Loading SONiC-OS OS initial ramdisk ...
```
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

