### PR TITLE
Update program_console_speed() in rc.local #22458

### DIFF
--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -198,9 +198,9 @@ program_console_speed()
     # Subsequent boots may have new baud rate without finding keep-baud argument
     grep agetty /lib/systemd/system/serial-getty@.service |grep keep-baud
     if [ $? = 0 ]; then
-        sed -i "s|\-\-keep\-baud .* %I| $CONSOLE_SPEED %I|g" /lib/systemd/system/serial-getty@.service
+        sed -i "s|\-\-keep\-baud .* -| $CONSOLE_SPEED -|g" /lib/systemd/system/serial-getty@.service
     else
-        sed -i "s|u' .* %I|u' $CONSOLE_SPEED %I|g" /lib/systemd/system/serial-getty@.service
+        sed -i "s|u' .* -|u' $CONSOLE_SPEED -|g" /lib/systemd/system/serial-getty@.service
     fi
 
     # Reload systemd config


### PR DESCRIPTION

This is the double commit of https://github.com/sonic-net/sonic-buildimage/pull/22458 

#### Why I did it

The --keep-baud option in agetty allows it to cycle through a set of baud rates (like 115200,57600,38400,9600) when it receives a break signal. This feature helps ensure that agetty can seamlessly adjust to different terminal speeds, enhancing compatibility across various setups.

Challenges with the sed Command:

Our current sed command (program_console_speed in rc.local ) is intended to update the baud rates in the serial-getty@.service based on the CONSOLE_SPEED variable. However, the command is not working as planned because the pattern --keep-baud .* %I doesn't match when %I isn't part of the file's content.


#### How I did it

To make the sed command more effective, we can simplify the matching pattern to focus solely on the baud rate list:
sed -i "s|\-\-keep\-baud .* -| $CONSOLE_SPEED -|g" /lib/systemd/system/serial-getty@.service
This adjustment should ensure that the command correctly updates the baud rate settings.

#### How to verify it

Verify serial-getty@.service before and after modifying rc.local

Before update
===========
 ExecStart=-/sbin/agetty -o '-p -- \\u' --keep-baud 115200,57600,38400,9600 - $TERM

After Update
==========
 ExecStart=-/sbin/agetty -o '-p -- \\u'  115200 - $TERM
 
 

#### Tested branch (Please provide the tested image version)

202501

 
Note: https://github.com/sonic-net/sonic-buildimage/issues/24506
