### PR TITLE
[202503] Changes to support other SpineRouter roles

### DIFF
--- a/dockers/docker-fpm-frr/base_image_files/TS
+++ b/dockers/docker-fpm-frr/base_image_files/TS
@@ -4,10 +4,11 @@
 [ -f /etc/sonic/sonic-environment ] && . /etc/sonic/sonic-environment
 
 PLATFORM=${PLATFORM:-`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`}
-type=`sonic-db-cli CONFIG_DB hget 'DEVICE_METADATA|localhost' 'type'`
+subtype=`sonic-db-cli CONFIG_DB hget 'DEVICE_METADATA|localhost' 'subtype'`
 TSA_CHASSIS_STATE=false
 
-if [[ $type == *"SpineRouter"* ]]; then
+if [[ $subtype == *"UpstreamLC"* || $subtype == *"DownstreamLC"* ]]; then
+ # Check supervisor TSA state, only required on chassis linecard
  TSA_CHASSIS_STATE="$(sonic-db-cli CHASSIS_APP_DB HGET "BGP_DEVICE_GLOBAL|STATE" tsa_enabled)"
 fi
 

--- a/dockers/docker-fpm-frr/base_image_files/TSA
+++ b/dockers/docker-fpm-frr/base_image_files/TSA
@@ -53,13 +53,9 @@ if [ -z "$STARTED_BY_TSA_TSB_SERVICE" ]; then
 fi
 
 /usr/bin/TS TSA
-if [[ "$(sonic-cfggen -d -v DEVICE_METADATA.localhost.type)" == *"SpineRouter"* ]] ; then
-  if [[ "$1" != "chassis" ]] ; then
-      echo "Please execute 'sudo config save' to preserve System mode in Maintenance after reboot or config reload"
-      if [[ $disaggregated_chassis -ne 1 ]]; then
-          echo -e "\nWARNING: Please execute 'TSA' on all other linecards of the chassis to fully isolate this device"
-      fi
-  fi
-else
-  echo "Please execute 'sudo config save' to preserve System mode in Maintenance after reboot or config reload"
+echo "Please execute 'sudo config save' to preserve System mode in Maintenance after reboot or config reload"
+
+subtype=`sonic-db-cli CONFIG_DB hget 'DEVICE_METADATA|localhost' 'subtype'`
+if [[ $subtype == *"UpstreamLC"* || $subtype == *"DownstreamLC"* ]] ; then
+  echo -e "\nWARNING: Please execute 'TSA' on Supervisor or on all other linecards of the chassis to fully isolate the chassis"
 fi

--- a/dockers/docker-fpm-frr/base_image_files/TSB
+++ b/dockers/docker-fpm-frr/base_image_files/TSB
@@ -52,10 +52,4 @@ if [ -z "$STARTED_BY_TSA_TSB_SERVICE" ]; then
 fi
 
 /usr/bin/TS TSB
-if [[ "$(sonic-cfggen -d -v DEVICE_METADATA.localhost.type)" == *"SpineRouter"* ]] ; then
-  if [[ "$1" != "chassis" ]] ; then
-    echo "Please execute 'sudo config save' to preserve System mode in Normal state after reboot or config reload"    
-  fi
-else
-  echo "Please execute 'sudo config save' to preserve System mode in Normal state after reboot or config reload"
-fi
+echo "Please execute 'sudo config save' to preserve System mode in Normal state after reboot or config reload"

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/monitors/peer-group.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/monitors/peer-group.conf.j2
@@ -2,7 +2,7 @@
 ! template: bgpd/templates/BGPMON/peer-group.conf.j2
 !
   neighbor BGPMON peer-group
-{% if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' %}
+{% if CONFIG_DB__DEVICE_METADATA['localhost']['switch_type'] == 'voq' or CONFIG_DB__DEVICE_METADATA['localhost']['switch_type'] == 'chassis-packet' %}
   neighbor BGPMON update-source Loopback4096
 {% elif loopback0_ipv4 %}
   neighbor BGPMON update-source {{ loopback0_ipv4 | ip }}
@@ -16,7 +16,7 @@
     neighbor BGPMON maximum-prefix 1
   exit-address-family
 
-{% if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' %}
+{% if CONFIG_DB__DEVICE_METADATA['localhost']['switch_type'] == 'voq' or CONFIG_DB__DEVICE_METADATA['localhost']['switch_type'] == 'chassis-packet' %}
   address-family ipv6
     neighbor BGPMON activate
     neighbor BGPMON route-map FROM_BGPMON in

--- a/dockers/docker-orchagent/switch.json.j2
+++ b/dockers/docker-orchagent/switch.json.j2
@@ -13,6 +13,10 @@
 {% set lag_hash_offset_value = 10 %}
 {% elif "SpineRouter" in DEVICE_METADATA.localhost.type %}
 {% set hash_seed = 25 %}
+{% elif "FabricSpineRouter" in DEVICE_METADATA.localhost.type %}
+{% set hash_seed = 40 %}
+{% elif "UpperSpineRouter" in DEVICE_METADATA.localhost.type %}
+{% set hash_seed = 50 %}
 {% endif %}
 {% endif %}
 {% if DEVICE_METADATA.localhost.namespace_id %}

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -64,7 +64,7 @@
 {%- set features = [("bgp", "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}disabled{% else %}enabled{% endif %}", false, "enabled"),
                    ("database", "always_enabled", false, "always_enabled"),
                    ("lldp", "enabled", true, "enabled"),
-                   ("pmon", "enabled", "{% if 'type' in DEVICE_METADATA['localhost'] and 'SpineRouter' in DEVICE_METADATA['localhost']['type'] %}False{% else %}True{% endif %}", "enabled"),
+                   ("pmon", "enabled", "{% if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'SpineRouter' %}False{% else %}True{% endif %}", "enabled"),
                    ("snmp", "enabled", true, "enabled"),
                    ("swss", "enabled", false, "enabled"),
                    ("syncd", "enabled", false, "enabled")] %}
@@ -84,7 +84,7 @@
     {% do features.append(("restapi", "enabled", false, "enabled")) %}
 {%- endif %}
 {%- if include_sflow == "y" %}{% do features.append(("sflow", "disabled", true, "enabled")) %}{% endif %}
-{%- if include_macsec == "y" %}{% do features.append(("macsec", "{% if DEVICE_RUNTIME_METADATA['MACSEC_SUPPORTED'] %}enabled{% else %}disabled{% endif %}", false, "enabled")) %}{% endif %}
+{%- if include_macsec == "y" %}{% do features.append(("macsec", "{% if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and DEVICE_RUNTIME_METADATA['MACSEC_SUPPORTED'] %}enabled{% else %}disabled{% endif %}", false, "enabled")) %}{% endif %}
 {%- if include_system_gnmi == "y" %}{% do features.append(("gnmi", "enabled", true, "enabled")) %}{% endif %}
 {%- if include_system_telemetry == "y" %}{% do features.append(("telemetry", "enabled", true, "enabled")) %}{% endif %}
 {%- if include_system_eventd == "y" and BUILD_REDUCE_IMAGE_SIZE == "y" %}

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -64,7 +64,7 @@
 {%- set features = [("bgp", "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}disabled{% else %}enabled{% endif %}", false, "enabled"),
                    ("database", "always_enabled", false, "always_enabled"),
                    ("lldp", "enabled", true, "enabled"),
-                   ("pmon", "enabled", "{% if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'SpineRouter' %}False{% else %}True{% endif %}", "enabled"),
+                   ("pmon", "enabled", "{% if 'type' in DEVICE_METADATA['localhost'] and 'SpineRouter' in DEVICE_METADATA['localhost']['type'] %}False{% else %}True{% endif %}", "enabled"),
                    ("snmp", "enabled", true, "enabled"),
                    ("swss", "enabled", false, "enabled"),
                    ("syncd", "enabled", false, "enabled")] %}
@@ -84,7 +84,7 @@
     {% do features.append(("restapi", "enabled", false, "enabled")) %}
 {%- endif %}
 {%- if include_sflow == "y" %}{% do features.append(("sflow", "disabled", true, "enabled")) %}{% endif %}
-{%- if include_macsec == "y" %}{% do features.append(("macsec", "{% if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and DEVICE_RUNTIME_METADATA['MACSEC_SUPPORTED'] %}enabled{% else %}disabled{% endif %}", false, "enabled")) %}{% endif %}
+{%- if include_macsec == "y" %}{% do features.append(("macsec", "{% if DEVICE_RUNTIME_METADATA['MACSEC_SUPPORTED'] %}enabled{% else %}disabled{% endif %}", false, "enabled")) %}{% endif %}
 {%- if include_system_gnmi == "y" %}{% do features.append(("gnmi", "enabled", true, "enabled")) %}{% endif %}
 {%- if include_system_telemetry == "y" %}{% do features.append(("telemetry", "enabled", true, "enabled")) %}{% endif %}
 {%- if include_system_eventd == "y" and BUILD_REDUCE_IMAGE_SIZE == "y" %}

--- a/src/sonic-bgpcfgd/tests/data/monitors/peer-group.conf/param_chassis.json
+++ b/src/sonic-bgpcfgd/tests/data/monitors/peer-group.conf/param_chassis.json
@@ -1,7 +1,8 @@
 {
     "CONFIG_DB__DEVICE_METADATA": {
         "localhost": {
-            "type": "SpineRouter"
+            "type": "SpineRouter",
+            "switch_type": "voq"
         }
     }
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Manual cherry-pick of https://github.com/sonic-net/sonic-buildimage/pull/22337

#### Why I did it
To support additional SpineRouter roles introduced in https://github.com/sonic-net/sonic-buildimage/pull/22285

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added additional roles to checks of spinerouter, changed chassis specific code to look for upstream/downstreamLC

#### How to verify it
Test with switch role set to one of the new SpineRouter roles

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

