### PR TITLE
Add script to periodically update oper status of management interface

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -393,6 +393,8 @@ sudo cp $IMAGE_CONFIGS/monit/memory_checker $FILESYSTEM_ROOT/usr/bin/
 sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/memory_checker
 sudo cp $IMAGE_CONFIGS/monit/restart_service $FILESYSTEM_ROOT/usr/bin/
 sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/restart_service
+sudo cp $IMAGE_CONFIGS/monit/mgmt_oper_status.py $FILESYSTEM_ROOT/usr/bin/
+sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/mgmt_oper_status.py
 
 # Installed smartmontools version should match installed smartmontools in docker-platform-monitor Dockerfile
 # TODO: are mismatching versions fine for bookworm?

--- a/files/image_config/monit/conf.d/sonic-host
+++ b/files/image_config/monit/conf.d/sonic-host
@@ -56,3 +56,8 @@ check program vnetRouteCheck with path "/usr/local/bin/vnet_route_check.py"
 # memory_check tool that verifies that memory usage does not cross the threshold or invokes techsupport.
 check program memory_check with path "/usr/local/bin/memory_threshold_check.py"
     if status == 2 for 10 times within 20 cycles then exec "/usr/local/bin/memory_threshold_check_handler.py"
+
+# Periodically update oper status of mgmt interface in STATE_DB 
+check program mgmtOperStatus with path "/usr/bin/mgmt_oper_status.py"
+    every 1 cycles
+    if status != 0 for 3 cycle then alert repeat every 1 cycles

--- a/files/image_config/monit/mgmt_oper_status.py
+++ b/files/image_config/monit/mgmt_oper_status.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+"""
+"""
+import sys
+import subprocess
+import syslog
+
+from sonic_py_common import multi_asic, device_info
+from swsscommon.swsscommon import SonicV2Connector
+
+
+def main():
+    db = SonicV2Connector(use_unix_socket_path=True)
+    db.connect('CONFIG_DB')
+    db.connect('STATE_DB')
+    mgmt_ports_keys = db.keys(db.CONFIG_DB, 'MGMT_PORT|*' )
+    if not mgmt_ports_keys:
+        syslog.syslog(syslog.LOG_DEBUG, 'No management interface found')
+    else:
+        try:
+            mgmt_ports = [key.split('MGMT_PORT|')[-1] for key in mgmt_ports_keys]
+            for port in mgmt_ports:
+                state_db_mgmt_port = db.keys(db.STATE_DB, 'MGMT_PORT_TABLE|*' )
+                state_db_key = "MGMT_PORT_TABLE|{}".format(port)
+                prev_oper_status = 'unknown'
+                if state_db_key in state_db_mgmt_port:
+                    prev_oper_status = db.get(db.STATE_DB, state_db_key, 'oper_status')
+                port_operstate_path = '/sys/class/net/{}/operstate'.format(port)
+                oper_status = subprocess.run(['cat', port_operstate_path], capture_output=True, text=True)
+                current_oper_status = oper_status.stdout.strip()
+                if current_oper_status != prev_oper_status:
+                    db.set(db.STATE_DB, state_db_key, 'oper_status', current_oper_status)
+                    log_level = syslog.LOG_INFO if current_oper_status == 'up' else syslog.LOG_WARNING 
+                    syslog.syslog(log_level, "mgmt_oper_status: {}".format(current_oper_status))
+        except Exception as e:
+            syslog.syslog(syslog.LOG_ERR, "mgmt_oper_status exception : {}".format(str(e)))
+            db.set(db.STATE_DB, state_db_key, 'oper_status', 'unknown')
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/files/image_config/monit/tests/test_mgmt_oper_status.py
+++ b/files/image_config/monit/tests/test_mgmt_oper_status.py
@@ -1,0 +1,79 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import subprocess
+import syslog
+import sys
+import mgmt_oper_status
+
+class TestMgmtOperStatusCheck(unittest.TestCase):
+
+    @patch('mgmt_oper_status.SonicV2Connector')
+    @patch('mgmt_oper_status.subprocess.run')
+    @patch('mgmt_oper_status.syslog.syslog')
+    def test_main_no_mgmt_ports(self, mock_syslog, mock_subprocess, mock_SonicV2Connector):
+        mock_db = MagicMock()
+        mock_SonicV2Connector.return_value = mock_db
+        mock_db.keys.return_value = [] 
+
+        mgmt_oper_status.main()
+
+        mock_syslog.assert_called_with(syslog.LOG_DEBUG, 'No management interface found')
+
+    @patch('mgmt_oper_status.SonicV2Connector')
+    @patch('mgmt_oper_status.subprocess.run')
+    @patch('mgmt_oper_status.syslog.syslog')
+    def test_main_with_mgmt_ports(self, mock_syslog, mock_subprocess, mock_SonicV2Connector):
+        mock_db = MagicMock()
+        mock_SonicV2Connector.return_value = mock_db
+        mgmt_ports_keys = ['MGMT_PORT|eth0', 'MGMT_PORT|eth1']
+        mock_db.keys.return_value = mgmt_ports_keys
+        mock_db.set.return_value = None
+
+        mock_subprocess.return_value = subprocess.CompletedProcess(args=['cat', '/sys/class/net/eth0/operstate'], returncode=0, stdout='up', stderr='')
+
+        mgmt_oper_status.main()
+
+        mock_syslog.assert_any_call(syslog.LOG_INFO, 'mgmt_oper_status: up')
+        mock_syslog.assert_any_call(syslog.LOG_INFO, 'mgmt_oper_status: up')
+
+        mock_db.set.assert_any_call(mock_db.STATE_DB, 'MGMT_PORT_TABLE|eth0', 'oper_status', 'up')
+        mock_db.set.assert_any_call(mock_db.STATE_DB, 'MGMT_PORT_TABLE|eth1', 'oper_status', 'up')
+
+    @patch('mgmt_oper_status.SonicV2Connector')
+    @patch('mgmt_oper_status.subprocess.run')
+    @patch('mgmt_oper_status.syslog.syslog')
+    def test_main_with_mgmt_port_down(self, mock_syslog, mock_subprocess, mock_SonicV2Connector):
+        mock_db = MagicMock()
+        mock_SonicV2Connector.return_value = mock_db
+        mgmt_ports_keys = ['MGMT_PORT|eth0']
+        mock_db.keys.return_value = mgmt_ports_keys
+        mock_db.set.return_value = None
+
+        mock_subprocess.return_value = subprocess.CompletedProcess(args=['cat', '/sys/class/net/eth0/operstate'], returncode=0, stdout='down', stderr='')
+
+        mgmt_oper_status.main()
+
+        mock_syslog.assert_any_call(syslog.LOG_WARNING, 'mgmt_oper_status: down')
+
+        mock_db.set.assert_any_call(mock_db.STATE_DB, 'MGMT_PORT_TABLE|eth0', 'oper_status', 'down')
+
+
+    @patch('mgmt_oper_status.SonicV2Connector')
+    @patch('mgmt_oper_status.subprocess.run')
+    @patch('mgmt_oper_status.syslog.syslog')
+    def test_main_exception_handling(self, mock_syslog, mock_subprocess, mock_SonicV2Connector):
+        mock_db = MagicMock()
+        mock_SonicV2Connector.return_value = mock_db
+        mgmt_ports_keys = ['MGMT_PORT|eth0']
+        mock_db.keys.return_value = mgmt_ports_keys
+        mock_db.set.return_value = None
+
+        mock_subprocess.side_effect = Exception("File not found")
+
+        mgmt_oper_status.main()
+
+        mock_syslog.assert_called_with(syslog.LOG_ERR, "mgmt_oper_status exception : File not found")
+        mock_db.set.assert_any_call(mock_db.STATE_DB, 'MGMT_PORT_TABLE|eth0', 'oper_status', 'unknown')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Cherry-pick of changes  in https://github.com/sonic-net/sonic-buildimage/pull/21245
##### Work item tracking
- Microsoft ADO **30279044**:

#### How I did it
Remove update of mgmt oper status from sonic-swss
Use monit script to periodically update oper status of mgmt interface.
#### How to verify it
Verified on Chassis platform

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

