### PR TITLE
Updated TM/FE error marking register to make FEC errors more reliable

### DIFF
--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/0/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/0/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,5 +1,6 @@
 appl_param_module_id=300
 system_ref_core_clock_khz=1600000
+sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/0/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/0/sai_postinit_cmd.soc
@@ -1,2 +1,1 @@
-linkscan interval=15000000
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/1/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/1/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,5 +1,6 @@
 appl_param_module_id=301
 system_ref_core_clock_khz=1600000
+sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/1/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/1/sai_postinit_cmd.soc
@@ -1,2 +1,1 @@
-linkscan interval=15000000
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/10/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/10/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,5 +1,6 @@
 appl_param_module_id=310
 system_ref_core_clock_khz=1600000
+sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/10/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/10/sai_postinit_cmd.soc
@@ -1,2 +1,1 @@
-linkscan interval=15000000
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/11/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/11/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,5 +1,6 @@
 appl_param_module_id=311
 system_ref_core_clock_khz=1600000
+sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/11/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/11/sai_postinit_cmd.soc
@@ -1,2 +1,1 @@
-linkscan interval=15000000
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/2/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/2/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,5 +1,6 @@
 appl_param_module_id=302
 system_ref_core_clock_khz=1600000
+sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/2/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/2/sai_postinit_cmd.soc
@@ -1,2 +1,1 @@
-linkscan interval=15000000
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/3/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/3/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,5 +1,6 @@
 appl_param_module_id=303
 system_ref_core_clock_khz=1600000
+sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/3/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/3/sai_postinit_cmd.soc
@@ -1,2 +1,1 @@
-linkscan interval=15000000
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/4/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/4/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,5 +1,6 @@
 appl_param_module_id=304
 system_ref_core_clock_khz=1600000
+sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/4/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/4/sai_postinit_cmd.soc
@@ -1,2 +1,1 @@
-linkscan interval=15000000
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/5/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/5/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,5 +1,6 @@
 appl_param_module_id=305
 system_ref_core_clock_khz=1600000
+sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/5/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/5/sai_postinit_cmd.soc
@@ -1,2 +1,1 @@
-linkscan interval=15000000
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/6/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/6/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,5 +1,6 @@
 appl_param_module_id=306
 system_ref_core_clock_khz=1600000
+sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/6/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/6/sai_postinit_cmd.soc
@@ -1,2 +1,1 @@
-linkscan interval=15000000
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/7/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/7/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,5 +1,6 @@
 appl_param_module_id=307
 system_ref_core_clock_khz=1600000
+sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/7/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/7/sai_postinit_cmd.soc
@@ -1,2 +1,1 @@
-linkscan interval=15000000
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/8/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/8/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,5 +1,6 @@
 appl_param_module_id=308
 system_ref_core_clock_khz=1600000
+sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/8/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/8/sai_postinit_cmd.soc
@@ -1,2 +1,1 @@
-linkscan interval=15000000
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/9/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/9/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,5 +1,6 @@
 appl_param_module_id=309
 system_ref_core_clock_khz=1600000
+sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/9/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/9/sai_postinit_cmd.soc
@@ -1,2 +1,1 @@
-linkscan interval=15000000
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/sai_postinit_cmd.soc
@@ -26,3 +26,4 @@ INTeRrupt ENAble id=1662
 
 INTeRrupt ENAble id=1093
 debug intr error
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/sai_postinit_cmd.soc
@@ -25,5 +25,5 @@ INTeRrupt ENAble id=1661
 INTeRrupt ENAble id=1662
 
 INTeRrupt ENAble id=1093
-debug intr err
+debug intr error
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/sai_postinit_cmd.soc
@@ -25,4 +25,5 @@ INTeRrupt ENAble id=1661
 INTeRrupt ENAble id=1662
 
 INTeRrupt ENAble id=1093
-debug intr error
+debug intr err
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/sai_postinit_cmd.soc
@@ -27,3 +27,4 @@ INTeRrupt ENAble id=488
 
 INTeRrupt ENAble id=1597
 debug intr error
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/sai_postinit_cmd.soc
@@ -27,3 +27,4 @@ INTeRrupt ENAble id=488
 
 INTeRrupt ENAble id=1597
 debug intr error
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/sai_postinit_cmd.soc
@@ -27,3 +27,4 @@ INTeRrupt ENAble id=488
 
 INTeRrupt ENAble id=1597
 debug intr error
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/sai_postinit_cmd.soc
@@ -27,3 +27,4 @@ INTeRrupt ENAble id=488
 
 INTeRrupt ENAble id=1597
 debug intr error
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/sai_postinit_cmd.soc
@@ -27,3 +27,4 @@ INTeRrupt ENAble id=488
 
 INTeRrupt ENAble id=1597
 debug intr error
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/sai_postinit_cmd.soc
@@ -27,3 +27,4 @@ INTeRrupt ENAble id=488
 
 INTeRrupt ENAble id=1597
 debug intr error
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/sai_postinit_cmd.soc
@@ -27,3 +27,4 @@ INTeRrupt ENAble id=488
 
 INTeRrupt ENAble id=1597
 debug intr error
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/sai_postinit_cmd.soc
@@ -27,3 +27,4 @@ INTeRrupt ENAble id=488
 
 INTeRrupt ENAble id=1597
 debug intr error
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/sai_postinit_cmd.soc
@@ -65,3 +65,4 @@ INTeRrupt ENAble id=488
 
 INTeRrupt ENAble id=1597
 debug intr error
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/sai_postinit_cmd.soc
@@ -42,3 +42,4 @@ INTeRrupt ENAble id=488
 
 INTeRrupt ENAble id=1597
 debug intr error
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/1/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/1/sai_postinit_cmd.soc
@@ -1,1 +1,2 @@
 linkscan interval=15000000
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/10/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/10/sai_postinit_cmd.soc
@@ -1,1 +1,2 @@
 linkscan interval=15000000
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/11/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/11/sai_postinit_cmd.soc
@@ -1,1 +1,2 @@
 linkscan interval=15000000
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/12/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/12/sai_postinit_cmd.soc
@@ -1,1 +1,2 @@
 linkscan interval=15000000
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/13/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/13/sai_postinit_cmd.soc
@@ -1,1 +1,2 @@
 linkscan interval=15000000
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/14/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/14/sai_postinit_cmd.soc
@@ -1,1 +1,2 @@
 linkscan interval=15000000
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/15/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/15/sai_postinit_cmd.soc
@@ -1,1 +1,2 @@
 linkscan interval=15000000
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/2/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/2/sai_postinit_cmd.soc
@@ -1,1 +1,2 @@
 linkscan interval=15000000
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/3/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/3/sai_postinit_cmd.soc
@@ -1,1 +1,2 @@
 linkscan interval=15000000
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/4/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/4/sai_postinit_cmd.soc
@@ -1,1 +1,2 @@
 linkscan interval=15000000
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/5/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/5/sai_postinit_cmd.soc
@@ -1,1 +1,2 @@
 linkscan interval=15000000
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/6/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/6/sai_postinit_cmd.soc
@@ -1,1 +1,2 @@
 linkscan interval=15000000
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/7/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/7/sai_postinit_cmd.soc
@@ -1,1 +1,2 @@
 linkscan interval=15000000
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/8/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/8/sai_postinit_cmd.soc
@@ -1,1 +1,2 @@
 linkscan interval=15000000
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/9/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/9/sai_postinit_cmd.soc
@@ -1,1 +1,2 @@
 linkscan interval=15000000
+Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Updated TM/FE error marking register to make FEC errors more reliable

##### Work item tracking
- Microsoft ADO **(34604903)**:

#### How I did it
Updated sai_postinit_cmd.soc file to set relevant registers. SW fix is work in progress.

#### How to verify it
Checked on lab system

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

