### PR TITLE
SONIC T2: Enable KDUMP by default on Arista Chassis

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -86,7 +86,8 @@ installer_image_path="$image_path/$installer_image"
 
 boot_config="$target_path/boot-config"
 
-cmdline_allowlist="crashkernel hwaddr_ma1 sonic_fips docker_inram"
+kernel_cmdline_allowlist="crashkernel hwaddr_ma1 sonic_fips docker_inram"
+default_cmdline_blacklist="crashkernel"
 
 # for backward compatibility with the sonic_upgrade= behavior
 install="${install:-${sonic_upgrade:-}}"
@@ -202,6 +203,11 @@ cmdline_clear() {
 
 cmdline_add() {
     echo "$@" >> /tmp/append
+}
+
+cmdline_remove() {
+    # remove all occurences of parameter and its value from the cmdline
+    sed -i "s/\b${1}=[^ ]*\s*//g" /tmp/append
 }
 
 cmdline_has() {
@@ -473,6 +479,18 @@ read_switch_eeprom() {
 read_system_eeprom() {
     read_eeprom /tmp/.system-prefdl
 }
+
+write_kdump_cmdline() {
+    local sid="$(cmdline_get sid | sed 's/Ssd$//')"
+    case "$sid" in
+        Wolverine*|Clearwater2*|OtterLake*|QuartzDd*|Redstart8Mk2Quartz4*|CitrineDd*)
+            if ! cmdline_has crashkernel; then
+                cmdline_add crashkernel=0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-16G:448M,16G-32G:768M,32G-:1G
+            fi
+            ;;
+    esac
+}
+
 
 write_platform_specific_cmdline() {
     local platform="$(cmdline_get platform)"
@@ -762,6 +780,11 @@ write_default_cmdline() {
         # for the Aboot part. Take an educated guess at a right delimiter.
         # Subject to breakage if EOS or SONiC cmdline change.
         cat /proc/cmdline | sed -E 's/^(.*) rw .*$/\1/' | tr ' ' '\n' | cmdline_append
+
+        # Remove any parameters that are inadvertently inherited
+        for field in $default_cmdline_blacklist; do
+            cmdline_remove "$field"
+        done
     fi
 
     cmdline_add "$delimiter"
@@ -782,7 +805,7 @@ write_cmdline() {
     #         this file can be either packaged in the swi or generated from userland
     for cpath in "$image_path/kernel-cmdline" "$image_path/kernel-cmdline-append"; do
         if [ -f "$cpath" ]; then
-            for field in $cmdline_allowlist; do
+            for field in $kernel_cmdline_allowlist; do
                cat "$cpath" | tr ' ' '\n' | grep -E "$field" | tail -n 1 | cmdline_append
             done
         fi
@@ -812,6 +835,7 @@ write_secureboot_configs() {
     # setting panic= has the side effect of disabling the initrd shell on error
     cmdline_add panic=0
     write_cmdline
+    write_kdump_cmdline
 }
 
 write_regular_configs() {
@@ -819,6 +843,7 @@ write_regular_configs() {
     cmdline_add "loop=$image_name/fs.squashfs"
     cmdline_add loopfstype=squashfs
     write_cmdline
+    write_kdump_cmdline
 }
 
 run_kexec() {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
cherry pick PR.. Master PR: https://github.com/sonic-net/sonic-buildimage/pull/23787
##### Work item tracking
- Microsoft ADO **(number only)**:
33992003

#### How I did it
Please refer Master PR: https://github.com/sonic-net/sonic-buildimage/pull/23787
#### How to verify it
Please refer Master PR: https://github.com/sonic-net/sonic-buildimage/pull/23787
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

