### PR TITLE
Fix info and order of components for 7060x6_64pe_b

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe_b/platform.json
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/platform.json
@@ -6,13 +6,13 @@
                 "name": "Aboot()"
             },
             {
-                "name": "Scd(addr=0000:04:00.0)"
-            },
-            {
-                "name": "Scd(addr=0000:08:00.0)"
+                "name": "Scd(addr=0000:03:00.0)"
             },
             {
                 "name": "RedstartSysCpld(addr=13-0023)"
+            },
+            {
+                "name": "Scd(addr=0000:05:00.0)"
             }
         ],
         "fans": [],

--- a/device/arista/x86_64-arista_7060x6_64pe_b/platform_components.json
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/platform_components.json
@@ -3,9 +3,9 @@
       "DCS-7060X6-64PE-B": {
          "component": {
             "Aboot()": {},
-            "Scd(addr=0000:04:00.0)": {},
-            "Scd(addr=0000:08:00.0)": {},
-            "RedstartSysCpld(addr=13-0023)": {}
+            "Scd(addr=0000:03:00.0)": {},
+            "RedstartSysCpld(addr=13-0023)": {},
+            "Scd(addr=0000:05:00.0)": {}
          }
       }
    }


### PR DESCRIPTION
#### Why I did it

`sonic-mgmt/tests/platform_tests/api/test_component.py` was failing due to an order mismatch between the `platform.json` file and our component API implementation. Since the two are not linked together we need to update the json files with the correct order.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Modified `platform.json` and `platform_components.json` with the correct info and order for the components.

#### How to verify it

Verified by running `sonic-mgmt/tests/platform_tests/api/test_component.py` with and without the change on a x86_64-arista_7060x6_64pe_b switch. With the change `test_get_name` no longer fails. 

#### Which release branch to backport (provide reason below if selected)

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] msft-202412

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

#### Link to config_db schema for YANG module changes
