### PR TITLE
[202412] Code sync sonic-net/sonic-buildimage:202411 => 202412

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/buffers.json.j2
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/buffers.json.j2
@@ -1,0 +1,1 @@
+../Mellanox-SN4280-O28/buffers.json.j2

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../Mellanox-SN4280-O28/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/buffers_defaults_t0.j2
@@ -1,0 +1,1 @@
+../Mellanox-SN4280-O28/buffers_defaults_t0.j2

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/buffers_defaults_t1.j2
@@ -1,0 +1,44 @@
+{#
+    Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+    Apache-2.0
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+#}
+{% set default_cable = '300m' %}
+{%-set ports2cable = {
+            'spinerouter_leafrouter' : '2000m',
+            'leafrouter_torrouter' : '300m'
+       }
+-%}
+{% set ingress_lossless_pool_size  =  '48422912' %}
+{% set ingress_lossless_pool_xoff  =   '6098944' %}
+{% set egress_lossless_pool_size   =  '60817392' %}
+{% set egress_lossy_pool_size      =  '48422912' %}
+
+{% import 'buffers_defaults_objects.j2' as defs with context %}
+
+{%- macro generate_buffer_pool_and_profiles_with_inactive_ports(port_names_inactive) %}
+{{ defs.generate_buffer_pool_and_profiles_with_inactive_ports(port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
+{%- endmacro %}
+

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/buffers_dynamic.json.j2
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/buffers_dynamic.json.j2
@@ -1,0 +1,1 @@
+../Mellanox-SN4280-O28/buffers_dynamic.json.j2

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/hwsku.json
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/hwsku.json
@@ -1,0 +1,264 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet4": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet8": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet12": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet16": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet20": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet24": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet28": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet32": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet36": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet40": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet44": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet48": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet52": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet56": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet60": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet64": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet68": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet72": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet76": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet80": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet84": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet88": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet92": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet96": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet104": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet112": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet120": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet128": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet136": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet144": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet152": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet160": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet164": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet168": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet172": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet176": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet180": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet184": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet188": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet192": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet196": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet200": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet204": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet208": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet212": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet216": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet220": {
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet224": {
+            "default_brkout_mode": "1x400G",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet232": {
+            "default_brkout_mode": "1x400G",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet240": {
+            "default_brkout_mode": "1x400G",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet248": {
+            "default_brkout_mode": "1x400G",
+            "subport": "1",
+            "autoneg": "off"
+        }
+    }
+}

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/media_settings.json
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/media_settings.json
@@ -1,0 +1,1 @@
+../Mellanox-SN4280-O28/media_settings.json

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/optics_si_settings.json
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/optics_si_settings.json
@@ -1,0 +1,1 @@
+../Mellanox-SN4280-O28/optics_si_settings.json

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/pg_profile_lookup.ini
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/pg_profile_lookup.ini
@@ -1,0 +1,60 @@
+##
+## Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+## Apache-2.0
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+#  PG lossless profiles.
+# speed cable  size   xon    xoff   threshold
+  10000    5m 19456  19456  16384          0
+  25000    5m 19456  19456  17408          0
+  40000    5m 19456  19456  19456          0
+  50000    5m 19456  19456  21504          0
+ 100000    5m 19456  19456  37888          0
+ 200000    5m 19456  19456  43008          0
+ 400000    5m 38912  38912  73728          0
+  10000   30m 19456  19456  16384          0
+  25000   30m 19456  19456  18432          0
+  40000   30m 19456  19456  21504          0
+  50000   30m 19456  19456  23552          0
+ 100000   30m 19456  19456  43008          0
+ 200000   30m 19456  19456  51200          0
+ 400000   30m 38912  38912  91136          0
+  10000   40m 19456  19456  16384          0
+  25000   40m 19456  19456  18432          0
+  40000   40m 19456  19456  21504          0
+  50000   40m 19456  19456  23552          0
+ 100000   40m 19456  19456  43008          0
+ 200000   40m 19456  19456  51200          0
+ 400000   40m 38912  38912  91136          0
+  10000  300m 19456  19456  19456          0
+  25000  300m 19456  19456  26624          0
+  40000  300m 19456  19456  34816          0
+  50000  300m 19456  19456  40960          0
+ 100000  300m 19456  19456  75776          0
+ 200000  300m 19456  19456  118784         0
+ 400000  300m 38912  38912  225280         0
+  10000 1500m 19456  19456  35840          0
+  25000 1500m 19456  19456  65536          0
+  40000 1500m 19456  19456  96256          0
+  50000 1500m 19456  19456  117760         0
+ 100000 1500m 19456  19456  230400         0
+ 200000 1500m 19456  19456  427008         0
+ 400000 1500m 38912  38912  427008         0
+  10000 2000m 19456  19456  41984          0
+  25000 2000m 19456  19456  80896          0
+  40000 2000m 19456  19456  121856         0
+  50000 2000m 19456  19456  149504         0
+ 100000 2000m 19456  19456  293888         0
+ 200000 2000m 19456  19456  555008         0
+ 400000 2000m 38912  38912  555008         0

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/pmon_daemon_control.json
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8C48/pmon_daemon_control.json

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/port_config.ini
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/port_config.ini
@@ -1,0 +1,70 @@
+##
+## Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+## Apache-2.0
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+# name         lanes                                  alias     index    speed
+Ethernet0      0,1,2,3                                etp1a     1        100000
+Ethernet4      4,5,6,7                                etp1b     1        100000
+Ethernet8      8,9,10,11                              etp2a     2        100000
+Ethernet12     12,13,14,15                            etp2b     2        100000
+Ethernet16     16,17,18,19                            etp3a     3        100000
+Ethernet20     20,21,22,23                            etp3b     3        100000
+Ethernet24     24,25,26,27                            etp4a     4        100000
+Ethernet28     28,29,30,31                            etp4b     4        100000
+Ethernet32     32,33,34,35                            etp5a     5        100000
+Ethernet36     36,37,38,39                            etp5b     5        100000
+Ethernet40     40,41,42,43                            etp6a     6        100000
+Ethernet44     44,45,46,47                            etp6b     6        100000
+Ethernet48     48,49,50,51                            etp7a     7        100000
+Ethernet52     52,53,54,55                            etp7b     7        100000
+Ethernet56     56,57,58,59                            etp8a     8        100000
+Ethernet60     60,61,62,63                            etp8b     8        100000
+Ethernet64     64,65,66,67                            etp9a     9        100000
+Ethernet68     68,69,70,71                            etp9b     9        100000
+Ethernet72     72,73,74,75                            etp10a    10       100000
+Ethernet76     76,77,78,79                            etp10b    10       100000
+Ethernet80     80,81,82,83                            etp11a    11       100000
+Ethernet84     84,85,86,87                            etp11b    11       100000
+Ethernet88     88,89,90,91                            etp12a    12       100000
+Ethernet92     92,93,94,95                            etp12b    12       100000
+Ethernet96     96,97,98,99,100,101,102,103            etp13     13       400000
+Ethernet104    104,105,106,107,108,109,110,111        etp14     14       400000
+Ethernet112    112,113,114,115,116,117,118,119        etp15     15       400000
+Ethernet120    120,121,122,123,124,125,126,127        etp16     16       400000
+Ethernet128    128,129,130,131,132,133,134,135        etp17     17       400000
+Ethernet136    136,137,138,139,140,141,142,143        etp18     18       400000
+Ethernet144    144,145,146,147,148,149,150,151        etp19     19       400000
+Ethernet152    152,153,154,155,156,157,158,159        etp20     20       400000
+Ethernet160    160,161,162,163                        etp21a    21       100000
+Ethernet164    164,165,166,167                        etp21b    21       100000
+Ethernet168    168,169,170,171                        etp22a    22       100000
+Ethernet172    172,173,174,175                        etp22b    22       100000
+Ethernet176    176,177,178,179                        etp23a    23       100000
+Ethernet180    180,181,182,183                        etp23b    23       100000
+Ethernet184    184,185,186,187                        etp24a    24       100000
+Ethernet188    188,189,190,191                        etp24b    24       100000
+Ethernet192    192,193,194,195                        etp25a    25       100000
+Ethernet196    196,197,198,199                        etp25b    25       100000
+Ethernet200    200,201,202,203                        etp26a    26       100000
+Ethernet204    204,205,206,207                        etp26b    26       100000
+Ethernet208    208,209,210,211                        etp27a    27       100000
+Ethernet212    212,213,214,215                        etp27b    27       100000
+Ethernet216    216,217,218,219                        etp28a    28       100000
+Ethernet220    220,221,222,223                        etp28b    28       100000
+Ethernet224    224,225,226,227,228,229,230,231        etp29     29       400000
+Ethernet232    232,233,234,235,236,237,238,239        etp30     30       400000
+Ethernet240    240,241,242,243,244,245,246,247        etp31     31       400000
+Ethernet248    248,249,250,251,252,253,254,255        etp32     32       400000

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/qos.json.j2
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/qos.json.j2
@@ -1,0 +1,1 @@
+../Mellanox-SN4280-O28/qos.json.j2

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/sai.profile
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/sai.profile
@@ -1,0 +1,1 @@
+../Mellanox-SN4280-O28/sai.profile

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/sai_4280.xml
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/sai_4280.xml
@@ -1,0 +1,1 @@
+../Mellanox-SN4280-O28/sai_4280.xml

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -201,8 +201,18 @@ function postStartAction()
            ip link set dev ns-eth1"$NET_NS" netns "$NET_NS"
            ip netns exec "$NET_NS" ip link set ns-eth1"$NET_NS" name eth1
 
+           if [[ -n "$lc_ip_offset" ]]; then
+	       # Use ip offset provided by platform vendor via chassisdb.conf to prevent any conflict
+	       # with any platform IP range, e.g., LC eth1-midplane IP.
+               ip_offset=$lc_ip_offset
+           else
+	       # If Vendor has not provided an ip offset, Use 10 as default offset. Platform vendor should
+	       # ensure there is no conflict with platform IP range for any slot.
+               ip_offset=10
+           fi
+
            # Configure IP address and enable eth1
-           slot_ip_address=`echo $midplane_subnet | awk -F. '{print $1 "." $2}'`.$slot_id.$(($DEV + 10))
+           slot_ip_address=`echo $midplane_subnet | awk -F. '{print $1 "." $2}'`.$slot_id.$(($DEV + $ip_offset))
            slot_subnet_mask=${midplane_subnet#*/}
            ip netns exec "$NET_NS" ip addr add $slot_ip_address/$slot_subnet_mask dev eth1
            ip netns exec "$NET_NS" ip link set dev eth1 up

--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -216,11 +216,6 @@ def main():
         print("Expected containers not running: " + ", ".join(not_running_containers))
         sys.exit(3)
 
-    unexpected_running_containers = current_running_containers.difference(expected_running_containers)
-    if unexpected_running_containers:
-        print("Unexpected running containers: " + ", ".join(unexpected_running_containers))
-        sys.exit(4)
-
 
 if __name__ == "__main__":
     main()

--- a/files/initramfs-tools/union-mount.j2
+++ b/files/initramfs-tools/union-mount.j2
@@ -218,9 +218,6 @@ mkdir -p ${rootmnt}/boot
 mkdir -p ${rootmnt}/host/$image_dir/boot
 mount --bind ${rootmnt}/host/$image_dir/boot ${rootmnt}/boot
 
-## Mount the /tmp directory as tmpfs
-mount -t tmpfs -o rw,nosuid,nodev,size=25% tmpfs ${rootmnt}/tmp
-
 ## Mount loop device or tmpfs for /var/log
 if $logs_inram; then
     # NOTE: some platforms, when reaching initramfs stage, have a small

--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -482,6 +482,9 @@ bootloader_menu_config()
     if echo "$CPUVENDOR" | grep -i 'Intel' >/dev/null 2>&1; then
         echo "Switch CPU cstates are: disabled"
         CSTATES="processor.max_cstate=1 intel_idle.max_cstate=0"
+    elif echo "$CPUVENDOR" | grep -i 'AMD' >/dev/null 2>&1; then
+        echo "Switch CPU cstates are: disabled"
+        CSTATES="processor.max_cstate=1 amd_idle.max_cstate=0"
     else
         CSTATES=""
     fi

--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202411.1.0.2
+ref=202411.1.0.4


### PR DESCRIPTION
Code sync sonic-net/sonic-buildimage:202411 => 202412

```
*   875852e7b (HEAD -> code-sync-202412, origin/code-sync-202412) r12f 250330:2343 - Merge remote-tracking branch 'base/202411' into code-sync-202412
|\  
| * e523d5171 (base/202411) mssonicbld 250329:0401 - Fix auditd container monit startup issue (#22012)
| * 0615c4a83 mssonicbld 250329:0325 - [installer] Add CSTATE configuration for the AMD CPU. (#22060)
| * 606ff683d mssonicbld 250328:1601 - [submodule] Update submodule sonic-swss to the latest HEAD automatically (#22159)
| * fb3640419 Aravind-Subbaroyan 250326:1714 - Update cisco-8000.ini (#22154)
| * 869a801f3 mssonicbld 250325:1901 - [submodule] Update submodule sonic-utilities to the latest HEAD automatically (#22127)
| * 81af0affe mssonicbld 250325:1601 - [chassis][multi-asic]: Add support for vendor LC ip range for macvlan ip (#22125)
| * a4f5972cd sschlafman 250321:1508 - [202411] Add new T1 Mellanox-SN4280-O8C40 SKU for 202411 (#22103)
| * b945441e6 mssonicbld 250322:0516 - [submodule] Update submodule sonic-sairedis to the latest HEAD automatically (#22090)
| * cac6efbe5 Dror Prital 250321:1846 - [202411][Mellanox] Update SDK/FW Version to 4.7.2214/2014.2214 (#22097)
| * 855e80d54 Zhijian Li 250322:0213 - [202411] Revert "Mount the /tmp directory as tmpfs" (#22080)
```