### PR TITLE
[asic_sensors] Generate the asic_sensors polling configuration based on the platform.json (#20826)

### DIFF
--- a/src/sonic-config-engine/asic_sensors_config.py
+++ b/src/sonic-config-engine/asic_sensors_config.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import portconfig
+from sonic_py_common import device_info
+
+try:
+    if os.environ["CFGGEN_UNIT_TESTING"] == "2":
+        modules_path = os.path.join(os.path.dirname(__file__), ".")
+        tests_path = os.path.join(modules_path, "tests")
+        sys.path.insert(0, modules_path)
+        sys.path.insert(0, tests_path)
+        import mock_tables.dbconnector
+        mock_tables.dbconnector.load_namespace_config()
+
+except KeyError:
+    pass
+
+ASIC_SENSORS_KEY = "asic_sensors"
+
+
+def get_asic_sensors_config():
+    config = {}
+    if os.environ.get("CFGGEN_UNIT_TESTING") == "2":
+        json_file =  os.path.join(tests_path, "data",  "asic_sensors", "platform.json")
+    else:
+        platform_path = device_info.get_path_to_platform_dir()
+        json_file = os.path.join(platform_path, device_info.PLATFORM_JSON_FILE)
+        
+    if not os.path.exists(json_file):
+        return config
+    
+    platform_json = portconfig.readJson(json_file)
+    if not platform_json:
+        return config
+
+    if ASIC_SENSORS_KEY in platform_json:
+        config["ASIC_SENSORS"] = {"ASIC_SENSORS_POLLER_INTERVAL": {"interval": platform_json[ASIC_SENSORS_KEY]["poll_interval"]},
+                                  "ASIC_SENSORS_POLLER_STATUS":  {"admin_status": platform_json[ASIC_SENSORS_KEY]["poll_admin_status"]}
+                                  }
+    return config

--- a/src/sonic-config-engine/setup.py
+++ b/src/sonic-config-engine/setup.py
@@ -52,7 +52,8 @@ py_modules = [
     'minigraph',
     'openconfig_acl',
     'portconfig',
-    'smartswitch_config'
+    'smartswitch_config',
+    'asic_sensors_config'
 ]
 if sys.version_info.major == 3:
     # Python 3-only modules

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -36,7 +36,7 @@ from portconfig import get_port_config, get_breakout_mode
 from sonic_py_common.multi_asic import get_asic_id_from_name, get_asic_device_id, is_multi_asic
 from sonic_py_common import device_info
 from swsscommon.swsscommon import ConfigDBConnector, SonicDBConfig, ConfigDBPipeConnector
-
+from asic_sensors_config import get_asic_sensors_config
 
 PY3x = sys.version_info >= (3, 0)
 
@@ -458,6 +458,15 @@ def main():
                 hardware_data['DEVICE_METADATA']['localhost'].update(asic_id=device_id)
 
         deep_update(data, hardware_data)
+
+        asic_sensors = {}
+        if is_multi_asic():
+            if asic_name is not None:
+                asic_sensors = get_asic_sensors_config()
+        else:
+            asic_sensors = get_asic_sensors_config()
+        if asic_sensors:
+            deep_update(data, asic_sensors) 
 
     paths = ['/', '/usr/share/sonic/templates']
     if args.template_dir:

--- a/src/sonic-config-engine/tests/data/asic_sensors/platform.json
+++ b/src/sonic-config-engine/tests/data/asic_sensors/platform.json
@@ -1,0 +1,6 @@
+{
+    "asic_sensors": {
+        "poll_interval": "10",
+        "poll_admin_status": "enable"
+    }
+}

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -1155,3 +1155,13 @@ class TestCfgGen(TestCase):
         self.assertEqual(
             utils.liststr_to_dict(output.strip()),
             utils.liststr_to_dict("['192.168.200.15|161|', '100.0.0.6|161|', '100.0.0.7|161|', 'fe80::1%Management0|161|']"))
+   
+    def test_platform_asic_sensors_config(self):
+        os.environ["PLATFORM"] = "x86_64-kvm_x86_64-r0"
+        argument = ["-H","--print-data"]
+        output = self.run_script(argument, check_stderr=False)
+        config_json = utils.to_dict(output.strip())
+        os.environ["PLATFORM"] = ""
+        self.assertEqual(config_json['ASIC_SENSORS'], utils.to_dict("{'ASIC_SENSORS_POLLER_INTERVAL': {'interval': '10'}, 'ASIC_SENSORS_POLLER_STATUS': {'admin_status': 'enable'}}"))
+
+


### PR DESCRIPTION


---------

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
For any platform which supports the asic_sensors pulling, it requires the configuration files (config_db#.json) contain the following configuration to trigger the system to poll the ASIC sensors temperature. Fixes Nokia-ION/ndk#48 Adding Yang model support to fixes #20633

##### Work item tracking
- Microsoft ADO **[32401949](https://msazure.visualstudio.com/One/_workitems/edit/32401949)**:

Port https://github.com/sonic-net/sonic-buildimage/pull/20826 to `202503` branch
#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

