### PR TITLE
[chassis] update service_checker module to handle database-chassis service (#17836)

### DIFF
--- a/src/system-health/health_checker/service_checker.py
+++ b/src/system-health/health_checker/service_checker.py
@@ -4,7 +4,7 @@ import pickle
 import re
 
 from swsscommon import swsscommon
-from sonic_py_common import multi_asic
+from sonic_py_common import multi_asic, device_info
 from sonic_py_common.logger import Logger
 from .health_checker import HealthChecker
 from . import utils
@@ -95,7 +95,9 @@ class ServiceChecker(HealthChecker):
                 else:
                     expected_running_containers.add(feature_name)
                     container_feature_dict[feature_name] = feature_name
-
+                    
+        if device_info.is_supervisor():
+            expected_running_containers.add("database-chassis")
         return expected_running_containers, container_feature_dict
 
     def get_current_running_containers(self):


### PR DESCRIPTION
* Update service_checker.py

#### Why I did it
This is to cherry-pick the fix needed for chassis platform for this public merged PR that was taken on master but not allowed for 202205 branch:
https://github.com/sonic-net/sonic-buildimage/pull/17836

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

