### PR TITLE
[202405] Restart `PMON` when `SWSS` flushes APPL_DB on Arista SKUs that use `media_settings.json`

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -339,6 +339,23 @@ start() {
         $SONIC_DB_CLI APPL_STATE_DB FLUSHDB
         clean_up_chassis_db_tables
         rm -rf /tmp/cache
+        if [[ x"$sonic_asic_platform" == x"broadcom" ]]; then
+            . /host/machine.conf
+            if [ -n "$aboot_platform" ]; then
+                platform=$aboot_platform
+            elif [ -n "$onie_platform" ]; then
+                platform=$onie_platform
+            else
+                platform="unknown"
+            fi
+            # Need to restart PMON on media_settings.json skus due to
+            # https://github.com/sonic-net/sonic-buildimage/issues/21902
+            if [[ x"$platform" == x"x86_64-arista_7800r3a"* ]]; then
+                debug "Restarting pmon service..."
+                /bin/systemctl restart pmon
+            fi
+        fi
+
     fi
 
     # On supervisor card, skip starting asic related services here. In wait(),


### PR DESCRIPTION
Workaround for https://github.com/sonic-net/sonic-buildimage/issues/21902

SWSS startup causes APPL_DB to be flushed.
This results in `PORT_TABLE:Ethernet#` losing it's media_settings tunings populated by XCVRD.

Without this change (tuning lost):
```
sonic-db-cli -n asic0 APPL_DB hgetall "PORT_TABLE:Ethernet96"
{'alias': 'Ethernet13/1', 'asic_port_name': 'Eth96', 'core_id': '0', 'core_port_id': '13', 'index': '13', 'lanes': '40,41,42,43', 'num_voq': '8', 'role': 'Ext', 'speed': '100000', 'admin_status': 'up', 'description': 'ARISTA13T3:Ethernet1', 'fec': 'none', 'mtu': '9100', 'pfc_asym': 'off', 'tpid': '0x8100', 'oper_stat
us': 'up', 'flap_count': '1', 'main': '0x4e,0x4e,0x53,0x4b', 'post1': '0xffffffea,0xffffffea,0xffffffea,0xffffffec', 'post2': '0x0,0x0,0x0,0x0', 'post3': '0x0,0x0,0x0,0x0', 'pre1': '0xfffffffb,0xfffffffb,0xfffffffb,0xfffffffb', 'pre2': '0x0,0x0,0x0,0x0', 'last_up_time': 'Thu Apr 03 16:32:03 2025'}

systemctl restart swss@0.service

sonic-db-cli -n asic0 APPL_DB hgetall "PORT_TABLE:Ethernet96"
{'alias': 'Ethernet13/1', 'asic_port_name': 'Eth96', 'core_id': '0', 'core_port_id': '13', 'index': '13', 'lanes': '40,41,42,43', 'num_voq': '8', 'role': 'Ext', 'speed': '100000', 'admin_status': 'up', 'description': 'ARISTA13T3:Ethernet1', 'fec': 'none', 'mtu': '9100', 'pfc_asym': 'off', 'tpid': '0x8100', 'oper_stat
us': 'up', 'flap_count': '1', 'last_up_time': 'Thu Apr 03 17:41:08 2025'}
```
With this change (tuning preserved):
```
sonic-db-cli -n asic0 APPL_DB hgetall "PORT_TABLE:Ethernet96"
{'alias': 'Ethernet13/1', 'asic_port_name': 'Eth96', 'core_id': '0', 'core_port_id': '13', 'index': '13', 'lanes': '40,41,42,43', 'num_voq': '8', 'role': 'Ext', 'speed': '100000', 'admin_status': 'up', 'description': 'ARISTA13T3:Ethernet1', 'fec': 'none', 'mtu': '9100', 'pfc_asym': 'off', 'tpid': '0x8100', 'oper_stat
us': 'up', 'flap_count': '1', 'main': '0x4e,0x4e,0x53,0x4b', 'post1': '0xffffffea,0xffffffea,0xffffffea,0xffffffec', 'post2': '0x0,0x0,0x0,0x0', 'post3': '0x0,0x0,0x0,0x0', 'pre1': '0xfffffffb,0xfffffffb,0xfffffffb,0xfffffffb', 'pre2': '0x0,0x0,0x0,0x0', 'last_up_time': 'Thu Apr 03 16:32:03 2025'}

systemctl restart swss@0.service

sonic-db-cli -n asic0 APPL_DB hgetall "PORT_TABLE:Ethernet96"
{'alias': 'Ethernet13/1', 'asic_port_name': 'Eth96', 'core_id': '0', 'core_port_id': '13', 'index': '13', 'lanes': '40,41,42,43', 'num_voq': '8', 'role': 'Ext', 'speed': '100000', 'admin_status': 'up', 'description': 'ARISTA13T3:Ethernet1', 'fec': 'none', 'mtu': '9100', 'pfc_asym': 'off', 'tpid': '0x8100', 'oper_stat
us': 'up', 'flap_count': '1', 'main': '0x4e,0x4e,0x53,0x4b', 'post1': '0xffffffea,0xffffffea,0xffffffea,0xffffffec', 'post2': '0x0,0x0,0x0,0x0', 'post3': '0x0,0x0,0x0,0x0', 'pre1': '0xfffffffb,0xfffffffb,0xfffffffb,0xfffffffb', 'pre2': '0x0,0x0,0x0,0x0', 'last_up_time': 'Fri Apr 04 17:12:59 2025'}
```
I also see the message in syslog that pmon is restarted right after the dbs are flushed:
```
NOTICE root: Chassis db clean up for swss0. Number of SYSTEM_LAG_TABLE entries deleted: 8
NOTICE root: Restarting pmon service...
```

This is a cast specifically for MSFT-202405 for Arista T2 SKUs, we'll submit a change that applies more generally to all media_settings.json SKUs in master.