### PR TITLE
[YANG] Add srv6 yang model and unit tests

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -94,6 +94,7 @@ Table of Contents
          * [SYSTEM_DEFAULTS table](#systemdefaults-table)
          * [RADIUS](#radius)
          * [Static DNS](#static-dns)
+         * [SRv6](#srv6)
    * [For Developers](#for-developers)
       * [Generating Application Config by Jinja2 Template](#generating-application-config-by-jinja2-template)
       * [Incremental Configuration by Subscribing to ConfigDB](#incremental-configuration-by-subscribing-to-configdb)
@@ -2870,6 +2871,30 @@ The DNS_NAMESERVER table introduces static DNS nameservers configuration.
 		"1.1.1.1": {},
 		"fe80:1000:2000:3000::1": {}
 	},
+}
+```
+
+### SRv6
+
+The **SRV6_MY_SIDS** and **SRV6_MY_LOCATORS** tables introduce Segment Routing over IPv6 configuration.
+An example is as follows:
+```
+{
+    "SRV6_MY_LOCATORS" : {
+        "loc1" : {
+            "prefix" : "FCBB:BBBB:20::"
+        }
+    }
+    "SRV6_MY_SIDS" : {
+        "loc1|FCBB:BBBB:20::" : {
+           "action": "uN"
+        },
+        "loc1|FCBB:BBBB:20:F1::" : {
+           "action": "uDT46",
+           "decap_vrf": "default",
+           "decap_dscp_mode": "pipe"
+        }
+    }
 }
 ```
 

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/srv6.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/srv6.json
@@ -1,0 +1,36 @@
+{
+    "SRV6_VALID": {
+        "desc": "Valid config"
+    },
+    "SRV6_MY_LOCATOR_INVALID_FUNC_LEN": {
+        "desc": "A locator configured with invalid func_len",
+        "eStrKey" : "Must"
+    },
+    "SRV6_MY_LOCATOR_INVALID_VRF": {
+        "desc": "A locator configured with an invalid VRF name",
+        "eStrKey" : "InvalidValue",
+        "eStr": ["vrf"]
+    },
+    "SRV6_MY_SID_INVALID_LOCATOR": {
+        "desc": "A SID configured with invalid locator identifier",
+        "eStrKey" : "LeafRef"
+    },
+    "SRV6_MY_SID_INVALID_IP_ADDR": {
+        "desc": "A SID configured with invalid IPv6 address",
+        "eStrKey" : "Pattern"
+    },
+    "SRV6_MY_SID_UNMATCHED_IP_ADDR": {
+        "desc": "A SID configured with an IPv6 Address that does not match with the prefix of the locator",
+        "eStrKey" : "Must"
+    },
+    "SRV6_MY_SID_INVALID_ACTION": {
+        "desc": "A SID configured with invalid action",
+        "eStrKey" : "InvalidValue",
+        "eStr": ["action"]
+    },
+    "SRV6_MY_SID_DSCP_MODE_WITH_UN": {
+        "desc": "A SID configured with dscp_mode and uN action",
+        "eStrKey" : "When",
+        "eStr": ["action"]
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/srv6.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/srv6.json
@@ -1,0 +1,213 @@
+{
+    "SRV6_VALID": {
+        "sonic-srv6:sonic-srv6": {
+            "sonic-srv6:SRV6_MY_LOCATORS": {
+                "SRV6_MY_LOCATORS_LIST": [
+                    {
+                        "locator_name": "MAIN",
+                        "prefix": "FCBB:BBBB:20::"
+                    }
+                ]
+            },
+            "sonic-srv6:SRV6_MY_SIDS": {
+                "SRV6_MY_SIDS_LIST": [
+                    {
+                        "ip_address": "FCBB:BBBB:20::",
+                        "locator": "MAIN",
+                        "action": "uN"
+                    },
+                    {
+                        "ip_address": "FCBB:BBBB:20:F1::",
+                        "locator": "MAIN",
+                        "action": "uDT46"
+                    }
+                ]
+            }
+        }
+    },
+    "SRV6_MY_LOCATOR_INVALID_FUNC_LEN": {
+        "sonic-srv6:sonic-srv6": {
+            "sonic-srv6:SRV6_MY_LOCATORS": {
+                "SRV6_MY_LOCATORS_LIST": [
+                    {
+                        "locator_name": "MAIN",
+                        "prefix": "FCBB:BBBB:20::",
+                        "func_len": 127
+                    }
+                ]
+            },
+            "sonic-srv6:SRV6_MY_SIDS": {
+                "SRV6_MY_SIDS_LIST": [
+                    {
+                        "ip_address": "FCBB:BBBB:20::",
+                        "locator": "MAIN",
+                        "action": "uN"
+                    },
+                    {
+                        "ip_address": "FCBB:BBBB:20:F1::",
+                        "locator": "MAIN",
+                        "action": "uDT46"
+                    }
+                ]
+            }
+        }
+    },
+    "SRV6_MY_LOCATOR_INVALID_VRF": {
+        "sonic-srv6:sonic-srv6": {
+            "sonic-srv6:SRV6_MY_LOCATORS": {
+                "SRV6_MY_LOCATORS_LIST": [
+                    {
+                        "locator_name": "MAIN",
+                        "prefix": "FCBB:BBBB:20::",
+                        "vrf": "Vrf1"
+                    }
+                ]
+            },
+            "sonic-srv6:SRV6_MY_SIDS": {
+                "SRV6_MY_SIDS_LIST": [
+                    {
+                        "ip_address": "FCBB:BBBB:20::",
+                        "locator": "MAIN",
+                        "action": "uN"
+                    },
+                    {
+                        "ip_address": "FCBB:BBBB:20:F1::",
+                        "locator": "MAIN",
+                        "action": "uDT46"
+                    }
+                ]
+            }
+        }
+    },
+    "SRV6_MY_SID_INVALID_LOCATOR": {
+        "sonic-srv6:sonic-srv6": {
+            "sonic-srv6:SRV6_MY_LOCATORS": {
+                "SRV6_MY_LOCATORS_LIST": [
+                    {
+                        "locator_name": "MAIN",
+                        "prefix": "FCBB:BBBB:20::"
+                    }
+                ]
+            },
+            "sonic-srv6:SRV6_MY_SIDS": {
+                "SRV6_MY_SIDS_LIST": [
+                    {
+                        "ip_address": "FCBB:BBBB:20::",
+                        "locator": "None",
+                        "action": "uN"
+                    },
+                    {
+                        "ip_address": "FCBB:BBBB:20:F1::",
+                        "locator": "MAIN",
+                        "action": "uDT46"
+                    }
+                ]
+            }
+        }
+    },
+    "SRV6_MY_SID_INVALID_IP_ADDR": {
+        "sonic-srv6:sonic-srv6": {
+            "sonic-srv6:SRV6_MY_LOCATORS": {
+                "SRV6_MY_LOCATORS_LIST": [
+                    {
+                        "locator_name": "MAIN",
+                        "prefix": "FCBB:BBBB:20::"
+                    }
+                ]
+            },
+            "sonic-srv6:SRV6_MY_SIDS": {
+                "SRV6_MY_SIDS_LIST": [
+                    {
+                        "ip_address": "FCBB:BBBB:200001::",
+                        "locator": "MAIN",
+                        "action": "uN"
+                    },
+                    {
+                        "ip_address": "FCBB:BBBB:20:F1::",
+                        "locator": "MAIN",
+                        "action": "uDT46"
+                    }
+                ]
+            }
+        }
+    },
+    "SRV6_MY_SID_UNMATCHED_IP_ADDR": {
+        "sonic-srv6:sonic-srv6": {
+            "sonic-srv6:SRV6_MY_LOCATORS": {
+                "SRV6_MY_LOCATORS_LIST": [
+                    {
+                        "locator_name": "MAIN",
+                        "prefix": "FCBB:BBBB:20::"
+                    }
+                ]
+            },
+            "sonic-srv6:SRV6_MY_SIDS": {
+                "SRV6_MY_SIDS_LIST": [
+                    {
+                        "ip_address": "FCBB:BBBB:21::",
+                        "locator": "MAIN",
+                        "action": "uN"
+                    },
+                    {
+                        "ip_address": "FCBB:BBBB:20:F1::",
+                        "locator": "MAIN",
+                        "action": "uDT46"
+                    }
+                ]
+            }
+        }
+    },
+    "SRV6_MY_SID_INVALID_ACTION": {
+        "sonic-srv6:sonic-srv6": {
+            "sonic-srv6:SRV6_MY_LOCATORS": {
+                "SRV6_MY_LOCATORS_LIST": [
+                    {
+                        "locator_name": "MAIN",
+                        "prefix": "FCBB:BBBB:20::"
+                    }
+                ]
+            },
+            "sonic-srv6:SRV6_MY_SIDS": {
+                "SRV6_MY_SIDS_LIST": [
+                    {
+                        "ip_address": "FCBB:BBBB:20::",
+                        "locator": "MAIN",
+                        "action": "uA"
+                    },
+                    {
+                        "ip_address": "FCBB:BBBB:20:F1::",
+                        "locator": "MAIN",
+                        "action": "uDT46"
+                    }
+                ]
+            }
+        }
+    },
+    "SRV6_MY_SID_DSCP_MODE_WITH_UN": {
+        "sonic-srv6:sonic-srv6": {
+            "sonic-srv6:SRV6_MY_LOCATORS": {
+                "SRV6_MY_LOCATORS_LIST": [
+                    {
+                        "locator_name": "MAIN",
+                        "prefix": "FCBB:BBBB:20::"
+                    }
+                ]
+            },
+            "sonic-srv6:SRV6_MY_SIDS": {
+                "SRV6_MY_SIDS_LIST": [
+                    {
+                        "ip_address": "FCBB:BBBB:20::",
+                        "locator": "MAIN",
+                        "action": "uN",
+                        "decap_dscp_mode": "uniform"
+                    },
+                    {
+                        "ip_address": "FCBB:BBBB:20:F1::",
+                        "locator": "MAIN",
+                        "action": "uDT46"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-srv6.yang
+++ b/src/sonic-yang-models/yang-models/sonic-srv6.yang
@@ -1,0 +1,139 @@
+module sonic-srv6 {
+    namespace "http://github.com/sonic-net/sonic-srv6";
+    prefix srv6;
+    yang-version 1.1;
+
+    import ietf-yang-types {
+		prefix yang;
+	}
+
+	import ietf-inet-types {
+		prefix inet;
+	}
+
+    import sonic-vrf {
+		prefix vrf;
+	}
+
+    revision 2024-12-05 {
+		description
+			"Initial revision.";
+	}
+
+    container sonic-srv6 {
+
+        container SRV6_MY_LOCATORS {
+            list SRV6_MY_LOCATORS_LIST {
+                key "locator_name";
+
+                leaf locator_name {
+                    type string;
+                }
+
+                leaf prefix {
+                    type inet:ipv6-address;
+                    mandatory true;
+                }
+
+                leaf block_len {
+                    type uint8 {
+                        range "1..128";
+                    }
+                    
+                    default 32;
+                }
+
+                leaf node_len {
+                    type uint8 {
+                        range "1..128";
+                    }
+
+                    default 16;
+                }
+
+                leaf func_len {
+                    type uint8 {
+                        range "1..128";
+                    }
+
+                    default 16;
+                }
+
+                leaf arg_len {
+                    type uint8 {
+                        range "0..128";
+                    }
+
+                    default 0;
+                }
+
+                must 'block_len + node_len + func_len + arg_len <= 128';
+
+                leaf vrf {
+                    type union {
+                        type leafref {
+                            path "/vrf:sonic-vrf/vrf:VRF/vrf:VRF_LIST/vrf:name";
+                        }
+                        type string {
+                            pattern 'default';
+                        }
+                    }
+                    description "VRF name";
+
+                    default "default";
+                }
+            }
+        }
+
+        container SRV6_MY_SIDS {
+            list SRV6_MY_SIDS_LIST {
+                key "locator ip_address";
+
+                leaf ip_address {
+                    type inet:ipv6-address;
+                }
+
+                leaf locator {
+                    type leafref {
+                        path "/srv6:sonic-srv6/srv6:SRV6_MY_LOCATORS/srv6:SRV6_MY_LOCATORS_LIST/srv6:locator_name";
+                    }
+                }
+
+                leaf action {
+                    type enumeration {
+                        enum uN;
+                        enum uDT46;
+                    }
+                }
+
+                leaf decap_vrf {
+                    type union {
+                        type leafref {
+                            path "/vrf:sonic-vrf/vrf:VRF/vrf:VRF_LIST/vrf:name";
+                        }
+                        type string {
+                            pattern 'default';
+                        }
+                    }
+                    description "VRF name used for decapsulation";
+
+                    default "default";
+                }
+
+                leaf decap_dscp_mode {
+                    type enumeration {
+                        enum uniform;
+                        enum pipe;
+                    }
+                    when "../action = 'uDT46'";
+
+                    default "uniform";
+                }
+
+                must 'starts-with(./ip_address,
+                                  substring-before(/srv6:sonic-srv6/SRV6_MY_LOCATORS/SRV6_MY_LOCATORS_LIST[current()/locator]/prefix, "::"))';
+            }
+        }
+        
+    }
+}


### PR DESCRIPTION
Cherry-pick PR for [SRv6 YANG](https://github.com/sonic-net/sonic-buildimage/pull/21175) to resolve the conflict.
----------------------------------------------------------------------------------------------------
Why I did it
To support the addition of two new tables in CONFIG_DB, i.e. SRV6_MY_SIDS and SRV6_MY_LOCATORS, in order to allow configuration for SRv6 in SONiC.

Work item tracking
Microsoft ADO (number only): 30513277

How I did it
I define the YANG model based on SRv6 HLD.

How to verify it
Run the unit tests and build image.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
