### PR TITLE
Populate serial number into StateDB before starting telemetry process

### DIFF
--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -9,8 +9,9 @@ if [ "${TELEMETRY_WATCHDOG_SERIALNUMBER_PROBE_ENABLED}" = "true" ]; then
         if [ $? -eq 0 ] && [ -n "$SERIAL_NUMBER" ]; then
             CURRENT_VALUE=$(sonic-db-cli STATE_DB HGET "DEVICE_METADATA|localhost" chassis_serial_number)
             if [ "$CURRENT_VALUE" != "$SERIAL_NUMBER" ]; then
-                echo "Updating chassis_serial_number in STATE_DB: $SERIAL_NUMBER"
-                sonic-db-cli STATE_DB HSET "DEVICE_METADATA|localhost" chassis_serial_number "$SERIAL_NUMBER"
+                echo "Updating chassis_serial_number in STATE_DB: $CURRENT_VALUE -> $SERIAL_NUMBER"
+                RESULT=$(sonic-db-cli STATE_DB HSET "DEVICE_METADATA|localhost" chassis_serial_number "$SERIAL_NUMBER")
+                echo "sonic-db-cli HSET result: $RESULT"
             else
                 echo "chassis_serial_number already up to date in STATE_DB: $SERIAL_NUMBER"
             fi

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -1,5 +1,25 @@
 #!/usr/bin/env bash
 
+## Populate serial number to StateDB so telemetry could use it
+## Only update if decode-syseeprom succeeds and value differs from Redis
+## Set TELEMETRY_WATCHDOG_SERIALNUMBER_PROBE_ENABLED=true to enable
+if [ "${TELEMETRY_WATCHDOG_SERIALNUMBER_PROBE_ENABLED}" = "true" ]; then
+    nsenter --target 1 --pid --mount --uts --ipc --net bash -c '
+        SERIAL_NUMBER=$(decode-syseeprom -s)
+        if [ $? -eq 0 ] && [ -n "$SERIAL_NUMBER" ]; then
+            CURRENT_VALUE=$(sonic-db-cli STATE_DB HGET "DEVICE_METADATA|localhost" chassis_serial_number)
+            if [ "$CURRENT_VALUE" != "$SERIAL_NUMBER" ]; then
+                echo "Updating chassis_serial_number in STATE_DB: $SERIAL_NUMBER"
+                sonic-db-cli STATE_DB HSET "DEVICE_METADATA|localhost" chassis_serial_number "$SERIAL_NUMBER"
+            else
+                echo "chassis_serial_number already up to date in STATE_DB: $SERIAL_NUMBER"
+            fi
+        else
+            echo "Failed to retrieve serial number from decode-syseeprom"
+        fi
+    '
+fi
+
 EXIT_TELEMETRY_VARS_FILE_NOT_FOUND=1
 INCORRECT_TELEMETRY_VALUE=2
 TELEMETRY_VARS_FILE=/usr/share/sonic/templates/telemetry_vars.j2


### PR DESCRIPTION
#### Why I did it
Populate serial number into StateDB before starting telemetry process. In case snmp feature is disabled, we need this logic in order to have serial number into StateDB, so telemetry client could access it.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

