### PR TITLE
[DT2] Update buffer configuration for Arista-7060x6 (#22464)

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-O128S2/buffers_defaults_lt2.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-O128S2/buffers_defaults_lt2.j2
@@ -1,0 +1,1 @@
+BALANCED/buffers_defaults_lt2.j2

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-P32O64/buffers_default_lt2.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-P32O64/buffers_default_lt2.j2
@@ -1,1 +1,0 @@
-BALANCED/buffers_defaults_t1.j2

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-P32O64/buffers_defaults_lt2.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-P32O64/buffers_defaults_lt2.j2
@@ -1,0 +1,1 @@
+BALANCED/buffers_defaults_lt2.j2

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE/buffers_defaults_ft2.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE/buffers_defaults_ft2.j2
@@ -1,0 +1,1 @@
+BALANCED/buffers_defaults_ft2.j2

--- a/device/common/profiles/th5/gen/BALANCED/buffers_defaults_ft2.j2
+++ b/device/common/profiles/th5/gen/BALANCED/buffers_defaults_ft2.j2
@@ -1,0 +1,19 @@
+{%- set default_cable = '5m' %}
+
+{%- include 'buffer_ports.j2' %}
+
+{# Skip BUFFER_POOL, BUFFER_PROFILE #}
+{%- macro generate_buffer_pool_and_profiles() %}
+{%- endmacro %}
+
+{# Skip BUFFER_QUEUE #}
+{%- macro generate_queue_buffers(ports) %}
+    "BUFFER_QUEUE": {
+    }
+{%- endmacro %}
+
+{# Skip BUFFER_PG #}
+{%- macro generate_pg_profils(ports) %}
+    "BUFFER_PG": {
+    },
+{%- endmacro %}

--- a/device/common/profiles/th5/gen/BALANCED/buffers_defaults_lt2.j2
+++ b/device/common/profiles/th5/gen/BALANCED/buffers_defaults_lt2.j2
@@ -1,0 +1,19 @@
+{%- set default_cable = '5m' %}
+
+{%- include 'buffer_ports.j2' %}
+
+{# Skip BUFFER_POOL, BUFFER_PROFILE #}
+{%- macro generate_buffer_pool_and_profiles() %}
+{%- endmacro %}
+
+{# Skip BUFFER_QUEUE #}
+{%- macro generate_queue_buffers(ports) %}
+    "BUFFER_QUEUE": {
+    }
+{%- endmacro %}
+
+{# Skip BUFFER_PG #}
+{%- macro generate_pg_profils(ports) %}
+    "BUFFER_PG": {
+    },
+{%- endmacro %}

--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -9,16 +9,30 @@ def
 {# Determine device topology and filename postfix #}
 {%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost']['type'] is defined %}
 {%-     set switch_role = DEVICE_METADATA['localhost']['type'] %}
+{%  if DEVICE_METADATA['localhost']['subtype'] is defined %}
+{%-     set switch_subrole = DEVICE_METADATA['localhost']['subtype'] %}
+{%- else %}
+{%-     set switch_subrole = '' %}
+{%- endif %}
 {%-     if 'torrouter' in switch_role.lower() and 'mgmt' not in switch_role.lower()%}
 {%-         set filename_postfix = 't0' %}
 {%-     elif 'leafrouter' in switch_role.lower() and 'mgmt' not in switch_role.lower()%}
 {%-         set filename_postfix = 't1' %}
+{%-     elif 'spinerouter' in switch_role.lower() and 'mgmt' not in switch_role.lower()%}
+    {%-     if 'lowerspinerouter' == switch_subrole.lower() %}
+    {%-         set filename_postfix = 'lt2' %}
+    {%-     elif 'fabricspinerouter' == switch_role.lower() %}
+    {%-         set filename_postfix = 'ft2' %}
+    {%-     else %}
+    {%-         set filename_postfix = 't2' %}
+    {%-     endif -%}
 {%-     else %}
 {%-         set filename_postfix = set_default_topology() %}
-{%-     endif %}
+{%-     endif -%}
 {%- else %}
-{%-     set filename_postfix = set_default_topology() %}
-{%-     set switch_role      = '' %}
+{%-         set filename_postfix = set_default_topology() %}
+{%-         set switch_role      = '' %}
+{%-         set switch_subrole   = '' %}
 {%- endif -%}
 
 {% set voq_chassis = false %}


### PR DESCRIPTION
Why I did it
This PR is to add buffer configurations for 3 Arista-7060x6 HWSKUs

Arista-7060X6-64PE-O128S2
Arista-7060X6-64PE-P32O64
Arista-7060X6-64PE
Different buffer configuration files are loaded for different roles

buffers_default_lt2.json if subtype == lowerspinerouter buffers_default_ft2.json is type == fabricspinerouter

Work item tracking
Microsoft ADO 32548218

How I did it
Add new configuration files
Select right file according to device type and subtype

How to verify it
Change is verified on a physical testbed by generating buffer configurations.

Revert unnecessary change

Update buffer configuration for LT2/FT2

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

