### PR TITLE
Add boundary check before memset, memcpy, strncpy

### DIFF
--- a/src/iccpd/src/iccp_cli.c
+++ b/src/iccpd/src/iccp_cli.c
@@ -117,7 +117,17 @@ int set_peer_link(int mid, const char* ifname)
                        csm->mlag_id, ifname);
     }
 
+    if (MAX_L_PORT_NAME > strlen(csm->peer_itf_name))
+    {
+        ICCPD_LOG_ERR(__FUNCTION__, "MAX=%d is greater than peer_itf_name length=%d", MAX_L_PORT_NAME, strlen(csm->peer_itf_name));
+        return MCLAG_ERROR;
+    }
     memset(csm->peer_itf_name, 0, MAX_L_PORT_NAME);
+    if (len > strlen(csm->peer_itf_name))
+    {
+        ICCPD_LOG_ERR(__FUNCTION__, "len=%d is greater than peer_itf_name length=%d", len, strlen(csm->peer_itf_name));
+        return MCLAG_ERROR;
+    }
     memcpy(csm->peer_itf_name, ifname, len);
 
     /* update peer-link link handler*/
@@ -208,8 +218,18 @@ int set_local_address(int mid, const char* addr)
 
     len = strlen(addr);
     memset(csm->sender_ip, 0, INET_ADDRSTRLEN);
+    if (len > strlen(csm->sender_ip))
+    {
+        ICCPD_LOG_ERR(__FUNCTION__, "len=%d is greater than sender_ip length=%d", len, strlen(csm->sender_ip));
+        return MCLAG_ERROR;
+    }
     memcpy(csm->sender_ip, addr, len);
     memset(csm->iccp_info.sender_name, 0, INET_ADDRSTRLEN);
+    if (len > strlen(csm->iccp_info.sender_name))
+    {
+        ICCPD_LOG_ERR(__FUNCTION__, "len=%d is greater than sender_name length=%d", len, strlen(csm->iccp_info.sender_name));
+        return MCLAG_ERROR;
+    }
     memcpy(csm->iccp_info.sender_name, addr, len);
 
     return 0;
@@ -268,6 +288,11 @@ int set_peer_address(int mid, const char* addr)
     }
 
     memset(csm->peer_ip, 0, INET_ADDRSTRLEN);
+    if (len > strlen(csm->peer_ip))
+    {
+        ICCPD_LOG_ERR(__FUNCTION__, "len=%d is greater than peer_ip length=%d", len, strlen(csm->peer_ip));
+        return MCLAG_ERROR;
+    }
     memcpy(csm->peer_ip, addr, len);
 
     return 0;

--- a/src/iccpd/src/iccp_cmd.c
+++ b/src/iccpd/src/iccp_cmd.c
@@ -135,6 +135,10 @@ int iccp_config_from_command(char * line)
                 cp++;
 
             slen = cp - start;
+            if (slen > strlen(token))
+            {
+                return MCLAG_ERROR;
+            }
             strncpy(token, start, slen);
             *(token + slen) = '\0';
             iccp_cli_attach_mclag_domain_to_port_channel(mid, token);


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
ADO 27008041
#### Why I did it
Add boundary check before memset, memcpy, strncpy calls to prevent buffer overflow
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [X] 202106
- [X] 202111
- [X] 202205
- [X] 202305

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

