### PR TITLE
[VoQ_T2_PizzaBox] Modify the existing common code to support VOQ T2 for PizzaBox 

### DIFF
--- a/dockers/docker-fpm-frr/base_image_files/TSA
+++ b/dockers/docker-fpm-frr/base_image_files/TSA
@@ -11,7 +11,13 @@ if [ "$EUID" -ne 0 ] ; then
   exit 1
 fi
 
-if [ -f /etc/sonic/chassisdb.conf ] && [ "$SMARTSWITCH" = false ] ; then
+PLATFORM="$(sonic-cfggen -d -v DEVICE_METADATA.localhost.platform)"
+PLATFORM_ENV_CONF_FILE=/usr/share/sonic/device/$PLATFORM/platform_env.conf
+if [ -f $PLATFORM_ENV_CONF_FILE ]; then
+  source $PLATFORM_ENV_CONF_FILE
+fi
+
+if [ -f /etc/sonic/chassisdb.conf ] && [ "$SMARTSWITCH" = false ] && [[ $disaggregated_chassis -ne 1 ]]; then
   CHASSIS_TSA_STATE_UPDATE="CHASSIS_APP_DB HMSET "BGP_DEVICE_GLOBAL\|STATE" tsa_enabled "true""
   CONFIG_DB_TSA_STATE_UPDATE='{"BGP_DEVICE_GLOBAL":{"STATE":{"tsa_enabled": "true"}}}'
   current_tsa_state="$(sonic-cfggen -d -v BGP_DEVICE_GLOBAL.STATE.tsa_enabled)"
@@ -49,8 +55,10 @@ fi
 /usr/bin/TS TSA
 if [[ "$(sonic-cfggen -d -v DEVICE_METADATA.localhost.type)" == *"SpineRouter"* ]] ; then
   if [[ "$1" != "chassis" ]] ; then
-    echo "Please execute 'sudo config save' to preserve System mode in Maintenance after reboot or config reload"
-    echo -e "\nWARNING: Please execute 'TSA' on all other linecards of the chassis to fully isolate this device"    
+      echo "Please execute 'sudo config save' to preserve System mode in Maintenance after reboot or config reload"
+      if [[ $disaggregated_chassis -ne 1 ]]; then
+          echo -e "\nWARNING: Please execute 'TSA' on all other linecards of the chassis to fully isolate this device"
+      fi
   fi
 else
   echo "Please execute 'sudo config save' to preserve System mode in Maintenance after reboot or config reload"

--- a/dockers/docker-fpm-frr/base_image_files/TSB
+++ b/dockers/docker-fpm-frr/base_image_files/TSB
@@ -11,7 +11,13 @@ if [ "$EUID" -ne 0 ] ; then
   exit 1
 fi
 
-if [ -f /etc/sonic/chassisdb.conf ] && [ "$SMARTSWITCH" = false ] ; then
+PLATFORM="$(sonic-cfggen -d -v DEVICE_METADATA.localhost.platform)"
+PLATFORM_ENV_CONF_FILE=/usr/share/sonic/device/$PLATFORM/platform_env.conf
+if [ -f $PLATFORM_ENV_CONF_FILE ]; then
+  source $PLATFORM_ENV_CONF_FILE
+fi
+
+if [ -f /etc/sonic/chassisdb.conf ] && [ "$SMARTSWITCH" = false ] && [[ $disaggregated_chassis -ne 1 ]]; then
   CHASSIS_TSA_STATE_UPDATE="CHASSIS_APP_DB HMSET "BGP_DEVICE_GLOBAL\|STATE" tsa_enabled "false""
   CONFIG_DB_TSA_STATE_UPDATE='{"BGP_DEVICE_GLOBAL":{"STATE":{"tsa_enabled": "false"}}}'
   current_tsa_state="$(sonic-cfggen -d -v BGP_DEVICE_GLOBAL.STATE.tsa_enabled)"

--- a/dockers/docker-fpm-frr/base_image_files/TSC
+++ b/dockers/docker-fpm-frr/base_image_files/TSC
@@ -11,7 +11,13 @@ if [ "$EUID" -ne 0 ] ; then
   exit 1
 fi
 
-if [ -f /etc/sonic/chassisdb.conf ] && [ "$SMARTSWITCH" = false ] ; then
+PLATFORM="$(sonic-cfggen -d -v DEVICE_METADATA.localhost.platform)"
+PLATFORM_ENV_CONF_FILE=/usr/share/sonic/device/$PLATFORM/platform_env.conf
+if [ -f $PLATFORM_ENV_CONF_FILE ]; then
+  source $PLATFORM_ENV_CONF_FILE
+fi
+
+if [ -f /etc/sonic/chassisdb.conf ] && [ "$SMARTSWITCH" = false ] && [[ $disaggregated_chassis -ne 1 ]]; then
   if [[ $1 == "no-stats" ]]; then
     rexec all -c "sudo TSC no-stats"
   else

--- a/dockers/docker-fpm-frr/base_image_files/idf_isolation
+++ b/dockers/docker-fpm-frr/base_image_files/idf_isolation
@@ -12,10 +12,18 @@ if [[ "$(sonic-cfggen -d -v DEVICE_METADATA.localhost.type)" != *"SpineRouter"* 
     exit 1
 fi
 
+PLATFORM=${PLATFORM:-`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`}
+
 # Skip operation on chassis supervisor
-if [ -f /etc/sonic/chassisdb.conf ]; then  
-    echo "Skipping Operation on chassis supervisor"
-    exit 0
+if [ -f /etc/sonic/chassisdb.conf ]; then
+    PLATFORM_ENV_CONF_FILE=/usr/share/sonic/device/$PLATFORM/platform_env.conf
+    if [ -f "$PLATFORM_ENV_CONF_FILE" ]; then
+        source $PLATFORM_ENV_CONF_FILE
+    fi
+    if [[ $disaggregated_chassis -ne 1 ]]; then
+        echo "Skipping Operation on chassis supervisor"
+        exit 0
+    fi
 fi
 
 idf_isolation_states=("isolated_no_export" "isolated_withdraw_all" "unisolated" "status")
@@ -37,8 +45,6 @@ IDF_ISOLATION_STATE="{\"BGP_DEVICE_GLOBAL\":{\"STATE\":{\"idf_isolation_state\":
 
 # read SONiC immutable variables
 [ -f /etc/sonic/sonic-environment ] && . /etc/sonic/sonic-environment
-
-PLATFORM=${PLATFORM:-`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`}
 
 # Parse the device specific asic conf file, if it exists
 ASIC_CONF=/usr/share/sonic/device/$PLATFORM/asic.conf

--- a/dockers/docker-platform-monitor/docker_init.j2
+++ b/dockers/docker-platform-monitor/docker_init.j2
@@ -9,6 +9,7 @@ FANCONTROL_CONF_FILE="/usr/share/sonic/platform/fancontrol"
 SUPERVISOR_CONF_TEMPLATE="/usr/share/sonic/templates/docker-pmon.supervisord.conf.j2"
 SUPERVISOR_CONF_FILE="/etc/supervisor/conf.d/supervisord.conf"
 MODULAR_CHASSISDB_CONF_FILE="/usr/share/sonic/platform/chassisdb.conf"
+PLATFORM_ENV_CONF_FILE="/usr/share/sonic/platform/platform_env.conf"
 
 HAVE_SENSORS_CONF=0
 HAVE_FANCONTROL_CONF=0
@@ -115,7 +116,11 @@ if [ -e $FANCONTROL_CONF_FILE ]; then
     /bin/cp -f $FANCONTROL_CONF_FILE /etc/
 fi
 
-if [ -e $MODULAR_CHASSISDB_CONF_FILE ]; then
+if [ -e $PLATFORM_ENV_CONF_FILE ]; then
+    source $PLATFORM_ENV_CONF_FILE
+fi
+
+if [ -e $MODULAR_CHASSISDB_CONF_FILE ] && [[ $disaggregated_chassis -ne 1 ]]; then
     IS_MODULAR_CHASSIS=1
 fi
 

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -293,7 +293,7 @@ function postStartAction()
         fi
 
         # In SUP, enforce CHASSIS_APP_DB.tsa_enabled to be in sync with BGP_DEVICE_GLOBAL.STATE.tsa_enabled
-        if [[ -z "$DEV" ]] && [[ -f /etc/sonic/chassisdb.conf ]]; then
+        if [[ -z "$DEV" ]] && [[ -f /etc/sonic/chassisdb.conf ]] && [[ $disaggregated_chassis -ne 1 ]]; then
            tsa_cfg="$($SONIC_DB_CLI CONFIG_DB HGET "BGP_DEVICE_GLOBAL|STATE" "tsa_enabled")"
            if [[ -n "$tsa_cfg" ]]; then
               docker exec -i ${DOCKERNAME} $SONIC_DB_CLI CHASSIS_APP_DB HMSET "BGP_DEVICE_GLOBAL|STATE" tsa_enabled ${tsa_cfg}
@@ -400,6 +400,7 @@ start() {
             IS_DPU_DEVICE="false"
         fi
     fi
+
 
     {%- if sonic_asic_platform == "broadcom" %}
     {%- if docker_container_name == "syncd" %}

--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -332,7 +332,7 @@ do_db_migration()
     sonic-db-cli CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"
 
     #Enforce CHASSIS_APP_DB.tsa_enabled to be in sync with BGP_DEVICE_GLOBAL.STATE.tsa_enabled
-    if [[ -f /etc/sonic/chassisdb.conf ]]; then
+    if [[ -f /etc/sonic/chassisdb.conf ]] && [[ $disaggregated_chassis -ne 1 ]]; then
        tsa_cfg="$(sonic-db-cli CONFIG_DB HGET "BGP_DEVICE_GLOBAL|STATE" "tsa_enabled")"
        sonic-db-cli CHASSIS_APP_DB HMSET "BGP_DEVICE_GLOBAL|STATE" tsa_enabled ${tsa_cfg}
        OP_CODE=$?
@@ -452,6 +452,10 @@ if [[ -f "$ASIC_CONF" ]]; then
     source $ASIC_CONF
 fi
 
+PLATFORM_ENV_CONF_FILE=/usr/share/sonic/device/$PLATFORM/platform_env.conf
+if [[ -f "$PLATFORM_ENV_CONF_FILE" ]]; then
+    source $PLATFORM_ENV_CONF_FILE
+fi
 
 CMD=$1
 # Default command is boot

--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -108,7 +108,7 @@ def get_expected_running_containers():
             else:
                 always_running_containers.add(container_name)
 
-    if device_info.is_supervisor() or device_info.is_smartswitch():
+    if device_info.is_supervisor() or device_info.is_disaggregated_chassis() or device_info.is_smartswitch():
         always_running_containers.add("database-chassis")
 
     if device_info.is_smartswitch():

--- a/files/scripts/asic_status.sh
+++ b/files/scripts/asic_status.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+PLATFORM="$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)"
+PLATFORM_ENV_CONF=/usr/share/sonic/device/$PLATFORM/platform_env.conf
+[ -f $PLATFORM_ENV_CONF ] && . $PLATFORM_ENV_CONF
+
 is_chassis_supervisor() {
-    if [ -f /etc/sonic/chassisdb.conf ]; then
+    if [ -f /etc/sonic/chassisdb.conf ] && [[ $disaggregated_chassis -ne 1 ]]; then
         true
         return
     fi

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -600,8 +600,24 @@ def is_packet_chassis():
     return True if switch_type and switch_type == 'chassis-packet' else False
 
 
+def is_disaggregated_chassis():
+    platform_env_conf_file_path = get_platform_env_conf_file_path()
+    if platform_env_conf_file_path is None:
+        return False
+    with open(platform_env_conf_file_path) as platform_env_conf_file:
+        for line in platform_env_conf_file:
+            tokens = line.split('=')
+            if len(tokens) < 2:
+               continue
+            if tokens[0] == 'disaggregated_chassis':
+                val = tokens[1].strip()
+                if val == '1':
+                    return True
+        return False
+
+    
 def is_chassis():
-    return is_voq_chassis() or is_packet_chassis()
+    return (is_voq_chassis() and not is_disaggregated_chassis()) or is_packet_chassis()
 
 
 def is_smartswitch():

--- a/src/sonic-py-common/tests/device_info_test.py
+++ b/src/sonic-py-common/tests/device_info_test.py
@@ -121,23 +121,34 @@ class TestDeviceInfo(object):
             open_mocked.assert_called_once_with(device_info.SONIC_VERSION_YAML_PATH)
 
     @mock.patch("sonic_py_common.device_info.get_platform_info")
-    def test_is_chassis(self, mock_platform_info):
+    @mock.patch("sonic_py_common.device_info.is_disaggregated_chassis")
+    def test_is_chassis(self, mock_is_disaggregated_chassis, mock_platform_info):
         mock_platform_info.return_value = {"switch_type": "npu"}
+        mock_is_disaggregated_chassis.return_value = False
         assert device_info.is_chassis() == False
         assert device_info.is_voq_chassis() == False
         assert device_info.is_packet_chassis() == False
 
         mock_platform_info.return_value = {"switch_type": "voq"}
+        mock_is_disaggregated_chassis.return_value = False
         assert device_info.is_voq_chassis() == True
         assert device_info.is_packet_chassis() == False
         assert device_info.is_chassis() == True
+        
+        mock_platform_info.return_value = {"switch_type": "voq"}
+        mock_is_disaggregated_chassis.return_value = True
+        assert device_info.is_voq_chassis() == True
+        assert device_info.is_packet_chassis() == False
+        assert device_info.is_chassis() == False
 
         mock_platform_info.return_value = {"switch_type": "chassis-packet"}
+        mock_is_disaggregated_chassis.return_value = False
         assert device_info.is_voq_chassis() == False
         assert device_info.is_packet_chassis() == True
         assert device_info.is_chassis() == True
 
         mock_platform_info.return_value = {}
+        mock_is_disaggregated_chassis.return_value = False
         assert device_info.is_voq_chassis() == False
         assert device_info.is_packet_chassis() == False
         assert device_info.is_chassis() == False

--- a/src/system-health/health_checker/service_checker.py
+++ b/src/system-health/health_checker/service_checker.py
@@ -131,7 +131,7 @@ class ServiceChecker(HealthChecker):
                     expected_running_containers.add(container_name)
                     container_feature_dict[container_name] = container_name
                     
-        if device_info.is_supervisor():
+        if device_info.is_supervisor() or device_info.is_disaggregated_chassis():
             expected_running_containers.add("database-chassis")
             container_feature_dict["database-chassis"] = "database"
         return expected_running_containers, container_feature_dict


### PR DESCRIPTION
(#21709)



---------

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
* [VoQ_T2_PizzaBox] Modify the existing common code to support VOQ T2 PizzaBox

 -- Modify the existing to use the platform_env.conf attribuite "supervisor", and combine with chassisdb.conf to differentiate if platform is Chassis  module or Pizzabox
 -- Add new method device_info.is_database_chassis_supported() insteaf of just using the existence of /etc/sonic/chassisdb.conf to identify if database-chassis should be supported (for container_check and service_check)
 -- Using platform_env.conf and chassisdb.conf to determine if reliable TSA/TSB is supported on Chassis platform only.

port https://github.com/sonic-net/sonic-buildimage/pull/21709
##### Work item tracking
- Microsoft ADO **(32337430)**:

#### How I did it
 port https://github.com/sonic-net/sonic-buildimage/pull/21709 to `202503`

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

