### PR TITLE
[ssw][ha] add `vnet_name` to global config (#23400)

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -3392,6 +3392,7 @@ Like NTP global configuration, DASH HA global configuration must have one entry 
 {
     "DASH_HA_GLOBAL_CONFIG": {
         "global": {
+            "vnet_name": "Vnet55",
             "cp_data_channel_port": "11362",
             "dp_channel_port": "11368",
             "dp_channel_src_port_min": "49152",
@@ -3404,6 +3405,8 @@ Like NTP global configuration, DASH HA global configuration must have one entry 
     }
 }
 ```
+
+**vnet_name**: Vnet name used in SmartSwitch HA scenarios.
 
 **cp_data_channel_port**: Control plane data channel port, used for bulk sync.
 

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2380,6 +2380,14 @@
                 "peer_list": "",
                 "advertise_prefix": "true",
                 "overlay_dmac": "22:33:44:55:66:77"
+            },
+            "Vnet55": {
+                "vxlan_tunnel": "vtep1",
+                "scope": "default",
+                "vni": "8000",
+                "peer_list": "",
+                "advertise_prefix": "true",
+                "overlay_dmac": "22:33:44:55:66:77"
             }
         },
         "VNET_ROUTE_TUNNEL" : {
@@ -2929,6 +2937,7 @@
         },
         "DASH_HA_GLOBAL_CONFIG": {
             "global": {
+                "vnet_name": "Vnet55",
                 "cp_data_channel_port": "11362",
                 "dp_channel_port": "11368",
                 "dp_channel_src_port_min": "49152",

--- a/src/sonic-yang-models/tests/yang_model_pytests/test_smart_switch.py
+++ b/src/sonic-yang-models/tests/yang_model_pytests/test_smart_switch.py
@@ -425,9 +425,34 @@ class TestSmartSwitch:
 
     def test_dash_ha_global_config(self, yang_model):
         data = {
+            "sonic-vxlan:sonic-vxlan": {
+                "sonic-vxlan:VXLAN_TUNNEL": {
+                    "VXLAN_TUNNEL_LIST": [
+                        {
+                            "name": "vtep1",
+                            "src_ip": "1.2.3.4"
+                        }
+                    ]
+                }
+            },
+            "sonic-vnet:sonic-vnet": {
+                "sonic-vnet:VNET": {
+                    "VNET_LIST": [
+                        {
+                            "name": "Vnet55",
+                            "vxlan_tunnel": "vtep1",
+                            "vni": 8000,
+                            "scope": "default",
+                            "advertise_prefix": True,
+                            "overlay_dmac": "22:33:44:55:66:77"
+                        }
+                    ]
+                }
+            },
             "sonic-smart-switch:sonic-smart-switch": {
                 "sonic-smart-switch:DASH_HA_GLOBAL_CONFIG": {
                     "global": {
+                        "vnet_name": "Vnet55",
                         "cp_data_channel_port": 11234,
                         "dp_channel_port": 11235,
                         "dp_channel_src_port_min": 11236,

--- a/src/sonic-yang-models/yang-models/sonic-smart-switch.yang
+++ b/src/sonic-yang-models/yang-models/sonic-smart-switch.yang
@@ -17,6 +17,10 @@ module sonic-smart-switch {
 		prefix port;
 	}
 
+	import sonic-vnet {
+		prefix sonic-vnet;
+	}
+
 	organization
 		"SONiC";
 
@@ -277,6 +281,16 @@ module sonic-smart-switch {
 			container global {
 
 				description "DASH_HA_GLOBAL_CONFIG part of config_db.json";
+
+				leaf vnet_name {
+					description "Name of the vnet used for VNET tunnel route.";
+					type leafref {
+						path "/sonic-vnet:sonic-vnet/sonic-vnet:VNET/sonic-vnet:VNET_LIST/sonic-vnet:name";
+					}
+					must "string-length(.) >= 1 and string-length(.) <= 255" {
+						error-message "vnet_name length must be between 1 and 255 characters";
+					}
+				}
 
 				leaf cp_data_channel_port {
 					description "Control plane data channel port, used for bulk sync";

--- a/src/sonic-yang-models/yang-models/sonic-vnet.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vnet.yang
@@ -44,7 +44,9 @@ module sonic-vnet {
 
                 leaf name {
                     description "An alphanumaric string to represent the name of the unique vnet";
-                    type string;
+                    type string {
+                        length 1..255;
+                    }
                 }
 
                 leaf vxlan_tunnel {


### PR DESCRIPTION
[ssw][ha] add `vnet_name` to global config

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Cherry-picking  https://github.com/sonic-net/sonic-buildimage/pull/23400

sign-off: Jing Zhang zhangjing@microsoft.com

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

