### PR TITLE
cherry-pick PR [PR:23510] KDUMP YANG: Update the regex to accept memory start range accept without suffix

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/kdump.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/kdump.json
@@ -8,6 +8,9 @@
     "KDUMP_WITH_VALID_VALUES_3": {
         "desc": "Configuring the kdump with valid values."
     },
+    "KDUMP_WITH_VALID_VALUES_4": {
+        "desc": "Configuring the kdump with valid values."
+    },
     "KDUMP_WITH_INVALID_NUM_DUMPS": {
         "desc": "Configuring kdump config with a invalid number of allowed kdumps.",
         "eStr": ["pattern", "does not satisfy"]

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/kdump.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/kdump.json
@@ -32,6 +32,18 @@
             }
         }
     },
+    "KDUMP_WITH_VALID_VALUES_4": {
+        "sonic-kdump:sonic-kdump": {
+            "sonic-kdump:KDUMP": {
+                "config": {
+                    "enabled": "true",
+                    "num_dumps": "3",
+                    "memory": "512-4G:37M,4G-8G:41M,8G-:59M"
+                }
+            }
+        }
+    },
+
     "KDUMP_WITH_INVALID_NUM_DUMPS": {
         "sonic-kdump:sonic-kdump": {
             "sonic-kdump:KDUMP": {

--- a/src/sonic-yang-models/yang-models/sonic-kdump.yang
+++ b/src/sonic-yang-models/yang-models/sonic-kdump.yang
@@ -33,7 +33,7 @@ module sonic-kdump {
 
                 leaf memory {
                     type string {
-                        pattern "(((([0-9]+[MG])?(-([0-9]+[MG])?):)?[0-9]+[MG],?)+)";
+                        pattern "(((([0-9]+[MG]?)?(-([0-9]+[MG])?):)?[0-9]+[MG],?)+)";
                     }
                     description
                         "Memory reserved for loading the crash handler kernel. The amount


### PR DESCRIPTION
…

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The KDUMP config for memory should accept start value without Suffix(M or G). Default suffix is bytes. Some platforms define the start value without suffix( which is valid and should be accepted)
##### Work item tracking
- Microsoft ADO **(number only)**:
33973757

#### How I did it
Updated the regex to make the start Memory suffix optional
#### How to verify it
Added a new test case to ensure that intended config is accepted.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [x] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)
master
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
