### PR TITLE
[chassis][multi-asic]: Add support for vendor LC ip range for macvlan  ip (#22008)

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -197,8 +197,18 @@ function postStartAction()
            ip link set dev ns-eth1"$NET_NS" netns "$NET_NS"
            ip netns exec "$NET_NS" ip link set ns-eth1"$NET_NS" name eth1
 
+           if [[ -n "$lc_ip_offset" ]]; then
+	       # Use ip offset provided by platform vendor via chassisdb.conf to prevent any conflict
+	       # with any platform IP range, e.g., LC eth1-midplane IP.
+               ip_offset=$lc_ip_offset
+           else
+	       # If Vendor has not provided an ip offset, Use 10 as default offset. Platform vendor should
+	       # ensure there is no conflict with platform IP range for any slot.
+               ip_offset=10
+           fi
+
            # Configure IP address and enable eth1
-           slot_ip_address=`echo $midplane_subnet | awk -F. '{print $1 "." $2}'`.$slot_id.$(($DEV + 10))
+           slot_ip_address=`echo $midplane_subnet | awk -F. '{print $1 "." $2}'`.$slot_id.$(($DEV + $ip_offset))
            slot_subnet_mask=${midplane_subnet#*/}
            ip netns exec "$NET_NS" ip addr add $slot_ip_address/$slot_subnet_mask dev eth1
            ip netns exec "$NET_NS" ip link set dev eth1 up


### PR DESCRIPTION

Signed-off-by: Anand Mehra anamehra@cisco.com

#### Why I did it

As per current design, macvlan IP start with an offset of 10 from miplane Ip subnet base ip on a namespace.
In some platforms this may cause conflict if the LC midplane ip for any slot falls in that range. The IP conflict cause midplane traffic loss.

In Cisco Chassis, macvlan IP may conflict with LC midplane IP range. This conflict causes midplane traffic loss for conflicting ip and affects any LC namespace transaction with Supervisor.

To prevent any conflict, Venddor may provide an offset to be used to generate macvlan IP address to prevent any conflict with midplane IP address.

##### Work item tracking
- Microsoft ADO **(31798758)**:

#### How I did it
Added an ip_offset value which Vendor may provide based on their midplane ip range to generate safe IP address for macvlan in namespace.

The **lc_ip_offset**  offset needs to be set in **/usr/share/sonic/device/<platform>/chassisdb.conf** file for the LC where an offset is required.

```
cat chassisdb.conf
chassis_db_address=127.0.0.3
midplane_subnet=127.0.0.0/16
lc_ip_offset=100
```

#### How to verify it
After boot, check eth1 IP address in namespaces. The IP addresses should not conflict with any expected LC eth1-midplane IP or any other IP in the system.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

