### PR TITLE
[202503] teamd: Increase netlink buffer size and eliminate a syscall

### DIFF
--- a/src/libteam/patch/0005-Increase-default-buffer-size-from-98304-to-2097152.patch
+++ b/src/libteam/patch/0005-Increase-default-buffer-size-from-98304-to-2097152.patch
@@ -1,7 +1,7 @@
 From fcb9932bdb9212e9b18302de4ffb4d64003e93ab Mon Sep 17 00:00:00 2001
 From: Pavel Shirshov <pavelsh@microsoft.com>
 Date: Tue, 3 Mar 2020 12:55:50 -0800
-Subject: [PATCH] Increase default buffer size from 98304 to 983040
+Subject: [PATCH] Increase default buffer size from 98304 to 2097152
 
 ---
  libteam/libteam.c | 4 ++--
@@ -16,10 +16,10 @@ index 9c9c93a..2cc80ca 100644
  
  /* libnl uses default 32k socket receive buffer size,
 - * which can get too small. Use 192k for all sockets.
-+ * which can get too small. Use 960k for all sockets.
++ * which can get too small. Use 2048k for all sockets.
   */
 -#define NETLINK_RCVBUF 196608
-+#define NETLINK_RCVBUF 983040
++#define NETLINK_RCVBUF 2097152
  
  /**
   * @param th		libteam library context

--- a/src/libteam/patch/0017-Specify-netlink-recv-buffer-size-to-avoid-a-syscall.patch
+++ b/src/libteam/patch/0017-Specify-netlink-recv-buffer-size-to-avoid-a-syscall.patch
@@ -1,0 +1,62 @@
+From b37f72d0272e727fd557948d6f115b0c9a38deab Mon Sep 17 00:00:00 2001
+From: Saikrishna Arcot <sarcot@microsoft.com>
+Date: Mon, 7 Oct 2024 14:36:04 -0700
+Subject: [PATCH] Specify netlink recv buffer size to avoid a syscall
+
+For each message being received, the netlink library first does a peek to see
+what the buffer size is, and then does the actual recv call to get the message.
+This results in 2 syscalls being made for each message being received.
+On a system with a weak CPU and many events happening, this could
+potentially be a noticeable performance impact.
+
+To work around this, tell libnl to use a fixed buffer size of 32kB (8 pages
+assuming page size of 4096 bytes). This is the maximum size that a netlink
+message from the kernel can be today. For the CLI sockets, use a fixed
+buffer size of 16kB, as these messages tend to be smaller.
+---
+ libteam/libteam.c | 22 ++++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+diff --git a/libteam/libteam.c b/libteam/libteam.c
+index 2fc3e5d..ee78aff 100644
+--- a/libteam/libteam.c
++++ b/libteam/libteam.c
+@@ -623,6 +623,17 @@ int team_init(struct team_handle *th, uint32_t ifindex)
+ 		return -nl2syserr(err);
+ 	}
+ 
++	err = nl_socket_set_msg_buf_size(th->nl_sock, 32768);
++	if (err) {
++		err(th, "Failed to set message buffer size of netlink sock.");
++		return -nl2syserr(err);
++	}
++	err = nl_socket_set_msg_buf_size(th->nl_sock_event, 32768);
++	if (err) {
++		err(th, "Failed to set message buffer size of netlink event sock.");
++		return -nl2syserr(err);
++	}
++
+ 	th->family = genl_ctrl_resolve(th->nl_sock, TEAM_GENL_NAME);
+ 	if (th->family < 0) {
+ 		err(th, "Failed to resolve netlink family.");
+@@ -658,6 +669,17 @@ int team_init(struct team_handle *th, uint32_t ifindex)
+ 		return err;
+ 	}
+ 
++	err = nl_socket_set_msg_buf_size(th->nl_cli.sock, 16384);
++	if (err) {
++		err(th, "Failed to set message buffer size of netlink cli sock.");
++		return -nl2syserr(err);
++	}
++	err = nl_socket_set_msg_buf_size(th->nl_cli.sock_event, 16384);
++	if (err) {
++		err(th, "Failed to set message buffer size of netlink cli event sock.");
++		return -nl2syserr(err);
++	}
++
+ 	err = nl_socket_add_membership(th->nl_cli.sock_event, RTNLGRP_LINK);
+ 	if (err < 0) {
+ 		err(th, "Failed to add netlink membership.");
+-- 
+2.34.1
+

--- a/src/libteam/patch/series
+++ b/src/libteam/patch/series
@@ -2,7 +2,7 @@
 0002-teamd-lacp-runner-will-send-lacp-update-right-after-.patch
 0003-libteam-Add-fallback-support-for-single-member-port-.patch
 #0004-Skip-setting-the-same-hwaddr-to-lag-port-to-avoid-di.patch
-0005-Increase-default-buffer-size-from-98304-to-983040.patch
+0005-Increase-default-buffer-size-from-98304-to-2097152.patch
 0006-teamd-Administratively-shutdown-port-channel-has-mem.patch
 #0007-Send-LACP-PDU-immediately-if-our-state-changed.patch
 0008-libteam-Add-warm_reboot-mode.patch
@@ -14,3 +14,4 @@
 0014-dont-move-the-port-state-from-disabled-when-admin-state-is-down.patch
 0015-add-support-for-custom-retry.patch
 0016-block-retry-count-changes.patch
+0017-Specify-netlink-recv-buffer-size-to-avoid-a-syscall.patch


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

On setups with many LAGs configured, if the teamd container is getting shut down, then there may be many messages sent from the kernel about LAGs/LAG members being removed. This may cause the netlink socket buffers to fill up.

NetworkManger (on the desktop side) uses 2MB socket buffers, whereas teamd is currently configured to use 960kB buffers. Additionally, because libnl doesn't know the size of each netlink message, it makes two `recvmsg` syscalls for each message: one to know the size of the message, and one to get the actual message. This can result in inefficiencies on weaker systems.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Increase the size of the netlink buffers from 960kB to 2048kB. Additionally, specify the maximum size of each netlink message, so that libnl doesn't need to do a `MSG_PEEK` first to get the actual length, allocate the buffer for it, and then get the actual message.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog


#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

