### PR TITLE
[Nokia][Device] Add BCM DNX soc properties to set STAN_ALN mode correctly

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/jr2cp-nokia-18x100g-4x25g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/jr2cp-nokia-18x100g-4x25g-config.bcm
@@ -2100,3 +2100,5 @@ trunk_group_max_members=16
 sai_default_cpu_tx_tc=7
 sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
 sai_disable_srcmacqedstmac_ctrl=1
+appl_param_active_links_thr_low=1
+appl_param_active_links_thr_high=112

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/jr2cp-nokia-18x100g-4x25g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/jr2cp-nokia-18x100g-4x25g-config.bcm
@@ -2101,3 +2101,5 @@ trunk_group_max_members=16
 sai_default_cpu_tx_tc=7
 sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
 sai_disable_srcmacqedstmac_ctrl=1
+appl_param_active_links_thr_low=1
+appl_param_active_links_thr_high=112

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/jr2cp-nokia-18x400g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/jr2cp-nokia-18x400g-config.bcm
@@ -2101,3 +2101,5 @@ sai_pfc_dlr_init_capability=0
 trunk_group_max_members=16
 sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
+appl_param_active_links_thr_low=1
+appl_param_active_links_thr_high=112

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/jr2cp-nokia-18x400g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/jr2cp-nokia-18x400g-config.bcm
@@ -2103,3 +2103,5 @@ sai_pfc_dlr_init_capability=0
 trunk_group_max_members=16
 sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
+appl_param_active_links_thr_low=1
+appl_param_active_links_thr_high=112


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Porting the PR https://github.com/sonic-net/sonic-buildimage/pull/21864 to msft repo.
The STAN_ALN mode was set incorrectly in BCM DNX asics and was advised by BCM to set these soc variables to correct it (One FAP with STAN_ALN=1 and other FAPs with STAN_ALN=0).
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added the soc variables in BCM config
#### How to verify it
Verified the STAN_ALN mode in all FAPS and also passing traffic without any issues.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

