### PR TITLE
copp cfg template for arp pkts in dualtor

### DIFF
--- a/files/image_config/copp/copp_cfg.j2
+++ b/files/image_config/copp/copp_cfg.j2
@@ -19,7 +19,11 @@
 		    "red_action":"drop"
 	    },
 	    "queue4_group2": {
+{% if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and 'ToRRouter' in DEVICE_METADATA['localhost']['type'] %}
+		    "trap_action":"trap",
+{% else %}
 		    "trap_action":"copy",
+{% endif %}
 		    "trap_priority":"4",
 		    "queue": "4",
 		    "meter_type":"packets",


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
ARP copp config trap action is set to copy. This results in dropping the ARP response packets that has DMAC as the SVI's MAC. Since SVI is a layer3 interface it cannot perform a layer 3 forwarding on this ARP response packet and it rightly drops the original packet. A copy of this packet is sent to the SONiC control plane to learn the ARP responses as indicated by the copp config trap action. In Cisco platforms this drop is accounted as interface RX_DROP.

In case of dualtor ARP proxy is used in the server facing bridge and ARP packets are never bridged. So normal forwarding and flooding of ARP packets between the bridge ports is not done. In such case the copp policy for ARP packets should be with 'trap' action instead of 'copy'

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
This fix changes the copp trap config for the ARP packets to trap instead of copy in case of dualtor. Trap will drop and send the packet to SONiC control plane as desired in this case.

#### How to verify it
Verified on hardware. Drop counters do not increase for ARP response packet with DMAC set to SVI's MAC.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

