### PR TITLE
Workaround for resource group mode misconfig on tgen 

### DIFF
--- a/dockers/docker-sonic-mgmt/0002-Fix-resource-group.patch
+++ b/dockers/docker-sonic-mgmt/0002-Fix-resource-group.patch
@@ -1,0 +1,18 @@
+From: Vivek Kumar Verma <vivekverma@arista.com>
+Date:   Wed May 7 07:11:47 2025 +0000
+Subject: [PATCH 1/2] Fix snappi api to retain group mode based on a flag.
+
+
+diff --git a/snappi_ixnetwork/resourcegroup.py b/snappi_ixnetwork/resourcegroup.py
+index 0b57f493..4ff0258d 100644
+--- a/snappi_ixnetwork/resourcegroup.py
++++ b/snappi_ixnetwork/resourcegroup.py
+@@ -190,7 +190,7 @@ class ResourceGroup(object):
+                                 card,
+                                 group_id,
+                                 current_mode,
+-                                group_mode,
++                                group_mode if self._api._retain_group_mode is False else current_mode
+                             )
+                             if l1_name is not None:
+                                 if l1_name not in self.layer1_check:

--- a/dockers/docker-sonic-mgmt/0003-Fix-snappi-api.patch
+++ b/dockers/docker-sonic-mgmt/0003-Fix-snappi-api.patch
@@ -1,0 +1,23 @@
+From: Vivek Kumar Verma <vivekverma@arista.com>
+Date: Wed May 7 07:12:00 2025 +0000
+Subject: [PATCH 2/2]Fix snappi api to retain group mode based on a flag.
+
+diff --git a/snappi_ixnetwork/snappi_api.py b/snappi_ixnetwork/snappi_api.py
+index 9a0e49b1..c3301cda 100644
+--- a/snappi_ixnetwork/snappi_api.py
++++ b/snappi_ixnetwork/snappi_api.py
+@@ -46,6 +46,7 @@ class Api(snappi.Api):
+         location = kwargs.get("location")
+         username = kwargs.get("username")
+         password = kwargs.get("password")
++        self._retain_group_mode = kwargs.get("retain_group_mode", False)
+         license_servers = kwargs.get("license_servers")
+         self._log_level = logging.INFO if kwargs.get("loglevel") is None \
+             else kwargs.get("loglevel")
+@@ -1135,4 +1136,4 @@ class Api(snappi.Api):
+         self.logger.debug(message)
+ 
+     def warning(self, message):
+-        logging.warning(message)
+\ No newline at end of file
++        logging.warning(message)

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -269,12 +269,16 @@ USER root
 WORKDIR /azp
 COPY start.sh \
      0001-Fix-getattr-AttributeError-in-multi-thread-scenario.patch \
+     0002-Fix-resource-group.patch \
+     0003-Fix-snappi-api.patch \
      ./
 RUN chmod +x start.sh \
     && ln -sf /usr/bin/python3 /usr/bin/python \
     && ln -sf `which pip3` /usr/bin/pip \
     && ln -sf `which pip3` /usr/local/sbin/pip \
-    && patch -u -b /usr/local/lib/python3.8/dist-packages/ansible/plugins/loader.py -i /azp/0001-Fix-getattr-AttributeError-in-multi-thread-scenario.patch
+    && patch -u -b /usr/local/lib/python3.8/dist-packages/ansible/plugins/loader.py -i /azp/0001-Fix-getattr-AttributeError-in-multi-thread-scenario.patch \
+    && patch -u -b /usr/local/lib/python3.8/dist-packages/snappi_ixnetwork/resourcegroup.py -i /azp/0002-Fix-resource-group.patch \
+    && patch -u -b /usr/local/lib/python3.8/dist-packages/snappi_ixnetwork/snappi_api.py -i /azp/0003-Fix-snappi-api.patch
 
 USER $user
 WORKDIR /var/$user


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The issue is described in detail here: https://github.com/open-traffic-generator/snappi-ixnetwork/issues/607

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Introduced patches for snappi api in docker-sonic-mgmt which introduce a flag based on which snappi api will retain the currently configured resource group mode. The user has to manually configure the resource group mode manually through other means but this should be a one time setup.

This PR should merge before sonic-mgmt change: https://github.com/Azure/sonic-mgmt.msft/pull/274

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
Ran snappi tests with msft-202405 on Arista platforms and didn't observe the misconfig happening.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

Signed-off-by: [vivekverma@arista.com](mailto:vivekverma@arista.com)

