### PR TITLE
[202503][7060X6] Added custom SI settings for the host side serdes and LPO modules

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe/media_settings.json
+++ b/device/arista/x86_64-arista_7060x6_64pe/media_settings.json
@@ -1,0 +1,8324 @@
+{
+    "PORT_MEDIA_SETTINGS": {
+        "1": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe6",
+                        "lane1": "0xffffffe6",
+                        "lane2": "0xffffffe6",
+                        "lane3": "0xffffffe6",
+                        "lane4": "0xffffffe6",
+                        "lane5": "0xffffffe6",
+                        "lane6": "0xffffffe6",
+                        "lane7": "0xffffffe6"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0x00000000",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0x00000000",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000004",
+                        "lane1": "0x0000000c",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000004",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffd6",
+                        "lane1": "0xffffffda",
+                        "lane2": "0xffffffda",
+                        "lane3": "0xffffffda",
+                        "lane4": "0xffffffde",
+                        "lane5": "0xffffffda",
+                        "lane6": "0xffffffda",
+                        "lane7": "0xffffffda"
+                    },
+                    "main": {
+                        "lane0": "0x0000005c",
+                        "lane1": "0x0000005c",
+                        "lane2": "0x00000058",
+                        "lane3": "0x00000054",
+                        "lane4": "0x00000068",
+                        "lane5": "0x00000060",
+                        "lane6": "0x00000068",
+                        "lane7": "0x00000058"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff0"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "2": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe6",
+                        "lane1": "0xffffffe6",
+                        "lane2": "0xffffffe6",
+                        "lane3": "0xffffffe6",
+                        "lane4": "0xffffffe6",
+                        "lane5": "0xffffffe6",
+                        "lane6": "0xffffffe6",
+                        "lane7": "0xffffffe6"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0x00000000",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000004",
+                        "lane1": "0x0000000c",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000004",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffd6",
+                        "lane1": "0xffffffda",
+                        "lane2": "0xffffffda",
+                        "lane3": "0xffffffda",
+                        "lane4": "0xffffffde",
+                        "lane5": "0xffffffda",
+                        "lane6": "0xffffffd6",
+                        "lane7": "0xffffffda"
+                    },
+                    "main": {
+                        "lane0": "0x0000005c",
+                        "lane1": "0x0000005c",
+                        "lane2": "0x00000058",
+                        "lane3": "0x00000054",
+                        "lane4": "0x00000068",
+                        "lane5": "0x00000060",
+                        "lane6": "0x00000060",
+                        "lane7": "0x00000058"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "3": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3",
+                        "lane4": "0xffffffe3",
+                        "lane5": "0xffffffe3",
+                        "lane6": "0xffffffe3",
+                        "lane7": "0xffffffe3"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0x00000000",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000004",
+                        "lane1": "0x0000000c",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000004",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffd6",
+                        "lane1": "0xffffffda",
+                        "lane2": "0xffffffe2",
+                        "lane3": "0xffffffda",
+                        "lane4": "0xffffffde",
+                        "lane5": "0xffffffda",
+                        "lane6": "0xffffffd6",
+                        "lane7": "0xffffffde"
+                    },
+                    "main": {
+                        "lane0": "0x0000005c",
+                        "lane1": "0x0000005c",
+                        "lane2": "0x00000054",
+                        "lane3": "0x00000054",
+                        "lane4": "0x00000068",
+                        "lane5": "0x00000060",
+                        "lane6": "0x00000060",
+                        "lane7": "0x00000058"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "4": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3",
+                        "lane4": "0xffffffe3",
+                        "lane5": "0xffffffe3",
+                        "lane6": "0xffffffe3",
+                        "lane7": "0xffffffe3"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0x00000000",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000004",
+                        "lane1": "0x0000000c",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffd6",
+                        "lane1": "0xffffffda",
+                        "lane2": "0xffffffe2",
+                        "lane3": "0xffffffda",
+                        "lane4": "0xffffffde",
+                        "lane5": "0xffffffda",
+                        "lane6": "0xffffffde",
+                        "lane7": "0xffffffde"
+                    },
+                    "main": {
+                        "lane0": "0x0000005c",
+                        "lane1": "0x0000005c",
+                        "lane2": "0x00000054",
+                        "lane3": "0x00000054",
+                        "lane4": "0x00000068",
+                        "lane5": "0x00000066",
+                        "lane6": "0x00000066",
+                        "lane7": "0x00000058"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff0"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "5": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3",
+                        "lane4": "0xffffffe3",
+                        "lane5": "0xffffffe3",
+                        "lane6": "0xffffffe3",
+                        "lane7": "0xffffffe3"
+                    },
+                    "main": {
+                        "lane0": "0x0000005d",
+                        "lane1": "0x0000005d",
+                        "lane2": "0x0000005d",
+                        "lane3": "0x0000005d",
+                        "lane4": "0x0000005d",
+                        "lane5": "0x0000005d",
+                        "lane6": "0x0000005d",
+                        "lane7": "0x0000005d"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "6": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3",
+                        "lane4": "0xffffffe3",
+                        "lane5": "0xffffffe3",
+                        "lane6": "0xffffffe3",
+                        "lane7": "0xffffffe3"
+                    },
+                    "main": {
+                        "lane0": "0x0000005d",
+                        "lane1": "0x0000005d",
+                        "lane2": "0x0000005d",
+                        "lane3": "0x0000005d",
+                        "lane4": "0x0000005d",
+                        "lane5": "0x0000005d",
+                        "lane6": "0x0000005d",
+                        "lane7": "0x0000005d"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "7": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x0000005a",
+                        "lane1": "0x0000005a",
+                        "lane2": "0x0000005a",
+                        "lane3": "0x0000005a",
+                        "lane4": "0x0000005a",
+                        "lane5": "0x0000005a",
+                        "lane6": "0x0000005a",
+                        "lane7": "0x0000005a"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "8": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x0000005a",
+                        "lane1": "0x0000005a",
+                        "lane2": "0x0000005a",
+                        "lane3": "0x0000005a",
+                        "lane4": "0x0000005a",
+                        "lane5": "0x0000005a",
+                        "lane6": "0x0000005a",
+                        "lane7": "0x0000005a"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "9": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe6",
+                        "lane1": "0xffffffe6",
+                        "lane2": "0xffffffe6",
+                        "lane3": "0xffffffe6",
+                        "lane4": "0xffffffe6",
+                        "lane5": "0xffffffe6",
+                        "lane6": "0xffffffe6",
+                        "lane7": "0xffffffe6"
+                    },
+                    "main": {
+                        "lane0": "0x00000068",
+                        "lane1": "0x00000068",
+                        "lane2": "0x00000068",
+                        "lane3": "0x00000068",
+                        "lane4": "0x00000068",
+                        "lane5": "0x00000068",
+                        "lane6": "0x00000068",
+                        "lane7": "0x00000068"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa",
+                        "lane4": "0xfffffffa",
+                        "lane5": "0xfffffffa",
+                        "lane6": "0xfffffffa",
+                        "lane7": "0xfffffffa"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff2",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff2"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x0000000c",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffda",
+                        "lane1": "0xffffffe0",
+                        "lane2": "0xffffffda",
+                        "lane3": "0xffffffdc",
+                        "lane4": "0xffffffd6",
+                        "lane5": "0xffffffde",
+                        "lane6": "0xffffffda",
+                        "lane7": "0xffffffdc"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x0000005c",
+                        "lane2": "0x00000060",
+                        "lane3": "0x0000005c",
+                        "lane4": "0x0000005c",
+                        "lane5": "0x00000068",
+                        "lane6": "0x00000060",
+                        "lane7": "0x00000068"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff4"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "10": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe6",
+                        "lane1": "0xffffffe6",
+                        "lane2": "0xffffffe6",
+                        "lane3": "0xffffffe6",
+                        "lane4": "0xffffffe6",
+                        "lane5": "0xffffffe6",
+                        "lane6": "0xffffffe6",
+                        "lane7": "0xffffffe6"
+                    },
+                    "main": {
+                        "lane0": "0x00000068",
+                        "lane1": "0x00000068",
+                        "lane2": "0x00000068",
+                        "lane3": "0x00000068",
+                        "lane4": "0x00000068",
+                        "lane5": "0x00000068",
+                        "lane6": "0x00000068",
+                        "lane7": "0x00000068"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa",
+                        "lane4": "0xfffffffa",
+                        "lane5": "0xfffffffa",
+                        "lane6": "0xfffffffa",
+                        "lane7": "0xfffffffa"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff2",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff2"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x0000000c",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffda",
+                        "lane1": "0xffffffe0",
+                        "lane2": "0xffffffda",
+                        "lane3": "0xffffffdc",
+                        "lane4": "0xffffffd6",
+                        "lane5": "0xffffffde",
+                        "lane6": "0xffffffda",
+                        "lane7": "0xffffffdc"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x0000005c",
+                        "lane2": "0x00000060",
+                        "lane3": "0x0000005c",
+                        "lane4": "0x0000005c",
+                        "lane5": "0x00000068",
+                        "lane6": "0x00000060",
+                        "lane7": "0x00000068"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff4"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "11": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005c",
+                        "lane1": "0x0000005c",
+                        "lane2": "0x0000005c",
+                        "lane3": "0x0000005c",
+                        "lane4": "0x0000005c",
+                        "lane5": "0x0000005c",
+                        "lane6": "0x0000005c",
+                        "lane7": "0x0000005c"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x0000000c",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffd6",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffda",
+                        "lane3": "0xffffffdc",
+                        "lane4": "0xffffffd6",
+                        "lane5": "0xffffffde",
+                        "lane6": "0xffffffd6",
+                        "lane7": "0xffffffdc"
+                    },
+                    "main": {
+                        "lane0": "0x00000060",
+                        "lane1": "0x00000058",
+                        "lane2": "0x00000060",
+                        "lane3": "0x0000005c",
+                        "lane4": "0x0000005c",
+                        "lane5": "0x00000068",
+                        "lane6": "0x0000005c",
+                        "lane7": "0x00000068"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff4"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "12": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005c",
+                        "lane1": "0x0000005c",
+                        "lane2": "0x0000005c",
+                        "lane3": "0x0000005c",
+                        "lane4": "0x0000005c",
+                        "lane5": "0x0000005c",
+                        "lane6": "0x0000005c",
+                        "lane7": "0x0000005c"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x0000000c",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffd6",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffda",
+                        "lane3": "0xffffffdc",
+                        "lane4": "0xffffffd6",
+                        "lane5": "0xffffffde",
+                        "lane6": "0xffffffdc",
+                        "lane7": "0xffffffdc"
+                    },
+                    "main": {
+                        "lane0": "0x00000060",
+                        "lane1": "0x00000058",
+                        "lane2": "0x00000060",
+                        "lane3": "0x0000005c",
+                        "lane4": "0x0000005c",
+                        "lane5": "0x00000068",
+                        "lane6": "0x00000068",
+                        "lane7": "0x00000068"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "13": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005e",
+                        "lane1": "0x0000005e",
+                        "lane2": "0x0000005e",
+                        "lane3": "0x0000005e",
+                        "lane4": "0x0000005e",
+                        "lane5": "0x0000005e",
+                        "lane6": "0x0000005e",
+                        "lane7": "0x0000005e"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x00000008",
+                        "lane6": "0x0000000c",
+                        "lane7": "0x0000000c"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe2",
+                        "lane1": "0xffffffda",
+                        "lane2": "0xffffffe2",
+                        "lane3": "0xffffffde",
+                        "lane4": "0xffffffe2",
+                        "lane5": "0xffffffe6",
+                        "lane6": "0xffffffea",
+                        "lane7": "0xffffffe6"
+                    },
+                    "main": {
+                        "lane0": "0x00000054",
+                        "lane1": "0x00000060",
+                        "lane2": "0x00000054",
+                        "lane3": "0x00000058",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000058",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000054"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "14": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005e",
+                        "lane1": "0x0000005e",
+                        "lane2": "0x0000005e",
+                        "lane3": "0x0000005e",
+                        "lane4": "0x0000005e",
+                        "lane5": "0x0000005e",
+                        "lane6": "0x0000005e",
+                        "lane7": "0x0000005e"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x00000008",
+                        "lane6": "0x0000000c",
+                        "lane7": "0x0000000c"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe2",
+                        "lane1": "0xffffffda",
+                        "lane2": "0xffffffe2",
+                        "lane3": "0xffffffde",
+                        "lane4": "0xffffffe2",
+                        "lane5": "0xffffffe6",
+                        "lane6": "0xffffffea",
+                        "lane7": "0xffffffe6"
+                    },
+                    "main": {
+                        "lane0": "0x00000054",
+                        "lane1": "0x00000060",
+                        "lane2": "0x00000054",
+                        "lane3": "0x00000058",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000058",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000054"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "15": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x00000008",
+                        "lane6": "0x0000000c",
+                        "lane7": "0x0000000c"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe2",
+                        "lane1": "0xffffffde",
+                        "lane2": "0xffffffe2",
+                        "lane3": "0xffffffde",
+                        "lane4": "0xffffffe6",
+                        "lane5": "0xffffffe2",
+                        "lane6": "0xffffffe6",
+                        "lane7": "0xffffffe2"
+                    },
+                    "main": {
+                        "lane0": "0x00000054",
+                        "lane1": "0x00000058",
+                        "lane2": "0x00000050",
+                        "lane3": "0x0000005c",
+                        "lane4": "0x00000054",
+                        "lane5": "0x00000054",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000058"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "16": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x0000000c"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe2",
+                        "lane1": "0xffffffde",
+                        "lane2": "0xffffffe2",
+                        "lane3": "0xffffffde",
+                        "lane4": "0xffffffe6",
+                        "lane5": "0xffffffe2",
+                        "lane6": "0xffffffe6",
+                        "lane7": "0xffffffe2"
+                    },
+                    "main": {
+                        "lane0": "0x00000054",
+                        "lane1": "0x00000058",
+                        "lane2": "0x00000050",
+                        "lane3": "0x0000005c",
+                        "lane4": "0x00000054",
+                        "lane5": "0x00000054",
+                        "lane6": "0x00000058",
+                        "lane7": "0x00000058"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "17": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffea",
+                        "lane1": "0xffffffea",
+                        "lane2": "0xffffffea",
+                        "lane3": "0xffffffea",
+                        "lane4": "0xffffffea",
+                        "lane5": "0xffffffea",
+                        "lane6": "0xffffffea",
+                        "lane7": "0xffffffea"
+                    },
+                    "main": {
+                        "lane0": "0x0000005c",
+                        "lane1": "0x0000005c",
+                        "lane2": "0x0000005c",
+                        "lane3": "0x0000005c",
+                        "lane4": "0x0000005c",
+                        "lane5": "0x0000005c",
+                        "lane6": "0x0000005c",
+                        "lane7": "0x0000005c"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff9",
+                        "lane1": "0xfffffff9",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff9",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff9"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "18": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffea",
+                        "lane1": "0xffffffea",
+                        "lane2": "0xffffffea",
+                        "lane3": "0xffffffea",
+                        "lane4": "0xffffffea",
+                        "lane5": "0xffffffea",
+                        "lane6": "0xffffffea",
+                        "lane7": "0xffffffea"
+                    },
+                    "main": {
+                        "lane0": "0x0000005c",
+                        "lane1": "0x0000005c",
+                        "lane2": "0x0000005c",
+                        "lane3": "0x0000005c",
+                        "lane4": "0x0000005c",
+                        "lane5": "0x0000005c",
+                        "lane6": "0x0000005c",
+                        "lane7": "0x0000005c"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff9",
+                        "lane1": "0xfffffff9",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff9",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff9"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "19": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x00000060",
+                        "lane1": "0x00000060",
+                        "lane2": "0x00000060",
+                        "lane3": "0x00000060",
+                        "lane4": "0x00000060",
+                        "lane5": "0x00000060",
+                        "lane6": "0x00000060",
+                        "lane7": "0x00000060"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "20": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x00000060",
+                        "lane1": "0x00000060",
+                        "lane2": "0x00000060",
+                        "lane3": "0x00000060",
+                        "lane4": "0x00000060",
+                        "lane5": "0x00000060",
+                        "lane6": "0x00000060",
+                        "lane7": "0x00000060"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "21": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe7",
+                        "lane4": "0xffffffe7",
+                        "lane5": "0xffffffe7",
+                        "lane6": "0xffffffe7",
+                        "lane7": "0xffffffe7"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe0",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000054",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "22": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe7",
+                        "lane4": "0xffffffe7",
+                        "lane5": "0xffffffe7",
+                        "lane6": "0xffffffe7",
+                        "lane7": "0xffffffe7"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe0",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000054",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "23": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe8",
+                        "lane1": "0xffffffe8",
+                        "lane2": "0xffffffe8",
+                        "lane3": "0xffffffe8",
+                        "lane4": "0xffffffe8",
+                        "lane5": "0xffffffe8",
+                        "lane6": "0xffffffe8",
+                        "lane7": "0xffffffe8"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa",
+                        "lane4": "0xfffffffa",
+                        "lane5": "0xfffffffa",
+                        "lane6": "0xfffffffa",
+                        "lane7": "0xfffffffa"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "24": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe8",
+                        "lane1": "0xffffffe8",
+                        "lane2": "0xffffffe8",
+                        "lane3": "0xffffffe8",
+                        "lane4": "0xffffffe8",
+                        "lane5": "0xffffffe8",
+                        "lane6": "0xffffffe8",
+                        "lane7": "0xffffffe8"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa",
+                        "lane4": "0xfffffffa",
+                        "lane5": "0xfffffffa",
+                        "lane6": "0xfffffffa",
+                        "lane7": "0xfffffffa"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "25": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000005",
+                        "lane1": "0x00000005",
+                        "lane2": "0x00000005",
+                        "lane3": "0x00000005",
+                        "lane4": "0x00000005",
+                        "lane5": "0x00000005",
+                        "lane6": "0x00000005",
+                        "lane7": "0x00000005"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffeb",
+                        "lane1": "0xffffffeb",
+                        "lane2": "0xffffffeb",
+                        "lane3": "0xffffffeb",
+                        "lane4": "0xffffffeb",
+                        "lane5": "0xffffffeb",
+                        "lane6": "0xffffffeb",
+                        "lane7": "0xffffffeb"
+                    },
+                    "main": {
+                        "lane0": "0x00000056",
+                        "lane1": "0x00000056",
+                        "lane2": "0x00000056",
+                        "lane3": "0x00000056",
+                        "lane4": "0x00000056",
+                        "lane5": "0x00000056",
+                        "lane6": "0x00000056",
+                        "lane7": "0x00000056"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "26": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000005",
+                        "lane1": "0x00000005",
+                        "lane2": "0x00000005",
+                        "lane3": "0x00000005",
+                        "lane4": "0x00000005",
+                        "lane5": "0x00000005",
+                        "lane6": "0x00000005",
+                        "lane7": "0x00000005"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffeb",
+                        "lane1": "0xffffffeb",
+                        "lane2": "0xffffffeb",
+                        "lane3": "0xffffffeb",
+                        "lane4": "0xffffffeb",
+                        "lane5": "0xffffffeb",
+                        "lane6": "0xffffffeb",
+                        "lane7": "0xffffffeb"
+                    },
+                    "main": {
+                        "lane0": "0x00000056",
+                        "lane1": "0x00000056",
+                        "lane2": "0x00000056",
+                        "lane3": "0x00000056",
+                        "lane4": "0x00000056",
+                        "lane5": "0x00000056",
+                        "lane6": "0x00000056",
+                        "lane7": "0x00000056"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "27": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe8",
+                        "lane1": "0xffffffe8",
+                        "lane2": "0xffffffe8",
+                        "lane3": "0xffffffe8",
+                        "lane4": "0xffffffe8",
+                        "lane5": "0xffffffe8",
+                        "lane6": "0xffffffe8",
+                        "lane7": "0xffffffe8"
+                    },
+                    "main": {
+                        "lane0": "0x00000052",
+                        "lane1": "0x00000052",
+                        "lane2": "0x00000052",
+                        "lane3": "0x00000052",
+                        "lane4": "0x00000052",
+                        "lane5": "0x00000052",
+                        "lane6": "0x00000052",
+                        "lane7": "0x00000052"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "28": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe8",
+                        "lane1": "0xffffffe8",
+                        "lane2": "0xffffffe8",
+                        "lane3": "0xffffffe8",
+                        "lane4": "0xffffffe8",
+                        "lane5": "0xffffffe8",
+                        "lane6": "0xffffffe8",
+                        "lane7": "0xffffffe8"
+                    },
+                    "main": {
+                        "lane0": "0x00000052",
+                        "lane1": "0x00000052",
+                        "lane2": "0x00000052",
+                        "lane3": "0x00000052",
+                        "lane4": "0x00000052",
+                        "lane5": "0x00000052",
+                        "lane6": "0x00000052",
+                        "lane7": "0x00000052"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "29": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000004",
+                        "lane1": "0x00000004",
+                        "lane2": "0x00000004",
+                        "lane3": "0x00000004",
+                        "lane4": "0x00000004",
+                        "lane5": "0x00000004",
+                        "lane6": "0x00000004",
+                        "lane7": "0x00000004"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffed",
+                        "lane1": "0xffffffed",
+                        "lane2": "0xffffffed",
+                        "lane3": "0xffffffed",
+                        "lane4": "0xffffffed",
+                        "lane5": "0xffffffed",
+                        "lane6": "0xffffffed",
+                        "lane7": "0xffffffed"
+                    },
+                    "main": {
+                        "lane0": "0x00000056",
+                        "lane1": "0x00000056",
+                        "lane2": "0x00000056",
+                        "lane3": "0x00000056",
+                        "lane4": "0x00000056",
+                        "lane5": "0x00000056",
+                        "lane6": "0x00000056",
+                        "lane7": "0x00000056"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffffb",
+                        "lane3": "0xfffffffb",
+                        "lane4": "0xfffffffb",
+                        "lane5": "0xfffffffb",
+                        "lane6": "0xfffffffb",
+                        "lane7": "0xfffffffb"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff7",
+                        "lane1": "0xfffffff7",
+                        "lane2": "0xfffffff7",
+                        "lane3": "0xfffffff7",
+                        "lane4": "0xfffffff7",
+                        "lane5": "0xfffffff7",
+                        "lane6": "0xfffffff7",
+                        "lane7": "0xfffffff7"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000004",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "30": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000004",
+                        "lane1": "0x00000004",
+                        "lane2": "0x00000004",
+                        "lane3": "0x00000004",
+                        "lane4": "0x00000004",
+                        "lane5": "0x00000004",
+                        "lane6": "0x00000004",
+                        "lane7": "0x00000004"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffed",
+                        "lane1": "0xffffffed",
+                        "lane2": "0xffffffed",
+                        "lane3": "0xffffffed",
+                        "lane4": "0xffffffed",
+                        "lane5": "0xffffffed",
+                        "lane6": "0xffffffed",
+                        "lane7": "0xffffffed"
+                    },
+                    "main": {
+                        "lane0": "0x00000056",
+                        "lane1": "0x00000056",
+                        "lane2": "0x00000056",
+                        "lane3": "0x00000056",
+                        "lane4": "0x00000056",
+                        "lane5": "0x00000056",
+                        "lane6": "0x00000056",
+                        "lane7": "0x00000056"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffffb",
+                        "lane3": "0xfffffffb",
+                        "lane4": "0xfffffffb",
+                        "lane5": "0xfffffffb",
+                        "lane6": "0xfffffffb",
+                        "lane7": "0xfffffffb"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff7",
+                        "lane1": "0xfffffff7",
+                        "lane2": "0xfffffff7",
+                        "lane3": "0xfffffff7",
+                        "lane4": "0xfffffff7",
+                        "lane5": "0xfffffff7",
+                        "lane6": "0xfffffff7",
+                        "lane7": "0xfffffff7"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffe8",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "31": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                   "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe8",
+                        "lane1": "0xffffffe8",
+                        "lane2": "0xffffffe8",
+                        "lane3": "0xffffffe8",
+                        "lane4": "0xffffffe8",
+                        "lane5": "0xffffffe8",
+                        "lane6": "0xffffffe8",
+                        "lane7": "0xffffffe8"
+                    },
+                    "main": {
+                        "lane0": "0x00000056",
+                        "lane1": "0x00000056",
+                        "lane2": "0x00000056",
+                        "lane3": "0x00000056",
+                        "lane4": "0x00000056",
+                        "lane5": "0x00000056",
+                        "lane6": "0x00000056",
+                        "lane7": "0x00000056"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff7",
+                        "lane1": "0xfffffff7",
+                        "lane2": "0xfffffff7",
+                        "lane3": "0xfffffff7",
+                        "lane4": "0xfffffff7",
+                        "lane5": "0xfffffff7",
+                        "lane6": "0xfffffff7",
+                        "lane7": "0xfffffff7"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "32": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                   "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe8",
+                        "lane1": "0xffffffe8",
+                        "lane2": "0xffffffe8",
+                        "lane3": "0xffffffe8",
+                        "lane4": "0xffffffe8",
+                        "lane5": "0xffffffe8",
+                        "lane6": "0xffffffe8",
+                        "lane7": "0xffffffe8"
+                    },
+                    "main": {
+                        "lane0": "0x00000056",
+                        "lane1": "0x00000056",
+                        "lane2": "0x00000056",
+                        "lane3": "0x00000056",
+                        "lane4": "0x00000056",
+                        "lane5": "0x00000056",
+                        "lane6": "0x00000056",
+                        "lane7": "0x00000056"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff7",
+                        "lane1": "0xfffffff7",
+                        "lane2": "0xfffffff7",
+                        "lane3": "0xfffffff7",
+                        "lane4": "0xfffffff7",
+                        "lane5": "0xfffffff7",
+                        "lane6": "0xfffffff7",
+                        "lane7": "0xfffffff7"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "33": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000005",
+                        "lane1": "0x00000005",
+                        "lane2": "0x00000005",
+                        "lane3": "0x00000005",
+                        "lane4": "0x00000005",
+                        "lane5": "0x00000005",
+                        "lane6": "0x00000005",
+                        "lane7": "0x00000005"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffee",
+                        "lane1": "0xffffffee",
+                        "lane2": "0xffffffee",
+                        "lane3": "0xffffffee",
+                        "lane4": "0xffffffee",
+                        "lane5": "0xffffffee",
+                        "lane6": "0xffffffee",
+                        "lane7": "0xffffffee"
+                    },
+                    "main": {
+                        "lane0": "0x00000059",
+                        "lane1": "0x00000059",
+                        "lane2": "0x00000059",
+                        "lane3": "0x00000059",
+                        "lane4": "0x00000059",
+                        "lane5": "0x00000059",
+                        "lane6": "0x00000059",
+                        "lane7": "0x00000059"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa",
+                        "lane4": "0xfffffffa",
+                        "lane5": "0xfffffffa",
+                        "lane6": "0xfffffffa",
+                        "lane7": "0xfffffffa"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff7",
+                        "lane1": "0xfffffff7",
+                        "lane2": "0xfffffff7",
+                        "lane3": "0xfffffff7",
+                        "lane4": "0xfffffff7",
+                        "lane5": "0xfffffff7",
+                        "lane6": "0xfffffff7",
+                        "lane7": "0xfffffff7"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "34": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000005",
+                        "lane1": "0x00000005",
+                        "lane2": "0x00000005",
+                        "lane3": "0x00000005",
+                        "lane4": "0x00000005",
+                        "lane5": "0x00000005",
+                        "lane6": "0x00000005",
+                        "lane7": "0x00000005"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffee",
+                        "lane1": "0xffffffee",
+                        "lane2": "0xffffffee",
+                        "lane3": "0xffffffee",
+                        "lane4": "0xffffffee",
+                        "lane5": "0xffffffee",
+                        "lane6": "0xffffffee",
+                        "lane7": "0xffffffee"
+                    },
+                    "main": {
+                        "lane0": "0x00000059",
+                        "lane1": "0x00000059",
+                        "lane2": "0x00000059",
+                        "lane3": "0x00000059",
+                        "lane4": "0x00000059",
+                        "lane5": "0x00000059",
+                        "lane6": "0x00000059",
+                        "lane7": "0x00000059"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa",
+                        "lane4": "0xfffffffa",
+                        "lane5": "0xfffffffa",
+                        "lane6": "0xfffffffa",
+                        "lane7": "0xfffffffa"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff7",
+                        "lane1": "0xfffffff7",
+                        "lane2": "0xfffffff7",
+                        "lane3": "0xfffffff7",
+                        "lane4": "0xfffffff7",
+                        "lane5": "0xfffffff7",
+                        "lane6": "0xfffffff7",
+                        "lane7": "0xfffffff7"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "35": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe7",
+                        "lane4": "0xffffffe7",
+                        "lane5": "0xffffffe7",
+                        "lane6": "0xffffffe7",
+                        "lane7": "0xffffffe7"
+                    },
+                    "main": {
+                        "lane0": "0x00000056",
+                        "lane1": "0x00000056",
+                        "lane2": "0x00000056",
+                        "lane3": "0x00000056",
+                        "lane4": "0x00000056",
+                        "lane5": "0x00000056",
+                        "lane6": "0x00000056",
+                        "lane7": "0x00000056"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff9",
+                        "lane1": "0xfffffff9",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff9",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff9"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "36": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe7",
+                        "lane4": "0xffffffe7",
+                        "lane5": "0xffffffe7",
+                        "lane6": "0xffffffe7",
+                        "lane7": "0xffffffe7"
+                    },
+                    "main": {
+                        "lane0": "0x00000056",
+                        "lane1": "0x00000056",
+                        "lane2": "0x00000056",
+                        "lane3": "0x00000056",
+                        "lane4": "0x00000056",
+                        "lane5": "0x00000056",
+                        "lane6": "0x00000056",
+                        "lane7": "0x00000056"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff9",
+                        "lane1": "0xfffffff9",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff9",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff9"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "37": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                   "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000005",
+                        "lane1": "0x00000005",
+                        "lane2": "0x00000005",
+                        "lane3": "0x00000005",
+                        "lane4": "0x00000005",
+                        "lane5": "0x00000005",
+                        "lane6": "0x00000005",
+                        "lane7": "0x00000005"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffea",
+                        "lane1": "0xffffffea",
+                        "lane2": "0xffffffea",
+                        "lane3": "0xffffffea",
+                        "lane4": "0xffffffea",
+                        "lane5": "0xffffffea",
+                        "lane6": "0xffffffea",
+                        "lane7": "0xffffffea"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff7",
+                        "lane1": "0xfffffff7",
+                        "lane2": "0xfffffff7",
+                        "lane3": "0xfffffff7",
+                        "lane4": "0xfffffff7",
+                        "lane5": "0xfffffff7",
+                        "lane6": "0xfffffff7",
+                        "lane7": "0xfffffff7"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "38": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                   "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000005",
+                        "lane1": "0x00000005",
+                        "lane2": "0x00000005",
+                        "lane3": "0x00000005",
+                        "lane4": "0x00000005",
+                        "lane5": "0x00000005",
+                        "lane6": "0x00000005",
+                        "lane7": "0x00000005"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffea",
+                        "lane1": "0xffffffea",
+                        "lane2": "0xffffffea",
+                        "lane3": "0xffffffea",
+                        "lane4": "0xffffffea",
+                        "lane5": "0xffffffea",
+                        "lane6": "0xffffffea",
+                        "lane7": "0xffffffea"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff7",
+                        "lane1": "0xfffffff7",
+                        "lane2": "0xfffffff7",
+                        "lane3": "0xfffffff7",
+                        "lane4": "0xfffffff7",
+                        "lane5": "0xfffffff7",
+                        "lane6": "0xfffffff7",
+                        "lane7": "0xfffffff7"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "39": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000005",
+                        "lane1": "0x00000005",
+                        "lane2": "0x00000005",
+                        "lane3": "0x00000005",
+                        "lane4": "0x00000005",
+                        "lane5": "0x00000005",
+                        "lane6": "0x00000005",
+                        "lane7": "0x00000005"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffea",
+                        "lane1": "0xffffffea",
+                        "lane2": "0xffffffea",
+                        "lane3": "0xffffffea",
+                        "lane4": "0xffffffea",
+                        "lane5": "0xffffffea",
+                        "lane6": "0xffffffea",
+                        "lane7": "0xffffffea"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff7",
+                        "lane1": "0xfffffff7",
+                        "lane2": "0xfffffff7",
+                        "lane3": "0xfffffff7",
+                        "lane4": "0xfffffff7",
+                        "lane5": "0xfffffff7",
+                        "lane6": "0xfffffff7",
+                        "lane7": "0xfffffff7"
+                    }
+                }
+           },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "40": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000005",
+                        "lane1": "0x00000005",
+                        "lane2": "0x00000005",
+                        "lane3": "0x00000005",
+                        "lane4": "0x00000005",
+                        "lane5": "0x00000005",
+                        "lane6": "0x00000005",
+                        "lane7": "0x00000005"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffea",
+                        "lane1": "0xffffffea",
+                        "lane2": "0xffffffea",
+                        "lane3": "0xffffffea",
+                        "lane4": "0xffffffea",
+                        "lane5": "0xffffffea",
+                        "lane6": "0xffffffea",
+                        "lane7": "0xffffffea"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff7",
+                        "lane1": "0xfffffff7",
+                        "lane2": "0xfffffff7",
+                        "lane3": "0xfffffff7",
+                        "lane4": "0xfffffff7",
+                        "lane5": "0xfffffff7",
+                        "lane6": "0xfffffff7",
+                        "lane7": "0xfffffff7"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "41": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe6",
+                        "lane1": "0xffffffe6",
+                        "lane2": "0xffffffe6",
+                        "lane3": "0xffffffe6",
+                        "lane4": "0xffffffe6",
+                        "lane5": "0xffffffe6",
+                        "lane6": "0xffffffe6",
+                        "lane7": "0xffffffe6"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe2",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x0000005c",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "42": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe6",
+                        "lane1": "0xffffffe6",
+                        "lane2": "0xffffffe6",
+                        "lane3": "0xffffffe6",
+                        "lane4": "0xffffffe6",
+                        "lane5": "0xffffffe6",
+                        "lane6": "0xffffffe6",
+                        "lane7": "0xffffffe6"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "43": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe6",
+                        "lane1": "0xffffffe6",
+                        "lane2": "0xffffffe6",
+                        "lane3": "0xffffffe6",
+                        "lane4": "0xffffffe6",
+                        "lane5": "0xffffffe6",
+                        "lane6": "0xffffffe6",
+                        "lane7": "0xffffffe6"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "44": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe6",
+                        "lane1": "0xffffffe6",
+                        "lane2": "0xffffffe6",
+                        "lane3": "0xffffffe6",
+                        "lane4": "0xffffffe6",
+                        "lane5": "0xffffffe6",
+                        "lane6": "0xffffffe6",
+                        "lane7": "0xffffffe6"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "45": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe7",
+                        "lane4": "0xffffffe7",
+                        "lane5": "0xffffffe7",
+                        "lane6": "0xffffffe7",
+                        "lane7": "0xffffffe7"
+                    },
+                    "main": {
+                        "lane0": "0x00000063",
+                        "lane1": "0x00000063",
+                        "lane2": "0x00000063",
+                        "lane3": "0x00000063",
+                        "lane4": "0x00000063",
+                        "lane5": "0x00000063",
+                        "lane6": "0x00000063",
+                        "lane7": "0x00000063"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "46": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe7",
+                        "lane4": "0xffffffe7",
+                        "lane5": "0xffffffe7",
+                        "lane6": "0xffffffe7",
+                        "lane7": "0xffffffe7"
+                    },
+                    "main": {
+                        "lane0": "0x00000063",
+                        "lane1": "0x00000063",
+                        "lane2": "0x00000063",
+                        "lane3": "0x00000063",
+                        "lane4": "0x00000063",
+                        "lane5": "0x00000063",
+                        "lane6": "0x00000063",
+                        "lane7": "0x00000063"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "47": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe7",
+                        "lane4": "0xffffffe7",
+                        "lane5": "0xffffffe7",
+                        "lane6": "0xffffffe7",
+                        "lane7": "0xffffffe7"
+                    },
+                    "main": {
+                        "lane0": "0x00000063",
+                        "lane1": "0x00000063",
+                        "lane2": "0x00000063",
+                        "lane3": "0x00000063",
+                        "lane4": "0x00000063",
+                        "lane5": "0x00000063",
+                        "lane6": "0x00000063",
+                        "lane7": "0x00000063"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "48": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe7",
+                        "lane4": "0xffffffe7",
+                        "lane5": "0xffffffe7",
+                        "lane6": "0xffffffe7",
+                        "lane7": "0xffffffe7"
+                    },
+                    "main": {
+                        "lane0": "0x00000063",
+                        "lane1": "0x00000063",
+                        "lane2": "0x00000063",
+                        "lane3": "0x00000063",
+                        "lane4": "0x00000063",
+                        "lane5": "0x00000063",
+                        "lane6": "0x00000063",
+                        "lane7": "0x00000063"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe8",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "49": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "50": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "51": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "52": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "53": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa",
+                        "lane4": "0xfffffffa",
+                        "lane5": "0xfffffffa",
+                        "lane6": "0xfffffffa",
+                        "lane7": "0xfffffffa"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff2",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff2"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "54": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa",
+                        "lane4": "0xfffffffa",
+                        "lane5": "0xfffffffa",
+                        "lane6": "0xfffffffa",
+                        "lane7": "0xfffffffa"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff2",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff2"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "55": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa",
+                        "lane4": "0xfffffffa",
+                        "lane5": "0xfffffffa",
+                        "lane6": "0xfffffffa",
+                        "lane7": "0xfffffffa"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff2",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff2"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "56": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa",
+                        "lane4": "0xfffffffa",
+                        "lane5": "0xfffffffa",
+                        "lane6": "0xfffffffa",
+                        "lane7": "0xfffffffa"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff2",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff2"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "57": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x0000000c",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000004"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffda",
+                        "lane1": "0xffffffda",
+                        "lane2": "0xffffffd6",
+                        "lane3": "0xffffffda",
+                        "lane4": "0xffffffde",
+                        "lane5": "0xffffffd6",
+                        "lane6": "0xffffffd2",
+                        "lane7": "0xffffffd2"
+                    },
+                    "main": {
+                        "lane0": "0x00000060",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000060",
+                        "lane3": "0x00000064",
+                        "lane4": "0x0000006c",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000068"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "58": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x0000000c",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000004"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffda",
+                        "lane1": "0xffffffda",
+                        "lane2": "0xffffffd6",
+                        "lane3": "0xffffffda",
+                        "lane4": "0xffffffde",
+                        "lane5": "0xffffffd6",
+                        "lane6": "0xffffffd2",
+                        "lane7": "0xffffffd2"
+                    },
+                    "main": {
+                        "lane0": "0x00000060",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000060",
+                        "lane3": "0x00000064",
+                        "lane4": "0x0000006c",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000068"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "59": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x0000000c",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000004"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffda",
+                        "lane1": "0xffffffda",
+                        "lane2": "0xffffffd6",
+                        "lane3": "0xffffffda",
+                        "lane4": "0xffffffde",
+                        "lane5": "0xffffffd6",
+                        "lane6": "0xffffffd2",
+                        "lane7": "0xffffffd2"
+                    },
+                    "main": {
+                        "lane0": "0x00000060",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000060",
+                        "lane3": "0x00000064",
+                        "lane4": "0x0000006c",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000068"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "60": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x0000000c",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000004"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffda",
+                        "lane1": "0xffffffda",
+                        "lane2": "0xffffffd6",
+                        "lane3": "0xffffffda",
+                        "lane4": "0xffffffde",
+                        "lane5": "0xffffffd6",
+                        "lane6": "0xffffffd2",
+                        "lane7": "0xffffffd2"
+                    },
+                    "main": {
+                        "lane0": "0x00000060",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000060",
+                        "lane3": "0x00000064",
+                        "lane4": "0x0000006c",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000068"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "61": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe7",
+                        "lane4": "0xffffffe7",
+                        "lane5": "0xffffffe7",
+                        "lane6": "0xffffffe7",
+                        "lane7": "0xffffffe7"
+                    },
+                    "main": {
+                        "lane0": "0x00000061",
+                        "lane1": "0x00000061",
+                        "lane2": "0x00000061",
+                        "lane3": "0x00000061",
+                        "lane4": "0x00000061",
+                        "lane5": "0x00000061",
+                        "lane6": "0x00000061",
+                        "lane7": "0x00000061"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff1",
+                        "lane1": "0xfffffff1",
+                        "lane2": "0xfffffff1",
+                        "lane3": "0xfffffff1",
+                        "lane4": "0xfffffff1",
+                        "lane5": "0xfffffff1",
+                        "lane6": "0xfffffff1",
+                        "lane7": "0xfffffff1"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0x00000000",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "pre2": {
+                        "lane0": "0x0000000c",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x0000000c",
+                        "lane6": "0x00000004",
+                        "lane7": "0x00000004"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffd2",
+                        "lane1": "0xffffffde",
+                        "lane2": "0xffffffd2",
+                        "lane3": "0xffffffda",
+                        "lane4": "0xffffffd2",
+                        "lane5": "0xffffffde",
+                        "lane6": "0xffffffda",
+                        "lane7": "0xffffffd6"
+                    },
+                    "main": {
+                        "lane0": "0x0000005c",
+                        "lane1": "0x00000058",
+                        "lane2": "0x00000058",
+                        "lane3": "0x00000054",
+                        "lane4": "0x00000060",
+                        "lane5": "0x00000054",
+                        "lane6": "0x00000068",
+                        "lane7": "0x00000060"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff4"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "62": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe7",
+                        "lane4": "0xffffffe7",
+                        "lane5": "0xffffffe7",
+                        "lane6": "0xffffffe7",
+                        "lane7": "0xffffffe7"
+                    },
+                    "main": {
+                        "lane0": "0x00000061",
+                        "lane1": "0x00000061",
+                        "lane2": "0x00000061",
+                        "lane3": "0x00000061",
+                        "lane4": "0x00000061",
+                        "lane5": "0x00000061",
+                        "lane6": "0x00000061",
+                        "lane7": "0x00000061"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff1",
+                        "lane1": "0xfffffff1",
+                        "lane2": "0xfffffff1",
+                        "lane3": "0xfffffff1",
+                        "lane4": "0xfffffff1",
+                        "lane5": "0xfffffff1",
+                        "lane6": "0xfffffff1",
+                        "lane7": "0xfffffff1"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0x00000000",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0x00000000"
+                    },
+                    "pre2": {
+                        "lane0": "0x0000000c",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x0000000c",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000004"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffd2",
+                        "lane1": "0xffffffde",
+                        "lane2": "0xffffffd2",
+                        "lane3": "0xffffffda",
+                        "lane4": "0xffffffd2",
+                        "lane5": "0xffffffde",
+                        "lane6": "0xffffffda",
+                        "lane7": "0xffffffd6"
+                    },
+                    "main": {
+                        "lane0": "0x0000005c",
+                        "lane1": "0x00000058",
+                        "lane2": "0x00000058",
+                        "lane3": "0x00000054",
+                        "lane4": "0x00000060",
+                        "lane5": "0x00000054",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000060"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "63": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3",
+                        "lane4": "0xffffffe3",
+                        "lane5": "0xffffffe3",
+                        "lane6": "0xffffffe3",
+                        "lane7": "0xffffffe3"
+                    },
+                    "main": {
+                        "lane0": "0x00000062",
+                        "lane1": "0x00000062",
+                        "lane2": "0x00000062",
+                        "lane3": "0x00000062",
+                        "lane4": "0x00000062",
+                        "lane5": "0x00000062",
+                        "lane6": "0x00000062",
+                        "lane7": "0x00000062"
+                    },
+                    "post1": {
+                        "lane0": "0",
+                        "lane1": "0",
+                        "lane2": "0",
+                        "lane3": "0",
+                        "lane4": "0",
+                        "lane5": "0",
+                        "lane6": "0",
+                        "lane7": "0"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0x00000000",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0x00000000"
+                    },
+                    "pre2": {
+                        "lane0": "0x0000000c",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x0000000c",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000004"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffd2",
+                        "lane1": "0xffffffde",
+                        "lane2": "0xffffffd2",
+                        "lane3": "0xffffffda",
+                        "lane4": "0xffffffd2",
+                        "lane5": "0xffffffde",
+                        "lane6": "0xffffffda",
+                        "lane7": "0xffffffd6"
+                    },
+                    "main": {
+                        "lane0": "0x0000005c",
+                        "lane1": "0x00000058",
+                        "lane2": "0x00000058",
+                        "lane3": "0x00000054",
+                        "lane4": "0x00000060",
+                        "lane5": "0x00000054",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000060"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff4"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "64": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3",
+                        "lane4": "0xffffffe3",
+                        "lane5": "0xffffffe3",
+                        "lane6": "0xffffffe3",
+                        "lane7": "0xffffffe3"
+                    },
+                    "main": {
+                        "lane0": "0x00000062",
+                        "lane1": "0x00000062",
+                        "lane2": "0x00000062",
+                        "lane3": "0x00000062",
+                        "lane4": "0x00000062",
+                        "lane5": "0x00000062",
+                        "lane6": "0x00000062",
+                        "lane7": "0x00000062"
+                    },
+                    "post1": {
+                        "lane0": "0",
+                        "lane1": "0",
+                        "lane2": "0",
+                        "lane3": "0",
+                        "lane4": "0",
+                        "lane5": "0",
+                        "lane6": "0",
+                        "lane7": "0"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0x00000000",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0x00000000"
+                    },
+                    "pre2": {
+                        "lane0": "0x0000000c",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000004"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffd6",
+                        "lane1": "0xffffffde",
+                        "lane2": "0xffffffda",
+                        "lane3": "0xffffffe2",
+                        "lane4": "0xffffffe2",
+                        "lane5": "0xffffffda",
+                        "lane6": "0xffffffda",
+                        "lane7": "0xffffffd6"
+                    },
+                    "main": {
+                        "lane0": "0x00000060",
+                        "lane1": "0x00000058",
+                        "lane2": "0x00000058",
+                        "lane3": "0x00000060",
+                        "lane4": "0x00000060",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000060"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff4"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/device/arista/x86_64-arista_7060x6_64pe/optics_si_settings.json
+++ b/device/arista/x86_64-arista_7060x6_64pe/optics_si_settings.json
@@ -1,0 +1,84 @@
+{
+    "GLOBAL_MEDIA_SETTINGS": {
+        "1-12": {
+            "100G_SPEED": {
+                "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                    "FixedInputEqTargetTx": {
+                        "FixedInputEqTargetTx1": 3,
+                        "FixedInputEqTargetTx2": 3,
+                        "FixedInputEqTargetTx3": 3,
+                        "FixedInputEqTargetTx4": 3,
+                        "FixedInputEqTargetTx5": 3,
+                        "FixedInputEqTargetTx6": 3,
+                        "FixedInputEqTargetTx7": 3,
+                        "FixedInputEqTargetTx8": 3
+                    }
+                }
+            }
+        },
+        "13-24": {
+            "100G_SPEED": {
+                "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                    "FixedInputEqTargetTx": {
+                        "FixedInputEqTargetTx1": 1,
+                        "FixedInputEqTargetTx2": 1,
+                        "FixedInputEqTargetTx3": 1,
+                        "FixedInputEqTargetTx4": 1,
+                        "FixedInputEqTargetTx5": 1,
+                        "FixedInputEqTargetTx6": 1,
+                        "FixedInputEqTargetTx7": 1,
+                        "FixedInputEqTargetTx8": 1
+                    }
+                }
+            }
+        },
+        "25-40": {
+            "100G_SPEED": {
+                "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                    "FixedInputEqTargetTx": {
+                        "FixedInputEqTargetTx1": 0,
+                        "FixedInputEqTargetTx2": 0,
+                        "FixedInputEqTargetTx3": 0,
+                        "FixedInputEqTargetTx4": 0,
+                        "FixedInputEqTargetTx5": 0,
+                        "FixedInputEqTargetTx6": 0,
+                        "FixedInputEqTargetTx7": 0,
+                        "FixedInputEqTargetTx8": 0
+                    }
+                }
+            }
+        },
+        "41-52": {
+            "100G_SPEED": {
+                "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                    "FixedInputEqTargetTx": {
+                        "FixedInputEqTargetTx1": 1,
+                        "FixedInputEqTargetTx2": 1,
+                        "FixedInputEqTargetTx3": 1,
+                        "FixedInputEqTargetTx4": 1,
+                        "FixedInputEqTargetTx5": 1,
+                        "FixedInputEqTargetTx6": 1,
+                        "FixedInputEqTargetTx7": 1,
+                        "FixedInputEqTargetTx8": 1
+                    }
+                }
+            }
+        },
+        "53-64": {
+            "100G_SPEED": {
+                "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                    "FixedInputEqTargetTx": {
+                        "FixedInputEqTargetTx1": 3,
+                        "FixedInputEqTargetTx2": 3,
+                        "FixedInputEqTargetTx3": 3,
+                        "FixedInputEqTargetTx4": 3,
+                        "FixedInputEqTargetTx5": 3,
+                        "FixedInputEqTargetTx6": 3,
+                        "FixedInputEqTargetTx7": 3,
+                        "FixedInputEqTargetTx8": 3
+                    }
+                }
+            }
+        }
+    }
+}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/media_settings.json
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/media_settings.json
@@ -1,0 +1,8324 @@
+{
+    "PORT_MEDIA_SETTINGS": {
+        "1": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe6",
+                        "lane1": "0xffffffe6",
+                        "lane2": "0xffffffe6",
+                        "lane3": "0xffffffe6",
+                        "lane4": "0xffffffe6",
+                        "lane5": "0xffffffe6",
+                        "lane6": "0xffffffe6",
+                        "lane7": "0xffffffe6"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0x00000000",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0x00000000",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000004",
+                        "lane1": "0x0000000c",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000004",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffd6",
+                        "lane1": "0xffffffda",
+                        "lane2": "0xffffffda",
+                        "lane3": "0xffffffda",
+                        "lane4": "0xffffffde",
+                        "lane5": "0xffffffda",
+                        "lane6": "0xffffffda",
+                        "lane7": "0xffffffda"
+                    },
+                    "main": {
+                        "lane0": "0x0000005c",
+                        "lane1": "0x0000005c",
+                        "lane2": "0x00000058",
+                        "lane3": "0x00000054",
+                        "lane4": "0x00000068",
+                        "lane5": "0x00000060",
+                        "lane6": "0x00000068",
+                        "lane7": "0x00000058"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff0"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "2": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe6",
+                        "lane1": "0xffffffe6",
+                        "lane2": "0xffffffe6",
+                        "lane3": "0xffffffe6",
+                        "lane4": "0xffffffe6",
+                        "lane5": "0xffffffe6",
+                        "lane6": "0xffffffe6",
+                        "lane7": "0xffffffe6"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0x00000000",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000004",
+                        "lane1": "0x0000000c",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000004",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffd6",
+                        "lane1": "0xffffffda",
+                        "lane2": "0xffffffda",
+                        "lane3": "0xffffffda",
+                        "lane4": "0xffffffde",
+                        "lane5": "0xffffffda",
+                        "lane6": "0xffffffd6",
+                        "lane7": "0xffffffda"
+                    },
+                    "main": {
+                        "lane0": "0x0000005c",
+                        "lane1": "0x0000005c",
+                        "lane2": "0x00000058",
+                        "lane3": "0x00000054",
+                        "lane4": "0x00000068",
+                        "lane5": "0x00000060",
+                        "lane6": "0x00000060",
+                        "lane7": "0x00000058"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "3": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3",
+                        "lane4": "0xffffffe3",
+                        "lane5": "0xffffffe3",
+                        "lane6": "0xffffffe3",
+                        "lane7": "0xffffffe3"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0x00000000",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000004",
+                        "lane1": "0x0000000c",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000004",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffd6",
+                        "lane1": "0xffffffda",
+                        "lane2": "0xffffffe2",
+                        "lane3": "0xffffffda",
+                        "lane4": "0xffffffde",
+                        "lane5": "0xffffffda",
+                        "lane6": "0xffffffd6",
+                        "lane7": "0xffffffde"
+                    },
+                    "main": {
+                        "lane0": "0x0000005c",
+                        "lane1": "0x0000005c",
+                        "lane2": "0x00000054",
+                        "lane3": "0x00000054",
+                        "lane4": "0x00000068",
+                        "lane5": "0x00000060",
+                        "lane6": "0x00000060",
+                        "lane7": "0x00000058"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "4": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3",
+                        "lane4": "0xffffffe3",
+                        "lane5": "0xffffffe3",
+                        "lane6": "0xffffffe3",
+                        "lane7": "0xffffffe3"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0x00000000",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000004",
+                        "lane1": "0x0000000c",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffd6",
+                        "lane1": "0xffffffda",
+                        "lane2": "0xffffffe2",
+                        "lane3": "0xffffffda",
+                        "lane4": "0xffffffde",
+                        "lane5": "0xffffffda",
+                        "lane6": "0xffffffde",
+                        "lane7": "0xffffffde"
+                    },
+                    "main": {
+                        "lane0": "0x0000005c",
+                        "lane1": "0x0000005c",
+                        "lane2": "0x00000054",
+                        "lane3": "0x00000054",
+                        "lane4": "0x00000068",
+                        "lane5": "0x00000066",
+                        "lane6": "0x00000066",
+                        "lane7": "0x00000058"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff0"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "5": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3",
+                        "lane4": "0xffffffe3",
+                        "lane5": "0xffffffe3",
+                        "lane6": "0xffffffe3",
+                        "lane7": "0xffffffe3"
+                    },
+                    "main": {
+                        "lane0": "0x0000005d",
+                        "lane1": "0x0000005d",
+                        "lane2": "0x0000005d",
+                        "lane3": "0x0000005d",
+                        "lane4": "0x0000005d",
+                        "lane5": "0x0000005d",
+                        "lane6": "0x0000005d",
+                        "lane7": "0x0000005d"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "6": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3",
+                        "lane4": "0xffffffe3",
+                        "lane5": "0xffffffe3",
+                        "lane6": "0xffffffe3",
+                        "lane7": "0xffffffe3"
+                    },
+                    "main": {
+                        "lane0": "0x0000005d",
+                        "lane1": "0x0000005d",
+                        "lane2": "0x0000005d",
+                        "lane3": "0x0000005d",
+                        "lane4": "0x0000005d",
+                        "lane5": "0x0000005d",
+                        "lane6": "0x0000005d",
+                        "lane7": "0x0000005d"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "7": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x0000005a",
+                        "lane1": "0x0000005a",
+                        "lane2": "0x0000005a",
+                        "lane3": "0x0000005a",
+                        "lane4": "0x0000005a",
+                        "lane5": "0x0000005a",
+                        "lane6": "0x0000005a",
+                        "lane7": "0x0000005a"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "8": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x0000005a",
+                        "lane1": "0x0000005a",
+                        "lane2": "0x0000005a",
+                        "lane3": "0x0000005a",
+                        "lane4": "0x0000005a",
+                        "lane5": "0x0000005a",
+                        "lane6": "0x0000005a",
+                        "lane7": "0x0000005a"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "9": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe6",
+                        "lane1": "0xffffffe6",
+                        "lane2": "0xffffffe6",
+                        "lane3": "0xffffffe6",
+                        "lane4": "0xffffffe6",
+                        "lane5": "0xffffffe6",
+                        "lane6": "0xffffffe6",
+                        "lane7": "0xffffffe6"
+                    },
+                    "main": {
+                        "lane0": "0x00000068",
+                        "lane1": "0x00000068",
+                        "lane2": "0x00000068",
+                        "lane3": "0x00000068",
+                        "lane4": "0x00000068",
+                        "lane5": "0x00000068",
+                        "lane6": "0x00000068",
+                        "lane7": "0x00000068"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa",
+                        "lane4": "0xfffffffa",
+                        "lane5": "0xfffffffa",
+                        "lane6": "0xfffffffa",
+                        "lane7": "0xfffffffa"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff2",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff2"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x0000000c",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffda",
+                        "lane1": "0xffffffe0",
+                        "lane2": "0xffffffda",
+                        "lane3": "0xffffffdc",
+                        "lane4": "0xffffffd6",
+                        "lane5": "0xffffffde",
+                        "lane6": "0xffffffda",
+                        "lane7": "0xffffffdc"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x0000005c",
+                        "lane2": "0x00000060",
+                        "lane3": "0x0000005c",
+                        "lane4": "0x0000005c",
+                        "lane5": "0x00000068",
+                        "lane6": "0x00000060",
+                        "lane7": "0x00000068"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff4"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "10": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe6",
+                        "lane1": "0xffffffe6",
+                        "lane2": "0xffffffe6",
+                        "lane3": "0xffffffe6",
+                        "lane4": "0xffffffe6",
+                        "lane5": "0xffffffe6",
+                        "lane6": "0xffffffe6",
+                        "lane7": "0xffffffe6"
+                    },
+                    "main": {
+                        "lane0": "0x00000068",
+                        "lane1": "0x00000068",
+                        "lane2": "0x00000068",
+                        "lane3": "0x00000068",
+                        "lane4": "0x00000068",
+                        "lane5": "0x00000068",
+                        "lane6": "0x00000068",
+                        "lane7": "0x00000068"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa",
+                        "lane4": "0xfffffffa",
+                        "lane5": "0xfffffffa",
+                        "lane6": "0xfffffffa",
+                        "lane7": "0xfffffffa"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff2",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff2"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x0000000c",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffda",
+                        "lane1": "0xffffffe0",
+                        "lane2": "0xffffffda",
+                        "lane3": "0xffffffdc",
+                        "lane4": "0xffffffd6",
+                        "lane5": "0xffffffde",
+                        "lane6": "0xffffffda",
+                        "lane7": "0xffffffdc"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x0000005c",
+                        "lane2": "0x00000060",
+                        "lane3": "0x0000005c",
+                        "lane4": "0x0000005c",
+                        "lane5": "0x00000068",
+                        "lane6": "0x00000060",
+                        "lane7": "0x00000068"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff4"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "11": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005c",
+                        "lane1": "0x0000005c",
+                        "lane2": "0x0000005c",
+                        "lane3": "0x0000005c",
+                        "lane4": "0x0000005c",
+                        "lane5": "0x0000005c",
+                        "lane6": "0x0000005c",
+                        "lane7": "0x0000005c"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x0000000c",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffd6",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffda",
+                        "lane3": "0xffffffdc",
+                        "lane4": "0xffffffd6",
+                        "lane5": "0xffffffde",
+                        "lane6": "0xffffffd6",
+                        "lane7": "0xffffffdc"
+                    },
+                    "main": {
+                        "lane0": "0x00000060",
+                        "lane1": "0x00000058",
+                        "lane2": "0x00000060",
+                        "lane3": "0x0000005c",
+                        "lane4": "0x0000005c",
+                        "lane5": "0x00000068",
+                        "lane6": "0x0000005c",
+                        "lane7": "0x00000068"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff4"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "12": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005c",
+                        "lane1": "0x0000005c",
+                        "lane2": "0x0000005c",
+                        "lane3": "0x0000005c",
+                        "lane4": "0x0000005c",
+                        "lane5": "0x0000005c",
+                        "lane6": "0x0000005c",
+                        "lane7": "0x0000005c"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x0000000c",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffd6",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffda",
+                        "lane3": "0xffffffdc",
+                        "lane4": "0xffffffd6",
+                        "lane5": "0xffffffde",
+                        "lane6": "0xffffffdc",
+                        "lane7": "0xffffffdc"
+                    },
+                    "main": {
+                        "lane0": "0x00000060",
+                        "lane1": "0x00000058",
+                        "lane2": "0x00000060",
+                        "lane3": "0x0000005c",
+                        "lane4": "0x0000005c",
+                        "lane5": "0x00000068",
+                        "lane6": "0x00000068",
+                        "lane7": "0x00000068"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "13": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005e",
+                        "lane1": "0x0000005e",
+                        "lane2": "0x0000005e",
+                        "lane3": "0x0000005e",
+                        "lane4": "0x0000005e",
+                        "lane5": "0x0000005e",
+                        "lane6": "0x0000005e",
+                        "lane7": "0x0000005e"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x00000008",
+                        "lane6": "0x0000000c",
+                        "lane7": "0x0000000c"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe2",
+                        "lane1": "0xffffffda",
+                        "lane2": "0xffffffe2",
+                        "lane3": "0xffffffde",
+                        "lane4": "0xffffffe2",
+                        "lane5": "0xffffffe6",
+                        "lane6": "0xffffffea",
+                        "lane7": "0xffffffe6"
+                    },
+                    "main": {
+                        "lane0": "0x00000054",
+                        "lane1": "0x00000060",
+                        "lane2": "0x00000054",
+                        "lane3": "0x00000058",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000058",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000054"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "14": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005e",
+                        "lane1": "0x0000005e",
+                        "lane2": "0x0000005e",
+                        "lane3": "0x0000005e",
+                        "lane4": "0x0000005e",
+                        "lane5": "0x0000005e",
+                        "lane6": "0x0000005e",
+                        "lane7": "0x0000005e"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x00000008",
+                        "lane6": "0x0000000c",
+                        "lane7": "0x0000000c"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe2",
+                        "lane1": "0xffffffda",
+                        "lane2": "0xffffffe2",
+                        "lane3": "0xffffffde",
+                        "lane4": "0xffffffe2",
+                        "lane5": "0xffffffe6",
+                        "lane6": "0xffffffea",
+                        "lane7": "0xffffffe6"
+                    },
+                    "main": {
+                        "lane0": "0x00000054",
+                        "lane1": "0x00000060",
+                        "lane2": "0x00000054",
+                        "lane3": "0x00000058",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000058",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000054"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "15": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x00000008",
+                        "lane6": "0x0000000c",
+                        "lane7": "0x0000000c"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe2",
+                        "lane1": "0xffffffde",
+                        "lane2": "0xffffffe2",
+                        "lane3": "0xffffffde",
+                        "lane4": "0xffffffe6",
+                        "lane5": "0xffffffe2",
+                        "lane6": "0xffffffe6",
+                        "lane7": "0xffffffe2"
+                    },
+                    "main": {
+                        "lane0": "0x00000054",
+                        "lane1": "0x00000058",
+                        "lane2": "0x00000050",
+                        "lane3": "0x0000005c",
+                        "lane4": "0x00000054",
+                        "lane5": "0x00000054",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000058"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "16": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x0000000c"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe2",
+                        "lane1": "0xffffffde",
+                        "lane2": "0xffffffe2",
+                        "lane3": "0xffffffde",
+                        "lane4": "0xffffffe6",
+                        "lane5": "0xffffffe2",
+                        "lane6": "0xffffffe6",
+                        "lane7": "0xffffffe2"
+                    },
+                    "main": {
+                        "lane0": "0x00000054",
+                        "lane1": "0x00000058",
+                        "lane2": "0x00000050",
+                        "lane3": "0x0000005c",
+                        "lane4": "0x00000054",
+                        "lane5": "0x00000054",
+                        "lane6": "0x00000058",
+                        "lane7": "0x00000058"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "17": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffea",
+                        "lane1": "0xffffffea",
+                        "lane2": "0xffffffea",
+                        "lane3": "0xffffffea",
+                        "lane4": "0xffffffea",
+                        "lane5": "0xffffffea",
+                        "lane6": "0xffffffea",
+                        "lane7": "0xffffffea"
+                    },
+                    "main": {
+                        "lane0": "0x0000005c",
+                        "lane1": "0x0000005c",
+                        "lane2": "0x0000005c",
+                        "lane3": "0x0000005c",
+                        "lane4": "0x0000005c",
+                        "lane5": "0x0000005c",
+                        "lane6": "0x0000005c",
+                        "lane7": "0x0000005c"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff9",
+                        "lane1": "0xfffffff9",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff9",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff9"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "18": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffea",
+                        "lane1": "0xffffffea",
+                        "lane2": "0xffffffea",
+                        "lane3": "0xffffffea",
+                        "lane4": "0xffffffea",
+                        "lane5": "0xffffffea",
+                        "lane6": "0xffffffea",
+                        "lane7": "0xffffffea"
+                    },
+                    "main": {
+                        "lane0": "0x0000005c",
+                        "lane1": "0x0000005c",
+                        "lane2": "0x0000005c",
+                        "lane3": "0x0000005c",
+                        "lane4": "0x0000005c",
+                        "lane5": "0x0000005c",
+                        "lane6": "0x0000005c",
+                        "lane7": "0x0000005c"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff9",
+                        "lane1": "0xfffffff9",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff9",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff9"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "19": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x00000060",
+                        "lane1": "0x00000060",
+                        "lane2": "0x00000060",
+                        "lane3": "0x00000060",
+                        "lane4": "0x00000060",
+                        "lane5": "0x00000060",
+                        "lane6": "0x00000060",
+                        "lane7": "0x00000060"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "20": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x00000060",
+                        "lane1": "0x00000060",
+                        "lane2": "0x00000060",
+                        "lane3": "0x00000060",
+                        "lane4": "0x00000060",
+                        "lane5": "0x00000060",
+                        "lane6": "0x00000060",
+                        "lane7": "0x00000060"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "21": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe7",
+                        "lane4": "0xffffffe7",
+                        "lane5": "0xffffffe7",
+                        "lane6": "0xffffffe7",
+                        "lane7": "0xffffffe7"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe0",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000054",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "22": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe7",
+                        "lane4": "0xffffffe7",
+                        "lane5": "0xffffffe7",
+                        "lane6": "0xffffffe7",
+                        "lane7": "0xffffffe7"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe0",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000054",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "23": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe8",
+                        "lane1": "0xffffffe8",
+                        "lane2": "0xffffffe8",
+                        "lane3": "0xffffffe8",
+                        "lane4": "0xffffffe8",
+                        "lane5": "0xffffffe8",
+                        "lane6": "0xffffffe8",
+                        "lane7": "0xffffffe8"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa",
+                        "lane4": "0xfffffffa",
+                        "lane5": "0xfffffffa",
+                        "lane6": "0xfffffffa",
+                        "lane7": "0xfffffffa"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "24": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe8",
+                        "lane1": "0xffffffe8",
+                        "lane2": "0xffffffe8",
+                        "lane3": "0xffffffe8",
+                        "lane4": "0xffffffe8",
+                        "lane5": "0xffffffe8",
+                        "lane6": "0xffffffe8",
+                        "lane7": "0xffffffe8"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa",
+                        "lane4": "0xfffffffa",
+                        "lane5": "0xfffffffa",
+                        "lane6": "0xfffffffa",
+                        "lane7": "0xfffffffa"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "25": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000005",
+                        "lane1": "0x00000005",
+                        "lane2": "0x00000005",
+                        "lane3": "0x00000005",
+                        "lane4": "0x00000005",
+                        "lane5": "0x00000005",
+                        "lane6": "0x00000005",
+                        "lane7": "0x00000005"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffeb",
+                        "lane1": "0xffffffeb",
+                        "lane2": "0xffffffeb",
+                        "lane3": "0xffffffeb",
+                        "lane4": "0xffffffeb",
+                        "lane5": "0xffffffeb",
+                        "lane6": "0xffffffeb",
+                        "lane7": "0xffffffeb"
+                    },
+                    "main": {
+                        "lane0": "0x00000056",
+                        "lane1": "0x00000056",
+                        "lane2": "0x00000056",
+                        "lane3": "0x00000056",
+                        "lane4": "0x00000056",
+                        "lane5": "0x00000056",
+                        "lane6": "0x00000056",
+                        "lane7": "0x00000056"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "26": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000005",
+                        "lane1": "0x00000005",
+                        "lane2": "0x00000005",
+                        "lane3": "0x00000005",
+                        "lane4": "0x00000005",
+                        "lane5": "0x00000005",
+                        "lane6": "0x00000005",
+                        "lane7": "0x00000005"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffeb",
+                        "lane1": "0xffffffeb",
+                        "lane2": "0xffffffeb",
+                        "lane3": "0xffffffeb",
+                        "lane4": "0xffffffeb",
+                        "lane5": "0xffffffeb",
+                        "lane6": "0xffffffeb",
+                        "lane7": "0xffffffeb"
+                    },
+                    "main": {
+                        "lane0": "0x00000056",
+                        "lane1": "0x00000056",
+                        "lane2": "0x00000056",
+                        "lane3": "0x00000056",
+                        "lane4": "0x00000056",
+                        "lane5": "0x00000056",
+                        "lane6": "0x00000056",
+                        "lane7": "0x00000056"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "27": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe8",
+                        "lane1": "0xffffffe8",
+                        "lane2": "0xffffffe8",
+                        "lane3": "0xffffffe8",
+                        "lane4": "0xffffffe8",
+                        "lane5": "0xffffffe8",
+                        "lane6": "0xffffffe8",
+                        "lane7": "0xffffffe8"
+                    },
+                    "main": {
+                        "lane0": "0x00000052",
+                        "lane1": "0x00000052",
+                        "lane2": "0x00000052",
+                        "lane3": "0x00000052",
+                        "lane4": "0x00000052",
+                        "lane5": "0x00000052",
+                        "lane6": "0x00000052",
+                        "lane7": "0x00000052"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "28": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe8",
+                        "lane1": "0xffffffe8",
+                        "lane2": "0xffffffe8",
+                        "lane3": "0xffffffe8",
+                        "lane4": "0xffffffe8",
+                        "lane5": "0xffffffe8",
+                        "lane6": "0xffffffe8",
+                        "lane7": "0xffffffe8"
+                    },
+                    "main": {
+                        "lane0": "0x00000052",
+                        "lane1": "0x00000052",
+                        "lane2": "0x00000052",
+                        "lane3": "0x00000052",
+                        "lane4": "0x00000052",
+                        "lane5": "0x00000052",
+                        "lane6": "0x00000052",
+                        "lane7": "0x00000052"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "29": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000004",
+                        "lane1": "0x00000004",
+                        "lane2": "0x00000004",
+                        "lane3": "0x00000004",
+                        "lane4": "0x00000004",
+                        "lane5": "0x00000004",
+                        "lane6": "0x00000004",
+                        "lane7": "0x00000004"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffed",
+                        "lane1": "0xffffffed",
+                        "lane2": "0xffffffed",
+                        "lane3": "0xffffffed",
+                        "lane4": "0xffffffed",
+                        "lane5": "0xffffffed",
+                        "lane6": "0xffffffed",
+                        "lane7": "0xffffffed"
+                    },
+                    "main": {
+                        "lane0": "0x00000056",
+                        "lane1": "0x00000056",
+                        "lane2": "0x00000056",
+                        "lane3": "0x00000056",
+                        "lane4": "0x00000056",
+                        "lane5": "0x00000056",
+                        "lane6": "0x00000056",
+                        "lane7": "0x00000056"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffffb",
+                        "lane3": "0xfffffffb",
+                        "lane4": "0xfffffffb",
+                        "lane5": "0xfffffffb",
+                        "lane6": "0xfffffffb",
+                        "lane7": "0xfffffffb"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff7",
+                        "lane1": "0xfffffff7",
+                        "lane2": "0xfffffff7",
+                        "lane3": "0xfffffff7",
+                        "lane4": "0xfffffff7",
+                        "lane5": "0xfffffff7",
+                        "lane6": "0xfffffff7",
+                        "lane7": "0xfffffff7"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000004",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "30": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000004",
+                        "lane1": "0x00000004",
+                        "lane2": "0x00000004",
+                        "lane3": "0x00000004",
+                        "lane4": "0x00000004",
+                        "lane5": "0x00000004",
+                        "lane6": "0x00000004",
+                        "lane7": "0x00000004"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffed",
+                        "lane1": "0xffffffed",
+                        "lane2": "0xffffffed",
+                        "lane3": "0xffffffed",
+                        "lane4": "0xffffffed",
+                        "lane5": "0xffffffed",
+                        "lane6": "0xffffffed",
+                        "lane7": "0xffffffed"
+                    },
+                    "main": {
+                        "lane0": "0x00000056",
+                        "lane1": "0x00000056",
+                        "lane2": "0x00000056",
+                        "lane3": "0x00000056",
+                        "lane4": "0x00000056",
+                        "lane5": "0x00000056",
+                        "lane6": "0x00000056",
+                        "lane7": "0x00000056"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffffb",
+                        "lane3": "0xfffffffb",
+                        "lane4": "0xfffffffb",
+                        "lane5": "0xfffffffb",
+                        "lane6": "0xfffffffb",
+                        "lane7": "0xfffffffb"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff7",
+                        "lane1": "0xfffffff7",
+                        "lane2": "0xfffffff7",
+                        "lane3": "0xfffffff7",
+                        "lane4": "0xfffffff7",
+                        "lane5": "0xfffffff7",
+                        "lane6": "0xfffffff7",
+                        "lane7": "0xfffffff7"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffe8",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "31": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                   "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe8",
+                        "lane1": "0xffffffe8",
+                        "lane2": "0xffffffe8",
+                        "lane3": "0xffffffe8",
+                        "lane4": "0xffffffe8",
+                        "lane5": "0xffffffe8",
+                        "lane6": "0xffffffe8",
+                        "lane7": "0xffffffe8"
+                    },
+                    "main": {
+                        "lane0": "0x00000056",
+                        "lane1": "0x00000056",
+                        "lane2": "0x00000056",
+                        "lane3": "0x00000056",
+                        "lane4": "0x00000056",
+                        "lane5": "0x00000056",
+                        "lane6": "0x00000056",
+                        "lane7": "0x00000056"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff7",
+                        "lane1": "0xfffffff7",
+                        "lane2": "0xfffffff7",
+                        "lane3": "0xfffffff7",
+                        "lane4": "0xfffffff7",
+                        "lane5": "0xfffffff7",
+                        "lane6": "0xfffffff7",
+                        "lane7": "0xfffffff7"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "32": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                   "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe8",
+                        "lane1": "0xffffffe8",
+                        "lane2": "0xffffffe8",
+                        "lane3": "0xffffffe8",
+                        "lane4": "0xffffffe8",
+                        "lane5": "0xffffffe8",
+                        "lane6": "0xffffffe8",
+                        "lane7": "0xffffffe8"
+                    },
+                    "main": {
+                        "lane0": "0x00000056",
+                        "lane1": "0x00000056",
+                        "lane2": "0x00000056",
+                        "lane3": "0x00000056",
+                        "lane4": "0x00000056",
+                        "lane5": "0x00000056",
+                        "lane6": "0x00000056",
+                        "lane7": "0x00000056"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff7",
+                        "lane1": "0xfffffff7",
+                        "lane2": "0xfffffff7",
+                        "lane3": "0xfffffff7",
+                        "lane4": "0xfffffff7",
+                        "lane5": "0xfffffff7",
+                        "lane6": "0xfffffff7",
+                        "lane7": "0xfffffff7"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "33": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000005",
+                        "lane1": "0x00000005",
+                        "lane2": "0x00000005",
+                        "lane3": "0x00000005",
+                        "lane4": "0x00000005",
+                        "lane5": "0x00000005",
+                        "lane6": "0x00000005",
+                        "lane7": "0x00000005"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffee",
+                        "lane1": "0xffffffee",
+                        "lane2": "0xffffffee",
+                        "lane3": "0xffffffee",
+                        "lane4": "0xffffffee",
+                        "lane5": "0xffffffee",
+                        "lane6": "0xffffffee",
+                        "lane7": "0xffffffee"
+                    },
+                    "main": {
+                        "lane0": "0x00000059",
+                        "lane1": "0x00000059",
+                        "lane2": "0x00000059",
+                        "lane3": "0x00000059",
+                        "lane4": "0x00000059",
+                        "lane5": "0x00000059",
+                        "lane6": "0x00000059",
+                        "lane7": "0x00000059"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa",
+                        "lane4": "0xfffffffa",
+                        "lane5": "0xfffffffa",
+                        "lane6": "0xfffffffa",
+                        "lane7": "0xfffffffa"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff7",
+                        "lane1": "0xfffffff7",
+                        "lane2": "0xfffffff7",
+                        "lane3": "0xfffffff7",
+                        "lane4": "0xfffffff7",
+                        "lane5": "0xfffffff7",
+                        "lane6": "0xfffffff7",
+                        "lane7": "0xfffffff7"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "34": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000005",
+                        "lane1": "0x00000005",
+                        "lane2": "0x00000005",
+                        "lane3": "0x00000005",
+                        "lane4": "0x00000005",
+                        "lane5": "0x00000005",
+                        "lane6": "0x00000005",
+                        "lane7": "0x00000005"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffee",
+                        "lane1": "0xffffffee",
+                        "lane2": "0xffffffee",
+                        "lane3": "0xffffffee",
+                        "lane4": "0xffffffee",
+                        "lane5": "0xffffffee",
+                        "lane6": "0xffffffee",
+                        "lane7": "0xffffffee"
+                    },
+                    "main": {
+                        "lane0": "0x00000059",
+                        "lane1": "0x00000059",
+                        "lane2": "0x00000059",
+                        "lane3": "0x00000059",
+                        "lane4": "0x00000059",
+                        "lane5": "0x00000059",
+                        "lane6": "0x00000059",
+                        "lane7": "0x00000059"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa",
+                        "lane4": "0xfffffffa",
+                        "lane5": "0xfffffffa",
+                        "lane6": "0xfffffffa",
+                        "lane7": "0xfffffffa"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff7",
+                        "lane1": "0xfffffff7",
+                        "lane2": "0xfffffff7",
+                        "lane3": "0xfffffff7",
+                        "lane4": "0xfffffff7",
+                        "lane5": "0xfffffff7",
+                        "lane6": "0xfffffff7",
+                        "lane7": "0xfffffff7"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "35": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe7",
+                        "lane4": "0xffffffe7",
+                        "lane5": "0xffffffe7",
+                        "lane6": "0xffffffe7",
+                        "lane7": "0xffffffe7"
+                    },
+                    "main": {
+                        "lane0": "0x00000056",
+                        "lane1": "0x00000056",
+                        "lane2": "0x00000056",
+                        "lane3": "0x00000056",
+                        "lane4": "0x00000056",
+                        "lane5": "0x00000056",
+                        "lane6": "0x00000056",
+                        "lane7": "0x00000056"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff9",
+                        "lane1": "0xfffffff9",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff9",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff9"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "36": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe7",
+                        "lane4": "0xffffffe7",
+                        "lane5": "0xffffffe7",
+                        "lane6": "0xffffffe7",
+                        "lane7": "0xffffffe7"
+                    },
+                    "main": {
+                        "lane0": "0x00000056",
+                        "lane1": "0x00000056",
+                        "lane2": "0x00000056",
+                        "lane3": "0x00000056",
+                        "lane4": "0x00000056",
+                        "lane5": "0x00000056",
+                        "lane6": "0x00000056",
+                        "lane7": "0x00000056"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff9",
+                        "lane1": "0xfffffff9",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff9",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff9"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x0000004e",
+                        "lane1": "0x0000004e",
+                        "lane2": "0x0000004e",
+                        "lane3": "0x0000004e",
+                        "lane4": "0x0000004e",
+                        "lane5": "0x0000004e",
+                        "lane6": "0x0000004e",
+                        "lane7": "0x0000004e"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "37": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                   "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000005",
+                        "lane1": "0x00000005",
+                        "lane2": "0x00000005",
+                        "lane3": "0x00000005",
+                        "lane4": "0x00000005",
+                        "lane5": "0x00000005",
+                        "lane6": "0x00000005",
+                        "lane7": "0x00000005"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffea",
+                        "lane1": "0xffffffea",
+                        "lane2": "0xffffffea",
+                        "lane3": "0xffffffea",
+                        "lane4": "0xffffffea",
+                        "lane5": "0xffffffea",
+                        "lane6": "0xffffffea",
+                        "lane7": "0xffffffea"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff7",
+                        "lane1": "0xfffffff7",
+                        "lane2": "0xfffffff7",
+                        "lane3": "0xfffffff7",
+                        "lane4": "0xfffffff7",
+                        "lane5": "0xfffffff7",
+                        "lane6": "0xfffffff7",
+                        "lane7": "0xfffffff7"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "38": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                   "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000005",
+                        "lane1": "0x00000005",
+                        "lane2": "0x00000005",
+                        "lane3": "0x00000005",
+                        "lane4": "0x00000005",
+                        "lane5": "0x00000005",
+                        "lane6": "0x00000005",
+                        "lane7": "0x00000005"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffea",
+                        "lane1": "0xffffffea",
+                        "lane2": "0xffffffea",
+                        "lane3": "0xffffffea",
+                        "lane4": "0xffffffea",
+                        "lane5": "0xffffffea",
+                        "lane6": "0xffffffea",
+                        "lane7": "0xffffffea"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff7",
+                        "lane1": "0xfffffff7",
+                        "lane2": "0xfffffff7",
+                        "lane3": "0xfffffff7",
+                        "lane4": "0xfffffff7",
+                        "lane5": "0xfffffff7",
+                        "lane6": "0xfffffff7",
+                        "lane7": "0xfffffff7"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "39": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000005",
+                        "lane1": "0x00000005",
+                        "lane2": "0x00000005",
+                        "lane3": "0x00000005",
+                        "lane4": "0x00000005",
+                        "lane5": "0x00000005",
+                        "lane6": "0x00000005",
+                        "lane7": "0x00000005"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffea",
+                        "lane1": "0xffffffea",
+                        "lane2": "0xffffffea",
+                        "lane3": "0xffffffea",
+                        "lane4": "0xffffffea",
+                        "lane5": "0xffffffea",
+                        "lane6": "0xffffffea",
+                        "lane7": "0xffffffea"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff7",
+                        "lane1": "0xfffffff7",
+                        "lane2": "0xfffffff7",
+                        "lane3": "0xfffffff7",
+                        "lane4": "0xfffffff7",
+                        "lane5": "0xfffffff7",
+                        "lane6": "0xfffffff7",
+                        "lane7": "0xfffffff7"
+                    }
+                }
+           },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "40": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000005",
+                        "lane1": "0x00000005",
+                        "lane2": "0x00000005",
+                        "lane3": "0x00000005",
+                        "lane4": "0x00000005",
+                        "lane5": "0x00000005",
+                        "lane6": "0x00000005",
+                        "lane7": "0x00000005"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffea",
+                        "lane1": "0xffffffea",
+                        "lane2": "0xffffffea",
+                        "lane3": "0xffffffea",
+                        "lane4": "0xffffffea",
+                        "lane5": "0xffffffea",
+                        "lane6": "0xffffffea",
+                        "lane7": "0xffffffea"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff7",
+                        "lane1": "0xfffffff7",
+                        "lane2": "0xfffffff7",
+                        "lane3": "0xfffffff7",
+                        "lane4": "0xfffffff7",
+                        "lane5": "0xfffffff7",
+                        "lane6": "0xfffffff7",
+                        "lane7": "0xfffffff7"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "41": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe6",
+                        "lane1": "0xffffffe6",
+                        "lane2": "0xffffffe6",
+                        "lane3": "0xffffffe6",
+                        "lane4": "0xffffffe6",
+                        "lane5": "0xffffffe6",
+                        "lane6": "0xffffffe6",
+                        "lane7": "0xffffffe6"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe2",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x0000005c",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "42": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe6",
+                        "lane1": "0xffffffe6",
+                        "lane2": "0xffffffe6",
+                        "lane3": "0xffffffe6",
+                        "lane4": "0xffffffe6",
+                        "lane5": "0xffffffe6",
+                        "lane6": "0xffffffe6",
+                        "lane7": "0xffffffe6"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "43": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe6",
+                        "lane1": "0xffffffe6",
+                        "lane2": "0xffffffe6",
+                        "lane3": "0xffffffe6",
+                        "lane4": "0xffffffe6",
+                        "lane5": "0xffffffe6",
+                        "lane6": "0xffffffe6",
+                        "lane7": "0xffffffe6"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "44": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe6",
+                        "lane1": "0xffffffe6",
+                        "lane2": "0xffffffe6",
+                        "lane3": "0xffffffe6",
+                        "lane4": "0xffffffe6",
+                        "lane5": "0xffffffe6",
+                        "lane6": "0xffffffe6",
+                        "lane7": "0xffffffe6"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff6",
+                        "lane1": "0xfffffff6",
+                        "lane2": "0xfffffff6",
+                        "lane3": "0xfffffff6",
+                        "lane4": "0xfffffff6",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffff6",
+                        "lane7": "0xfffffff6"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "45": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe7",
+                        "lane4": "0xffffffe7",
+                        "lane5": "0xffffffe7",
+                        "lane6": "0xffffffe7",
+                        "lane7": "0xffffffe7"
+                    },
+                    "main": {
+                        "lane0": "0x00000063",
+                        "lane1": "0x00000063",
+                        "lane2": "0x00000063",
+                        "lane3": "0x00000063",
+                        "lane4": "0x00000063",
+                        "lane5": "0x00000063",
+                        "lane6": "0x00000063",
+                        "lane7": "0x00000063"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "46": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe7",
+                        "lane4": "0xffffffe7",
+                        "lane5": "0xffffffe7",
+                        "lane6": "0xffffffe7",
+                        "lane7": "0xffffffe7"
+                    },
+                    "main": {
+                        "lane0": "0x00000063",
+                        "lane1": "0x00000063",
+                        "lane2": "0x00000063",
+                        "lane3": "0x00000063",
+                        "lane4": "0x00000063",
+                        "lane5": "0x00000063",
+                        "lane6": "0x00000063",
+                        "lane7": "0x00000063"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "47": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe7",
+                        "lane4": "0xffffffe7",
+                        "lane5": "0xffffffe7",
+                        "lane6": "0xffffffe7",
+                        "lane7": "0xffffffe7"
+                    },
+                    "main": {
+                        "lane0": "0x00000063",
+                        "lane1": "0x00000063",
+                        "lane2": "0x00000063",
+                        "lane3": "0x00000063",
+                        "lane4": "0x00000063",
+                        "lane5": "0x00000063",
+                        "lane6": "0x00000063",
+                        "lane7": "0x00000063"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "48": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe7",
+                        "lane4": "0xffffffe7",
+                        "lane5": "0xffffffe7",
+                        "lane6": "0xffffffe7",
+                        "lane7": "0xffffffe7"
+                    },
+                    "main": {
+                        "lane0": "0x00000063",
+                        "lane1": "0x00000063",
+                        "lane2": "0x00000063",
+                        "lane3": "0x00000063",
+                        "lane4": "0x00000063",
+                        "lane5": "0x00000063",
+                        "lane6": "0x00000063",
+                        "lane7": "0x00000063"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff5",
+                        "lane1": "0xfffffff5",
+                        "lane2": "0xfffffff5",
+                        "lane3": "0xfffffff5",
+                        "lane4": "0xfffffff5",
+                        "lane5": "0xfffffff5",
+                        "lane6": "0xfffffff5",
+                        "lane7": "0xfffffff5"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe8",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "49": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "50": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "51": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "52": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000050",
+                        "lane1": "0x00000050",
+                        "lane2": "0x00000050",
+                        "lane3": "0x00000050",
+                        "lane4": "0x00000050",
+                        "lane5": "0x00000050",
+                        "lane6": "0x00000050",
+                        "lane7": "0x00000050"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "53": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa",
+                        "lane4": "0xfffffffa",
+                        "lane5": "0xfffffffa",
+                        "lane6": "0xfffffffa",
+                        "lane7": "0xfffffffa"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff2",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff2"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "54": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa",
+                        "lane4": "0xfffffffa",
+                        "lane5": "0xfffffffa",
+                        "lane6": "0xfffffffa",
+                        "lane7": "0xfffffffa"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff2",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff2"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "55": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa",
+                        "lane4": "0xfffffffa",
+                        "lane5": "0xfffffffa",
+                        "lane6": "0xfffffffa",
+                        "lane7": "0xfffffffa"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff2",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff2"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "56": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe4",
+                        "lane1": "0xffffffe4",
+                        "lane2": "0xffffffe4",
+                        "lane3": "0xffffffe4",
+                        "lane4": "0xffffffe4",
+                        "lane5": "0xffffffe4",
+                        "lane6": "0xffffffe4",
+                        "lane7": "0xffffffe4"
+                    },
+                    "main": {
+                        "lane0": "0x00000064",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000064",
+                        "lane3": "0x00000064",
+                        "lane4": "0x00000064",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000064"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa",
+                        "lane4": "0xfffffffa",
+                        "lane5": "0xfffffffa",
+                        "lane6": "0xfffffffa",
+                        "lane7": "0xfffffffa"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff2",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff2"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x00000008",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000008"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
+                    },
+                    "main": {
+                        "lane0": "0x00000055",
+                        "lane1": "0x00000055",
+                        "lane2": "0x00000055",
+                        "lane3": "0x00000055",
+                        "lane4": "0x00000055",
+                        "lane5": "0x00000055",
+                        "lane6": "0x00000055",
+                        "lane7": "0x00000055"
+                    },
+                    "post1": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "57": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x0000000c",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000004"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffda",
+                        "lane1": "0xffffffda",
+                        "lane2": "0xffffffd6",
+                        "lane3": "0xffffffda",
+                        "lane4": "0xffffffde",
+                        "lane5": "0xffffffd6",
+                        "lane6": "0xffffffd2",
+                        "lane7": "0xffffffd2"
+                    },
+                    "main": {
+                        "lane0": "0x00000060",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000060",
+                        "lane3": "0x00000064",
+                        "lane4": "0x0000006c",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000068"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "58": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x0000000c",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000004"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffda",
+                        "lane1": "0xffffffda",
+                        "lane2": "0xffffffd6",
+                        "lane3": "0xffffffda",
+                        "lane4": "0xffffffde",
+                        "lane5": "0xffffffd6",
+                        "lane6": "0xffffffd2",
+                        "lane7": "0xffffffd2"
+                    },
+                    "main": {
+                        "lane0": "0x00000060",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000060",
+                        "lane3": "0x00000064",
+                        "lane4": "0x0000006c",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000068"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "59": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x0000000c",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000004"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffda",
+                        "lane1": "0xffffffda",
+                        "lane2": "0xffffffd6",
+                        "lane3": "0xffffffda",
+                        "lane4": "0xffffffde",
+                        "lane5": "0xffffffd6",
+                        "lane6": "0xffffffd2",
+                        "lane7": "0xffffffd2"
+                    },
+                    "main": {
+                        "lane0": "0x00000060",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000060",
+                        "lane3": "0x00000064",
+                        "lane4": "0x0000006c",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000068"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "60": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffe"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe5",
+                        "lane1": "0xffffffe5",
+                        "lane2": "0xffffffe5",
+                        "lane3": "0xffffffe5",
+                        "lane4": "0xffffffe5",
+                        "lane5": "0xffffffe5",
+                        "lane6": "0xffffffe5",
+                        "lane7": "0xffffffe5"
+                    },
+                    "main": {
+                        "lane0": "0x0000005f",
+                        "lane1": "0x0000005f",
+                        "lane2": "0x0000005f",
+                        "lane3": "0x0000005f",
+                        "lane4": "0x0000005f",
+                        "lane5": "0x0000005f",
+                        "lane6": "0x0000005f",
+                        "lane7": "0x0000005f"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000008",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x0000000c",
+                        "lane5": "0x0000000c",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000004"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffda",
+                        "lane1": "0xffffffda",
+                        "lane2": "0xffffffd6",
+                        "lane3": "0xffffffda",
+                        "lane4": "0xffffffde",
+                        "lane5": "0xffffffd6",
+                        "lane6": "0xffffffd2",
+                        "lane7": "0xffffffd2"
+                    },
+                    "main": {
+                        "lane0": "0x00000060",
+                        "lane1": "0x00000064",
+                        "lane2": "0x00000060",
+                        "lane3": "0x00000064",
+                        "lane4": "0x0000006c",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000068"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "61": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe7",
+                        "lane4": "0xffffffe7",
+                        "lane5": "0xffffffe7",
+                        "lane6": "0xffffffe7",
+                        "lane7": "0xffffffe7"
+                    },
+                    "main": {
+                        "lane0": "0x00000061",
+                        "lane1": "0x00000061",
+                        "lane2": "0x00000061",
+                        "lane3": "0x00000061",
+                        "lane4": "0x00000061",
+                        "lane5": "0x00000061",
+                        "lane6": "0x00000061",
+                        "lane7": "0x00000061"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff1",
+                        "lane1": "0xfffffff1",
+                        "lane2": "0xfffffff1",
+                        "lane3": "0xfffffff1",
+                        "lane4": "0xfffffff1",
+                        "lane5": "0xfffffff1",
+                        "lane6": "0xfffffff1",
+                        "lane7": "0xfffffff1"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0x00000000",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    },
+                    "pre2": {
+                        "lane0": "0x0000000c",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x0000000c",
+                        "lane6": "0x00000004",
+                        "lane7": "0x00000004"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffd2",
+                        "lane1": "0xffffffde",
+                        "lane2": "0xffffffd2",
+                        "lane3": "0xffffffda",
+                        "lane4": "0xffffffd2",
+                        "lane5": "0xffffffde",
+                        "lane6": "0xffffffda",
+                        "lane7": "0xffffffd6"
+                    },
+                    "main": {
+                        "lane0": "0x0000005c",
+                        "lane1": "0x00000058",
+                        "lane2": "0x00000058",
+                        "lane3": "0x00000054",
+                        "lane4": "0x00000060",
+                        "lane5": "0x00000054",
+                        "lane6": "0x00000068",
+                        "lane7": "0x00000060"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff4"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "62": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000006",
+                        "lane1": "0x00000006",
+                        "lane2": "0x00000006",
+                        "lane3": "0x00000006",
+                        "lane4": "0x00000006",
+                        "lane5": "0x00000006",
+                        "lane6": "0x00000006",
+                        "lane7": "0x00000006"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe7",
+                        "lane4": "0xffffffe7",
+                        "lane5": "0xffffffe7",
+                        "lane6": "0xffffffe7",
+                        "lane7": "0xffffffe7"
+                    },
+                    "main": {
+                        "lane0": "0x00000061",
+                        "lane1": "0x00000061",
+                        "lane2": "0x00000061",
+                        "lane3": "0x00000061",
+                        "lane4": "0x00000061",
+                        "lane5": "0x00000061",
+                        "lane6": "0x00000061",
+                        "lane7": "0x00000061"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff1",
+                        "lane1": "0xfffffff1",
+                        "lane2": "0xfffffff1",
+                        "lane3": "0xfffffff1",
+                        "lane4": "0xfffffff1",
+                        "lane5": "0xfffffff1",
+                        "lane6": "0xfffffff1",
+                        "lane7": "0xfffffff1"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0x00000000",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0x00000000"
+                    },
+                    "pre2": {
+                        "lane0": "0x0000000c",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x0000000c",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000004"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffd2",
+                        "lane1": "0xffffffde",
+                        "lane2": "0xffffffd2",
+                        "lane3": "0xffffffda",
+                        "lane4": "0xffffffd2",
+                        "lane5": "0xffffffde",
+                        "lane6": "0xffffffda",
+                        "lane7": "0xffffffd6"
+                    },
+                    "main": {
+                        "lane0": "0x0000005c",
+                        "lane1": "0x00000058",
+                        "lane2": "0x00000058",
+                        "lane3": "0x00000054",
+                        "lane4": "0x00000060",
+                        "lane5": "0x00000054",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000060"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "63": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3",
+                        "lane4": "0xffffffe3",
+                        "lane5": "0xffffffe3",
+                        "lane6": "0xffffffe3",
+                        "lane7": "0xffffffe3"
+                    },
+                    "main": {
+                        "lane0": "0x00000062",
+                        "lane1": "0x00000062",
+                        "lane2": "0x00000062",
+                        "lane3": "0x00000062",
+                        "lane4": "0x00000062",
+                        "lane5": "0x00000062",
+                        "lane6": "0x00000062",
+                        "lane7": "0x00000062"
+                    },
+                    "post1": {
+                        "lane0": "0",
+                        "lane1": "0",
+                        "lane2": "0",
+                        "lane3": "0",
+                        "lane4": "0",
+                        "lane5": "0",
+                        "lane6": "0",
+                        "lane7": "0"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0x00000000",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0x00000000"
+                    },
+                    "pre2": {
+                        "lane0": "0x0000000c",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x0000000c",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000004"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffd2",
+                        "lane1": "0xffffffde",
+                        "lane2": "0xffffffd2",
+                        "lane3": "0xffffffda",
+                        "lane4": "0xffffffd2",
+                        "lane5": "0xffffffde",
+                        "lane6": "0xffffffda",
+                        "lane7": "0xffffffd6"
+                    },
+                    "main": {
+                        "lane0": "0x0000005c",
+                        "lane1": "0x00000058",
+                        "lane2": "0x00000058",
+                        "lane3": "0x00000054",
+                        "lane4": "0x00000060",
+                        "lane5": "0x00000054",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000060"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff4"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        },
+        "64": {
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                "speed:100GAUI-1-S|800G": {
+                    "pre3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre2": {
+                        "lane0": "0x00000007",
+                        "lane1": "0x00000007",
+                        "lane2": "0x00000007",
+                        "lane3": "0x00000007",
+                        "lane4": "0x00000007",
+                        "lane5": "0x00000007",
+                        "lane6": "0x00000007",
+                        "lane7": "0x00000007"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3",
+                        "lane4": "0xffffffe3",
+                        "lane5": "0xffffffe3",
+                        "lane6": "0xffffffe3",
+                        "lane7": "0xffffffe3"
+                    },
+                    "main": {
+                        "lane0": "0x00000062",
+                        "lane1": "0x00000062",
+                        "lane2": "0x00000062",
+                        "lane3": "0x00000062",
+                        "lane4": "0x00000062",
+                        "lane5": "0x00000062",
+                        "lane6": "0x00000062",
+                        "lane7": "0x00000062"
+                    },
+                    "post1": {
+                        "lane0": "0",
+                        "lane1": "0",
+                        "lane2": "0",
+                        "lane3": "0",
+                        "lane4": "0",
+                        "lane5": "0",
+                        "lane6": "0",
+                        "lane7": "0"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffff3",
+                        "lane1": "0xfffffff3",
+                        "lane2": "0xfffffff3",
+                        "lane3": "0xfffffff3",
+                        "lane4": "0xfffffff3",
+                        "lane5": "0xfffffff3",
+                        "lane6": "0xfffffff3",
+                        "lane7": "0xfffffff3"
+                    }
+                }
+            },
+            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|P-OH8CNT\\d{3}-NMT)": {
+                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
+                    "pre3": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0x00000000",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0x00000000"
+                    },
+                    "pre2": {
+                        "lane0": "0x0000000c",
+                        "lane1": "0x00000008",
+                        "lane2": "0x0000000c",
+                        "lane3": "0x00000008",
+                        "lane4": "0x00000008",
+                        "lane5": "0x00000008",
+                        "lane6": "0x00000008",
+                        "lane7": "0x00000004"
+                    },
+                    "pre1": {
+                        "lane0": "0xffffffd6",
+                        "lane1": "0xffffffde",
+                        "lane2": "0xffffffda",
+                        "lane3": "0xffffffe2",
+                        "lane4": "0xffffffe2",
+                        "lane5": "0xffffffda",
+                        "lane6": "0xffffffda",
+                        "lane7": "0xffffffd6"
+                    },
+                    "main": {
+                        "lane0": "0x00000060",
+                        "lane1": "0x00000058",
+                        "lane2": "0x00000058",
+                        "lane3": "0x00000060",
+                        "lane4": "0x00000060",
+                        "lane5": "0x00000064",
+                        "lane6": "0x00000064",
+                        "lane7": "0x00000060"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff4"
+                    },
+                    "post2": {
+                        "lane0": "0x00000000",
+                        "lane1": "0x00000000",
+                        "lane2": "0x00000000",
+                        "lane3": "0x00000000",
+                        "lane4": "0x00000000",
+                        "lane5": "0x00000000",
+                        "lane6": "0x00000000",
+                        "lane7": "0x00000000"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/optics_si_settings.json
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/optics_si_settings.json
@@ -1,0 +1,84 @@
+{
+    "GLOBAL_MEDIA_SETTINGS": {
+        "1-12": {
+            "100G_SPEED": {
+                "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                    "FixedInputEqTargetTx": {
+                        "FixedInputEqTargetTx1": 3,
+                        "FixedInputEqTargetTx2": 3,
+                        "FixedInputEqTargetTx3": 3,
+                        "FixedInputEqTargetTx4": 3,
+                        "FixedInputEqTargetTx5": 3,
+                        "FixedInputEqTargetTx6": 3,
+                        "FixedInputEqTargetTx7": 3,
+                        "FixedInputEqTargetTx8": 3
+                    }
+                }
+            }
+        },
+        "13-24": {
+            "100G_SPEED": {
+                "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                    "FixedInputEqTargetTx": {
+                        "FixedInputEqTargetTx1": 1,
+                        "FixedInputEqTargetTx2": 1,
+                        "FixedInputEqTargetTx3": 1,
+                        "FixedInputEqTargetTx4": 1,
+                        "FixedInputEqTargetTx5": 1,
+                        "FixedInputEqTargetTx6": 1,
+                        "FixedInputEqTargetTx7": 1,
+                        "FixedInputEqTargetTx8": 1
+                    }
+                }
+            }
+        },
+        "25-40": {
+            "100G_SPEED": {
+                "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                    "FixedInputEqTargetTx": {
+                        "FixedInputEqTargetTx1": 0,
+                        "FixedInputEqTargetTx2": 0,
+                        "FixedInputEqTargetTx3": 0,
+                        "FixedInputEqTargetTx4": 0,
+                        "FixedInputEqTargetTx5": 0,
+                        "FixedInputEqTargetTx6": 0,
+                        "FixedInputEqTargetTx7": 0,
+                        "FixedInputEqTargetTx8": 0
+                    }
+                }
+            }
+        },
+        "41-52": {
+            "100G_SPEED": {
+                "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                    "FixedInputEqTargetTx": {
+                        "FixedInputEqTargetTx1": 1,
+                        "FixedInputEqTargetTx2": 1,
+                        "FixedInputEqTargetTx3": 1,
+                        "FixedInputEqTargetTx4": 1,
+                        "FixedInputEqTargetTx5": 1,
+                        "FixedInputEqTargetTx6": 1,
+                        "FixedInputEqTargetTx7": 1,
+                        "FixedInputEqTargetTx8": 1
+                    }
+                }
+            }
+        },
+        "53-64": {
+            "100G_SPEED": {
+                "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
+                    "FixedInputEqTargetTx": {
+                        "FixedInputEqTargetTx1": 3,
+                        "FixedInputEqTargetTx2": 3,
+                        "FixedInputEqTargetTx3": 3,
+                        "FixedInputEqTargetTx4": 3,
+                        "FixedInputEqTargetTx5": 3,
+                        "FixedInputEqTargetTx6": 3,
+                        "FixedInputEqTargetTx7": 3,
+                        "FixedInputEqTargetTx8": 3
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
202503 cherry-pick for https://github.com/sonic-net/sonic-buildimage/pull/23841

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Added SI settings for the 1x800G LPO module on Arista 7060X6

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added the media_settings.json
Added the optics_si_settings.json

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

