### PR TITLE
[202412] Set up PR testing in 202412 branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,6 +176,7 @@ stages:
         MIN_WORKER: $(T0_INSTANCE_NUM)
         MAX_WORKER: $(T0_INSTANCE_NUM)
         MGMT_BRANCH: $(BUILD_BRANCH)
+        STOP_ON_FAILURE: "False"
 
   - job: t0_2vlans_elastictest
     pool: sonic-ubuntu-1c
@@ -191,6 +192,7 @@ stages:
         MAX_WORKER: $(T0_2VLANS_INSTANCE_NUM)
         MGMT_BRANCH: $(BUILD_BRANCH)
         DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
+        STOP_ON_FAILURE: "False"
 
   - job: t1_lag_elastictest
     pool: sonic-ubuntu-1c
@@ -204,6 +206,7 @@ stages:
         MIN_WORKER: $(T1_LAG_INSTANCE_NUM)
         MAX_WORKER: $(T1_LAG_INSTANCE_NUM)
         MGMT_BRANCH: $(BUILD_BRANCH)
+        STOP_ON_FAILURE: "False"
 
   - job: multi_asic_elastictest
     displayName: "kvmtest-multi-asic-t1-lag by Elastictest"
@@ -219,6 +222,7 @@ stages:
           MAX_WORKER: $(MULTI_ASIC_INSTANCE_NUM)
           NUM_ASIC: 4
           MGMT_BRANCH: $(BUILD_BRANCH)
+          STOP_ON_FAILURE: "False"
 
   - job: dualtor_elastictest
     pool: sonic-ubuntu-1c
@@ -233,6 +237,7 @@ stages:
           MAX_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
           MGMT_BRANCH: $(BUILD_BRANCH)
           COMMON_EXTRA_PARAMS: "--disable_loganalyzer "
+          STOP_ON_FAILURE: "False"
 
   - job: sonic_t0_elastictest
     displayName: "kvmtest-t0-sonic by Elastictest"
@@ -249,6 +254,7 @@ stages:
           MGMT_BRANCH: $(BUILD_BRANCH)
           COMMON_EXTRA_PARAMS: "--neighbor_type=sonic "
           VM_TYPE: vsonic
+          STOP_ON_FAILURE: "False"
 
   - job: dpu_elastictest
     displayName: "kvmtest-dpu by Elastictest"
@@ -262,6 +268,7 @@ stages:
           MIN_WORKER: $(T0_SONIC_INSTANCE_NUM)
           MAX_WORKER: $(T0_SONIC_INSTANCE_NUM)
           MGMT_BRANCH: $(BUILD_BRANCH)
+          STOP_ON_FAILURE: "False"
 
   - job: onboarding_elastictest_t0
     displayName: "onboarding t0 testcases by Elastictest - optional"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,7 +176,6 @@ stages:
         MIN_WORKER: $(T0_INSTANCE_NUM)
         MAX_WORKER: $(T0_INSTANCE_NUM)
         MGMT_BRANCH: $(BUILD_BRANCH)
-        STOP_ON_FAILURE: "False"
 
   - job: t0_2vlans_elastictest
     pool: sonic-ubuntu-1c
@@ -192,7 +191,6 @@ stages:
         MAX_WORKER: $(T0_2VLANS_INSTANCE_NUM)
         MGMT_BRANCH: $(BUILD_BRANCH)
         DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
-        STOP_ON_FAILURE: "False"
 
   - job: t1_lag_elastictest
     pool: sonic-ubuntu-1c
@@ -206,7 +204,6 @@ stages:
         MIN_WORKER: $(T1_LAG_INSTANCE_NUM)
         MAX_WORKER: $(T1_LAG_INSTANCE_NUM)
         MGMT_BRANCH: $(BUILD_BRANCH)
-        STOP_ON_FAILURE: "False"
 
   - job: multi_asic_elastictest
     displayName: "kvmtest-multi-asic-t1-lag by Elastictest"
@@ -222,7 +219,6 @@ stages:
           MAX_WORKER: $(MULTI_ASIC_INSTANCE_NUM)
           NUM_ASIC: 4
           MGMT_BRANCH: $(BUILD_BRANCH)
-          STOP_ON_FAILURE: "False"
 
   - job: dualtor_elastictest
     pool: sonic-ubuntu-1c
@@ -237,7 +233,6 @@ stages:
           MAX_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
           MGMT_BRANCH: $(BUILD_BRANCH)
           COMMON_EXTRA_PARAMS: "--disable_loganalyzer "
-          STOP_ON_FAILURE: "False"
 
   - job: sonic_t0_elastictest
     displayName: "kvmtest-t0-sonic by Elastictest"
@@ -254,7 +249,6 @@ stages:
           MGMT_BRANCH: $(BUILD_BRANCH)
           COMMON_EXTRA_PARAMS: "--neighbor_type=sonic "
           VM_TYPE: vsonic
-          STOP_ON_FAILURE: "False"
 
   - job: dpu_elastictest
     displayName: "kvmtest-dpu by Elastictest"
@@ -268,7 +262,6 @@ stages:
           MIN_WORKER: $(T0_SONIC_INSTANCE_NUM)
           MAX_WORKER: $(T0_SONIC_INSTANCE_NUM)
           MGMT_BRANCH: $(BUILD_BRANCH)
-          STOP_ON_FAILURE: "False"
 
   - job: onboarding_elastictest_t0
     displayName: "onboarding t0 testcases by Elastictest - optional"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,11 +25,11 @@ name: $(TeamProject)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd
 
 resources:
   repositories:
-  - repository: sonic-mgmt
+  - repository: sonic-mgmt.msft
     type: github
-    name: sonic-net/sonic-mgmt
-    ref: master
-    endpoint: sonic-net
+    name: Azure/sonic-mgmt.msft
+    ref: 202412
+    endpoint: build
   - repository: buildimage
     type: github
     name: sonic-net/sonic-buildimage
@@ -170,7 +170,7 @@ stages:
     timeoutInMinutes: 240
     continueOnError: false
     steps:
-    - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
+    - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt.msft
       parameters:
         TOPOLOGY: t0
         MIN_WORKER: $(T0_INSTANCE_NUM)
@@ -183,7 +183,7 @@ stages:
     timeoutInMinutes: 240
     continueOnError: false
     steps:
-    - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
+    - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt.msft
       parameters:
         TOPOLOGY: t0
         TEST_SET: t0-2vlans
@@ -198,7 +198,7 @@ stages:
     timeoutInMinutes: 240
     continueOnError: false
     steps:
-    - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
+    - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt.msft
       parameters:
         TOPOLOGY: t1-lag
         MIN_WORKER: $(T1_LAG_INSTANCE_NUM)
@@ -211,7 +211,7 @@ stages:
     timeoutInMinutes: 240
     continueOnError: false
     steps:
-      - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
+      - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt.msft
         parameters:
           TOPOLOGY: t1-8-lag
           TEST_SET: multi-asic-t1-lag
@@ -226,7 +226,7 @@ stages:
     timeoutInMinutes: 240
     continueOnError: false
     steps:
-      - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
+      - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt.msft
         parameters:
           TOPOLOGY: dualtor
           MIN_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
@@ -240,7 +240,7 @@ stages:
     timeoutInMinutes: 240
     continueOnError: false
     steps:
-      - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
+      - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt.msft
         parameters:
           TOPOLOGY: t0-64-32
           MIN_WORKER: $(T0_SONIC_INSTANCE_NUM)
@@ -256,7 +256,7 @@ stages:
     continueOnError: false
     pool: sonic-ubuntu-1c
     steps:
-      - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
+      - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt.msft
         parameters:
           TOPOLOGY: dpu
           MIN_WORKER: $(T0_SONIC_INSTANCE_NUM)
@@ -269,7 +269,7 @@ stages:
     continueOnError: true
     pool: sonic-ubuntu-1c
     steps:
-      - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
+      - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt.msft
         parameters:
           TOPOLOGY: t0
           STOP_ON_FAILURE: "False"
@@ -286,7 +286,7 @@ stages:
     continueOnError: true
     pool: sonic-ubuntu-1c
     steps:
-      - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
+      - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt.msft
         parameters:
           TOPOLOGY: t1-lag
           STOP_ON_FAILURE: "False"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,6 +176,7 @@ stages:
         MIN_WORKER: $(T0_INSTANCE_NUM)
         MAX_WORKER: $(T0_INSTANCE_NUM)
         MGMT_BRANCH: $(BUILD_BRANCH)
+        MGMT_URL: "https://raw.githubusercontent.com/Azure/sonic-mgmt.msft"
 
   - job: t0_2vlans_elastictest
     pool: sonic-ubuntu-1c
@@ -191,6 +192,7 @@ stages:
         MAX_WORKER: $(T0_2VLANS_INSTANCE_NUM)
         MGMT_BRANCH: $(BUILD_BRANCH)
         DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
+        MGMT_URL: "https://raw.githubusercontent.com/Azure/sonic-mgmt.msft"
 
   - job: t1_lag_elastictest
     pool: sonic-ubuntu-1c
@@ -204,6 +206,7 @@ stages:
         MIN_WORKER: $(T1_LAG_INSTANCE_NUM)
         MAX_WORKER: $(T1_LAG_INSTANCE_NUM)
         MGMT_BRANCH: $(BUILD_BRANCH)
+        MGMT_URL: "https://raw.githubusercontent.com/Azure/sonic-mgmt.msft"
 
   - job: multi_asic_elastictest
     displayName: "kvmtest-multi-asic-t1-lag by Elastictest"
@@ -219,6 +222,7 @@ stages:
           MAX_WORKER: $(MULTI_ASIC_INSTANCE_NUM)
           NUM_ASIC: 4
           MGMT_BRANCH: $(BUILD_BRANCH)
+          MGMT_URL: "https://raw.githubusercontent.com/Azure/sonic-mgmt.msft"
 
   - job: dualtor_elastictest
     pool: sonic-ubuntu-1c
@@ -233,6 +237,7 @@ stages:
           MAX_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
           MGMT_BRANCH: $(BUILD_BRANCH)
           COMMON_EXTRA_PARAMS: "--disable_loganalyzer "
+          MGMT_URL: "https://raw.githubusercontent.com/Azure/sonic-mgmt.msft"
 
   - job: sonic_t0_elastictest
     displayName: "kvmtest-t0-sonic by Elastictest"
@@ -249,6 +254,7 @@ stages:
           MGMT_BRANCH: $(BUILD_BRANCH)
           COMMON_EXTRA_PARAMS: "--neighbor_type=sonic "
           VM_TYPE: vsonic
+          MGMT_URL: "https://raw.githubusercontent.com/Azure/sonic-mgmt.msft"
 
   - job: dpu_elastictest
     displayName: "kvmtest-dpu by Elastictest"
@@ -262,67 +268,4 @@ stages:
           MIN_WORKER: $(T0_SONIC_INSTANCE_NUM)
           MAX_WORKER: $(T0_SONIC_INSTANCE_NUM)
           MGMT_BRANCH: $(BUILD_BRANCH)
-
-  - job: onboarding_elastictest_t0
-    displayName: "onboarding t0 testcases by Elastictest - optional"
-    timeoutInMinutes: 240
-    continueOnError: true
-    pool: sonic-ubuntu-1c
-    steps:
-      - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt.msft
-        parameters:
-          TOPOLOGY: t0
-          STOP_ON_FAILURE: "False"
-          RETRY_TIMES: 0
-          MIN_WORKER: $(T0_ONBOARDING_SONIC_INSTANCE_NUM)
-          MAX_WORKER: $(T0_ONBOARDING_SONIC_INSTANCE_NUM)
-          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-          MGMT_BRANCH: $(BUILD_BRANCH)
-          TEST_SET: onboarding_t0
-
-  - job: onboarding_elastictest_t1
-    displayName: "onboarding t1 testcases by Elastictest - optional"
-    timeoutInMinutes: 240
-    continueOnError: true
-    pool: sonic-ubuntu-1c
-    steps:
-      - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt.msft
-        parameters:
-          TOPOLOGY: t1-lag
-          STOP_ON_FAILURE: "False"
-          RETRY_TIMES: 0
-          MIN_WORKER: $(T1_LAG_ONBOARDING_INSTANCE_NUM)
-          MAX_WORKER: $(T1_LAG_ONBOARDING_INSTANCE_NUM)
-          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-          MGMT_BRANCH: $(BUILD_BRANCH)
-          TEST_SET: onboarding_t1
-
-#  - job: onboarding_elastictest_dualtor
-#    displayName: "onboarding dualtor testcases by Elastictest - optional"
-#    timeoutInMinutes: 240
-#    continueOnError: true
-#    pool: sonic-ubuntu-1c
-#    steps:
-#      - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
-#        parameters:
-#          TOPOLOGY: dualtor
-#          STOP_ON_FAILURE: "False"
-#          RETRY_TIMES: 0
-#          MIN_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
-#          MAX_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
-#          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-#          MGMT_BRANCH: $(BUILD_BRANCH)
-#          TEST_SET: onboarding_dualtor
-
-#  - job: wan_elastictest
-#    displayName: "kvmtest-wan by Elastictest"
-#    pool: sonic-ubuntu-1c
-#    timeoutInMinutes: 240
-#    continueOnError: false
-#    steps:
-#      - template: .azure-pipelines/run-test-scheduler-template.yml
-#        parameters:
-#          TOPOLOGY: wan-pub
-#          MIN_WORKER: $(WAN_INSTANCE_NUM)
-#          MAX_WORKER: $(WAN_INSTANCE_NUM)
-#          COMMON_EXTRA_PARAMS: "--skip_sanity "
+          MGMT_URL: "https://raw.githubusercontent.com/Azure/sonic-mgmt.msft"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Set up PR testing in 202412 branch.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Use Azure/sonic-mgmt.msft as test code repo.

#### How to verify it
Test by pipeline itself.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

