### PR TITLE
Cherry-pick 17483 and 17378 from public master to msft/202205

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_ndk.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_ndk.json
@@ -14,7 +14,7 @@
     },
     {
         "key": "monitor_action",
-        "stringval": "warn"
+        "stringval": "reboot"
     },
     {
         "key": "grpc_thermal_monitor",
@@ -43,6 +43,26 @@
     {
       "key": "sonic_log_level",
       "stringval": "debug"
+    },
+    {
+      "key": "thermal_low_margin_threshold",
+      "intval": 10
+    },
+    {
+      "key": "thermal_log_current_threshold",
+      "intval": 2
+    },
+    {
+      "key": "thermal_log_margin_threshold",
+      "intval": 2
+    },
+    {
+      "key": "thermal_log_min_threshold",
+      "intval": 2
+    },
+    {
+      "key": "thermal_log_max_threshold",
+      "intval": 1
     }
     ]
 }

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_reboot
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_reboot
@@ -17,6 +17,10 @@ update_reboot_cause()
     sync
 }
 
+echo "Disable all SFPs"
+python3 -c 'import sonic_platform.platform; platform_chassis = sonic_platform.platform.Platform().get_chassis(); platform_chassis.tx_disable_all_sfps()'
+sleep 3
+
 # update the reboot_cuase file when reboot is trigger by device-mgr
 update_reboot_cause
 

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_ndk.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_ndk.json
@@ -31,6 +31,26 @@
     {
       "key": "sonic_log_level",
       "stringval": "debug"
+    },
+    {
+      "key": "thermal_low_margin_threshold",
+      "intval": 10
+    },
+    {
+      "key": "thermal_log_current_threshold",
+      "intval": 3
+    },
+    {
+      "key": "thermal_log_margin_threshold",
+      "intval": 3
+    },
+    {
+      "key": "thermal_log_min_threshold",
+      "intval": 5
+    },
+    {
+      "key": "thermal_log_max_threshold",
+      "intval": 1
     }
     ]
 }

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_reboot
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_reboot
@@ -1,15 +1,39 @@
 #!/bin/bash
-echo "Rebooting all Linecards"
-python3 -c 'import sonic_platform.platform; platform_chassis = sonic_platform.platform.Platform().get_chassis(); platform_chassis.reboot_imms()'
-sleep 3
+
+DEVICE_MGR_REBOOT_FILE="/tmp/device_mgr_reboot"
+
+update_reboot_cause()
+{
+    DEVICE_MGR_REBOOT_FILE=/tmp/device_mgr_reboot
+    REBOOT_CAUSE_FILE=/host/reboot-cause/reboot-cause.txt
+    DEVICE_REBOOT_CAUSE_FILE=/etc/opt/srlinux/reboot-cause.txt
+    if [ -e  $DEVICE_MGR_REBOOT_FILE ]; then
+        if [ -e $DEVICE_REBOOT_CAUSE_FILE ]; then
+            cp -f $DEVICE_REBOOT_CAUSE_FILE $REBOOT_CAUSE_FILE
+        fi
+        rm -f $DEVICE_MGR_REBOOT_FILE
+    else
+        touch /etc/opt/srlinux/devmgr_reboot_cause.done
+        rm -f $DEVICE_REBOOT_CAUSE_FILE &> /dev/null
+    fi
+    sync
+}
+
+if [ ! -e $DEVICE_MGR_REBOOT_FILE ]; then
+    echo "Rebooting all Linecards"
+    python3 -c 'import sonic_platform.platform; platform_chassis = sonic_platform.platform.Platform().get_chassis(); platform_chassis.reboot_imms()'
+    sleep 3
+fi
+
+# update the reboot_cuase file when reboot is trigger by device-mgr
+update_reboot_cause
+
 systemctl stop nokia-watchdog.service
 sleep 2
 echo "w" > /dev/watchdog
 kick_date=`date -u`
 echo "last watchdog kick $kick_date" > /var/log/nokia-watchdog-last.log
 rm -f /sys/firmware/efi/efivars/dump-*
-touch /etc/opt/srlinux/devmgr_reboot_cause.done
-rm -f /etc/opt/srlinux/reboot-cause.txt
 echo "Shutdown midplane"
 ifconfig xe0 down
 sync


### PR DESCRIPTION
This is to manually cherry-pick these two PRs from public master to msft repo 202205 branch that are needed for the Nokia NDK 22.9.21

https://github.com/sonic-net/sonic-buildimage/pull/17483
https://github.com/sonic-net/sonic-buildimage/pull/17378

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

