### PR TITLE
[asic_sensors] Generate the asic_sensors polling configuration based on the platform.json (#20826)

### DIFF
--- a/src/sonic-config-engine/asic_sensors_config.py
+++ b/src/sonic-config-engine/asic_sensors_config.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import portconfig
+from sonic_py_common import device_info
+
+try:
+    if os.environ["CFGGEN_UNIT_TESTING"] == "2":
+        modules_path = os.path.join(os.path.dirname(__file__), ".")
+        tests_path = os.path.join(modules_path, "tests")
+        sys.path.insert(0, modules_path)
+        sys.path.insert(0, tests_path)
+        import mock_tables.dbconnector
+        mock_tables.dbconnector.load_namespace_config()
+
+except KeyError:
+    pass
+
+ASIC_SENSORS_KEY = "asic_sensors"
+
+
+def get_asic_sensors_config():
+    config = {}
+    if os.environ.get("CFGGEN_UNIT_TESTING") == "2":
+        json_file =  os.path.join(tests_path, "data",  "asic_sensors", "platform.json")
+    else:
+        platform_path = device_info.get_path_to_platform_dir()
+        json_file = os.path.join(platform_path, device_info.PLATFORM_JSON_FILE)
+        
+    if not os.path.exists(json_file):
+        return config
+    
+    platform_json = portconfig.readJson(json_file)
+    if not platform_json:
+        return config
+
+    if ASIC_SENSORS_KEY in platform_json:
+        config["ASIC_SENSORS"] = {"ASIC_SENSORS_POLLER_INTERVAL": {"interval": platform_json[ASIC_SENSORS_KEY]["poll_interval"]},
+                                  "ASIC_SENSORS_POLLER_STATUS":  {"admin_status": platform_json[ASIC_SENSORS_KEY]["poll_admin_status"]}
+                                  }
+    return config

--- a/src/sonic-config-engine/setup.py
+++ b/src/sonic-config-engine/setup.py
@@ -52,7 +52,8 @@ py_modules = [
     'minigraph',
     'openconfig_acl',
     'portconfig',
-    'smartswitch_config'
+    'smartswitch_config',
+    'asic_sensors_config'
 ]
 if sys.version_info.major == 3:
     # Python 3-only modules

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -37,7 +37,7 @@ from smartswitch_config import get_smartswitch_config
 from sonic_py_common.multi_asic import get_asic_id_from_name, get_asic_device_id, is_multi_asic
 from sonic_py_common import device_info
 from swsscommon.swsscommon import ConfigDBConnector, SonicDBConfig, ConfigDBPipeConnector
-
+from asic_sensors_config import get_asic_sensors_config
 
 PY3x = sys.version_info >= (3, 0)
 
@@ -464,6 +464,15 @@ def main():
                 hardware_data['DEVICE_METADATA']['localhost'].update(asic_id=device_id)
 
         deep_update(data, hardware_data)
+
+        asic_sensors = {}
+        if is_multi_asic():
+            if asic_name is not None:
+                asic_sensors = get_asic_sensors_config()
+        else:
+            asic_sensors = get_asic_sensors_config()
+        if asic_sensors:
+            deep_update(data, asic_sensors) 
 
     paths = ['/', '/usr/share/sonic/templates']
     if args.template_dir:

--- a/src/sonic-config-engine/tests/data/asic_sensors/platform.json
+++ b/src/sonic-config-engine/tests/data/asic_sensors/platform.json
@@ -1,0 +1,6 @@
+{
+    "asic_sensors": {
+        "poll_interval": "10",
+        "poll_admin_status": "enable"
+    }
+}

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -1155,3 +1155,13 @@ class TestCfgGen(TestCase):
         self.assertEqual(
             utils.liststr_to_dict(output.strip()),
             utils.liststr_to_dict("['192.168.200.15|161|', '100.0.0.6|161|', '100.0.0.7|161|', 'fe80::1%Management0|161|']"))
+   
+    def test_platform_asic_sensors_config(self):
+        os.environ["PLATFORM"] = "x86_64-kvm_x86_64-r0"
+        argument = ["-H","--print-data"]
+        output = self.run_script(argument, check_stderr=False)
+        config_json = utils.to_dict(output.strip())
+        os.environ["PLATFORM"] = ""
+        self.assertEqual(config_json['ASIC_SENSORS'], utils.to_dict("{'ASIC_SENSORS_POLLER_INTERVAL': {'interval': '10'}, 'ASIC_SENSORS_POLLER_STATUS': {'admin_status': 'enable'}}"))
+
+


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
For any platform which supports the asic_sensors pulling, it requires the configuration files (config_db#.json) contain the following configuration to trigger the system to poll the ASIC sensors temperature. Fixes https://github.com/Nokia-ION/ndk/issues/48
Adding Yang model support to fixes https://github.com/sonic-net/sonic-buildimage/issues/20633
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Add new module src/sonic-config-engine/asic_sensors_config.py with function get_asic_sensors_config(). This function checks if device data platform.json contains the following configuration, it will generate the asic_sensors pulling configuration.
```
$ cat platform.json
{
...
...
...
   "asic_sensors": {
        "poll_interval": "10",
        "poll_admin_status": "enable"
    }
}
```
- Modify the script sonic-cfggen platform option "-H" to call the function get_asic_sensor_config() to generate the asic_sensors pulling configuration.
- Added new UT test_asic_sensors_config() to test_cfggen.py to test related the implementation.

Notice: For all platforms which support the asic_sensors polling requires to add the following definition to the device data platform.json file

```
$ cat platform.json
{
...
...
...
   "asic_sensors": {
        "poll_interval": "10",
        "poll_admin_status": "enable"
    }
}
```

Also add Yang Model support the ASIC_SENSORS configuration. INcluding YangModel UT.
#### How to verify it
1. Running the new image on the platform which supports the ASIC_SENSORS
2. Execute the CLI command "sonic-cfggen -H --print-data", the following code will be generated
```
{
   "ASIC_SENSORS": {
        "ASIC_SENSORS_POLLER_INTERVAL": {
            "interval": "10"
        },
        "ASIC_SENSORS_POLLER_STATUS": {
            "admin_status": "enable"
        }
    }
}
```
