### PR TITLE
[202405] Do not add switch_id in DEVICE_METADATA for chassis_packet.

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -2241,7 +2241,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     # #voq switch_id for asic
     # switch_id = chassis_metadata.get(asic_hostname, {}).get('asic_switch_id', None)
     # on Voq system each asic has a switch_id
-    if switch_id is not None:
+    if switch_id is not None and chassis_type == CHASSIS_CARD_VOQ:
         if sub_role is not None and  FRONTEND_ASIC_SUB_ROLE == sub_role:
             if slot_index is not None:
                 switch_id = get_asic_switch_id(slot_index, asic_name)

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -2241,7 +2241,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     # #voq switch_id for asic
     # switch_id = chassis_metadata.get(asic_hostname, {}).get('asic_switch_id', None)
     # on Voq system each asic has a switch_id
-    if switch_id is not None and chassis_type == CHASSIS_CARD_VOQ:
+    if switch_id is not None and chassis_type != CHASSIS_CARD_PACKET:
         if sub_role is not None and  FRONTEND_ASIC_SUB_ROLE == sub_role:
             if slot_index is not None:
                 switch_id = get_asic_switch_id(slot_index, asic_name)


### PR DESCRIPTION
What I did:

Do not add switch_id in DEVICE_METADATA for chassis_packet. In OA we do not pass/switch_id for chassis-packet. But their can be other application like Debug Shell which can use it when initalizing. To keep consistency just do not add this field.

How I verify:

Before

```
sonic-cfggen -m /etc/sonic/minigraph.xml -n asic0 -v DEVICE_METADATA
{'localhost': {'region': 'australiaeast', 'cloudtype': None, 'docker_routing_config_mode': 'separated', 'hostname': 'xxxx', 'hwsku': 'xxxxx', 'type': 'SpineRouter', 'synchronous_mode': 'enable', 'yang_config_validation': 'disable', 'bgp_asn': 'xxxxx', 'chassis_hostname': 'xxxxx', 'deployment_id': '3', 'cluster': 'xxxx', 'slice_type': 'AZNG_Production', 'subtype': 'DownstreamLC', 'asic_name': 'asic0', 'sub_role': 'FrontEnd', 'switch_type': 'chassis-packet', 'switch_id': 4}}
```

After

```
sonic-cfggen -m /etc/sonic/minigraph.xml -n asic0 -v DEVICE_METADATA
{'localhost': {'region': 'australiaeast', 'cloudtype': None, 'docker_routing_config_mode': 'separated', 'hostname': 'xxxxx', 'hwsku': 'xxxxx', 'type': 'SpineRouter', 'synchronous_mode': 'enable', 'yang_config_validation': 'disable', 'bgp_asn': 'xxxxx', 'chassis_hostname': 'xxxxx', 'deployment_id': '3', 'cluster': 'xxxxx', 'slice_type': 'AZNG_Production', 'subtype': 'DownstreamLC', 'asic_name': 'asic0', 'sub_role': 'FrontEnd', 'switch_type': 'chassis-packet'}}
```