### PR TITLE
[bgp]: Add sudo check for TSA/B/C command execution (#15288)

### DIFF
--- a/dockers/docker-fpm-frr/base_image_files/TSA
+++ b/dockers/docker-fpm-frr/base_image_files/TSA
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+# Restrict command to sudo users
+if [ "$EUID" -ne 0 ] ; then
+  echo "Root priveleges are needed for this operation"
+  exit 1
+fi
+
 if [ -f /etc/sonic/chassisdb.conf ]; then
-  rexec all -c "TSA chassis"
+  rexec all -c "sudo TSA chassis"
   echo "Please execute \"rexec all -c 'sudo config save -y'\" to preserve System mode in Maintenance after reboot\
   or config reload on all linecards"
   exit 0

--- a/dockers/docker-fpm-frr/base_image_files/TSB
+++ b/dockers/docker-fpm-frr/base_image_files/TSB
@@ -1,8 +1,14 @@
 #!/bin/bash
 
+# Restrict command to sudo users
+if [ "$EUID" -ne 0 ] ; then
+  echo "Root priveleges are needed for this operation"
+  exit 1
+fi
+
 # If run on supervisor of chassis, trigger remote execution of TSB on all linecards
 if [ -f /etc/sonic/chassisdb.conf ]; then
-  rexec all -c "TSB chassis"
+  rexec all -c "sudo TSB chassis"
   echo "Please execute \"rexec all -c 'sudo config save -y'\" to preserve System mode in Normal state after reboot\
  or config reload on all linecards"
   exit 0

--- a/dockers/docker-fpm-frr/base_image_files/TSC
+++ b/dockers/docker-fpm-frr/base_image_files/TSC
@@ -1,10 +1,16 @@
 #!/bin/bash
 
+# Restrict command to sudo users
+if [ "$EUID" -ne 0 ] ; then
+  echo "Root priveleges are needed for this operation"
+  exit 1
+fi
+
 if [ -f /etc/sonic/chassisdb.conf ]; then
   if [[ $1 == "no-stats" ]]; then
-    rexec all -c "TSC no-stats"
+    rexec all -c "sudo TSC no-stats"
   else
-    rexec all -c "TSC"
+    rexec all -c "sudo TSC"
   fi
   exit 0
 fi


### PR DESCRIPTION
TSA/B/C scripts invoke commands that require root permissions. If the user does not have sudo permissions, the scripts today execute until the command and throw a backtrace with error at the specific command. Added a check to ensure the operations check for root permissions upfront.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

