### PR TITLE
[202412][PR:23100] Remove S2 port bcm configs for Arista-7060X6-64PE-B-O128

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe.config.bcm
@@ -1330,14 +1330,6 @@ device:
                 PORT_ID: 530
             :
                 PC_PHYS_PORT_ID: 509
-            ?
-                PORT_ID: 118
-            :
-                PC_PHYS_PORT_ID: 513
-            ?
-                PORT_ID: 254
-            :
-                PC_PHYS_PORT_ID: 514
 ...
 ---
 device:
@@ -1381,13 +1373,6 @@ device:
                 SPEED: 400000
                 NUM_LANES: 4
                 FEC_MODE: PC_FEC_RS544_2XN
-                MAX_FRAME_SIZE: 9416
-            ?
-                PORT_ID: [118, 254]
-            :
-                ENABLE: 1
-                SPEED: 10000
-                NUM_LANES: 1
                 MAX_FRAME_SIZE: 9416
 ...
 ---


### PR DESCRIPTION
Sync PR #23100 from sonic-net/sonic-buildimage to 202412.
Original PR: https://github.com/sonic-net/sonic-buildimage/pull/23100