### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202205.3.2.2
+ref=202205.3.2.3


### PR DESCRIPTION
Updated platform version to 202205.3.2.3.

Release content for Cisco 8808 platform:
    * Fixed syncd crash due to 40G link configuration
    * Fixed load_minigraph failure due to 40G configuration
    * HBM route scale enablement for Vanguard Lancer
    * Fixed port handling of empty ecmp group to drop packets (MIGSMSFT-333 / SR 696141124)
