### PR TITLE
[Arista][DNX] Workaround for sai.profile being empty when syncd starts

### DIFF
--- a/platform/broadcom/docker-syncd-brcm-dnx/start.sh
+++ b/platform/broadcom/docker-syncd-brcm-dnx/start.sh
@@ -26,6 +26,16 @@ else
         sonic-cfggen -d -t $HWSKU_DIR/config.bcm.j2 > /etc/sai.d/config.bcm
     fi
     if [ -f $HWSKU_DIR/sai.profile ]; then
+        if [ ! -z $(grep "aboot_platform=.*arista" "/etc/machine.conf") ]; then
+            if [ -f /etc/sai.d/sai.profile ]; then
+                hashSrc=$(md5sum $HWSKU_DIR/sai.profile | cut -d ' ' -f 1)
+                hashDst=$(md5sum /etc/sai.d/sai.profile | cut -d ' ' -f 1)
+                if [ "${hashSrc}" == "${hashDst}" ]; then
+                    logger -p info "Arista: sai.profile unchanged, skip copying"
+                    exit 0
+                fi
+            fi
+        fi
         cp $HWSKU_DIR/sai.profile /etc/sai.d/sai.profile
     fi
 fi


### PR DESCRIPTION
We're seeing an issue where start.sh is run multiple times on syncd startup and if the 'cp' operation in the 2nd start.sh occurs while the Syncd process is reading the /etc/sai.d/sai.profile it will end up reading an empty file.

Therefor if we skip the 'cp' operation when the file is unchanged the 2nd start.sh run should always be a no-op.

This is a workaround until we find the reason and solution to stop start.sh from running multiple times.

