### PR TITLE
Revert "[202412] [Mellanox] platform: Enable cache on init"

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
@@ -23,7 +23,6 @@
 
 try:
     from sonic_platform_base.platform_base import PlatformBase
-    from sonic_platform_base.sonic_xcvr.api.public.cmis import CmisApi
     from .chassis import Chassis, ModularChassis
     from .device_data import DeviceDataManager
 except ImportError as e:
@@ -32,7 +31,6 @@ except ImportError as e:
 class Platform(PlatformBase):
     def __init__(self):
         PlatformBase.__init__(self)
-        CmisApi.set_cache_enabled(True)
         if DeviceDataManager.get_linecard_count() == 0:
             self._chassis = Chassis()
         else:


### PR DESCRIPTION
Reverts Azure/sonic-buildimage-msft#1145

The original PR is closed and change is causing image issues:

```
$ show int st
Traceback (most recent call last):
  File "/usr/local/bin/intfutil", line 900, in <module>
    main()
  File "/usr/local/bin/intfutil", line 880, in main
    interface_stat.display_intf_status()
  File "/usr/local/bin/intfutil", line 452, in display_intf_status
    self.get_intf_status()
  File "/usr/local/lib/python3.11/dist-packages/utilities_common/multi_asic.py", line 156, in wrapped_run_on_all_asics
    func(self,  *args, **kwargs)
  File "/usr/local/bin/intfutil", line 539, in get_intf_status
    self.table += self.generate_intf_status()
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/bin/intfutil", line 483, in generate_intf_status
    port_oper_speed_get(self.db, key),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/bin/intfutil", line 204, in port_oper_speed_get
    return appl_db_port_status_get(db, intf_name, PORT_SPEED)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/bin/intfutil", line 169, in appl_db_port_status_get
    optics_type = port_optics_get(appl_db, intf_name, PORT_OPTICS_TYPE)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/bin/intfutil", line 226, in port_optics_get
    if is_rj45_port(intf_name):
       ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/utilities_common/platform_sfputil_helper.py", line 306, in is_rj45_port
    platform_chassis = sonic_platform.platform.Platform().get_chassis()
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/sonic_platform/platform.py", line 35, in __init__
    CmisApi.set_cache_enabled(True)
    ^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: type object 'CmisApi' has no attribute 'set_cache_enabled'
```