### PR TITLE
[202509] YANG: Add ZTP models (#22237)

### DIFF
--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -144,6 +144,7 @@ yang_files = [
     'sonic-serial-console.yang',
     'sonic-smart-switch.yang',
     'sonic-srv6.yang',
+    'sonic-ztp.yang',
 ]
 
 class my_build_py(build_py):

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -3002,6 +3002,17 @@
         "DEBUG_COUNTER_DROP_REASON": {
             "DEBUG_4|DIP_LINK_LOCAL": {},
             "DEBUG_4|SIP_LINK_LOCAL": {}
+        },
+        "ZTP" : {
+            "mode" : {
+                "profile" : "active",
+                "inband" : "true",
+                "out-of-band" : "true",
+                "ipv4" : "true",
+                "ipv6" : "true",
+                "product-name" : "product name",
+                "serial-no" : "1234-5678-91A"
+            }
         }
     },
     "SAMPLE_CONFIG_DB_UNKNOWN": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/ztp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/ztp.json
@@ -1,0 +1,25 @@
+{
+    "ZTP_VALID": {
+        "desc": "ZTP All Valid"
+    },
+    "ZTP_PROFILE_INVALID": {
+        "desc": "ZTP profile invalid",
+        "eStrKey" : "InvalidValue"
+    },
+    "ZTP_INBAND_INVALID": {
+        "desc": "ZTP inband invalid",
+        "eStrKey" : "InvalidValue"
+    },
+    "ZTP_OUTOFBAND_INVALID": {
+        "desc": "ZTP out-of-band invalid",
+        "eStrKey" : "InvalidValue"
+    },
+    "ZTP_IPV4_INVALID": {
+        "desc": "ZTP ipv4 invalid",
+        "eStrKey" : "InvalidValue"
+    },
+    "ZTP_IPV6_INVALID": {
+        "desc": "ZTP ipv6 invalid",
+        "eStrKey" : "InvalidValue"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/ztp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/ztp.json
@@ -1,0 +1,66 @@
+{
+    "ZTP_VALID": {
+        "sonic-ztp:sonic-ztp": {
+            "sonic-ztp:ZTP": {
+                "sonic-ztp:mode": {
+                    "profile" : "active",
+                    "inband" : "true",
+                    "out-of-band" : "true",
+                    "ipv4" : "true",
+                    "ipv6" : "true",
+                    "product-name" : "product name",
+                    "serial-no" : "1234-5678-9A1"
+                }
+            }
+        }
+    },
+    "ZTP_PROFILE_INVALID": {
+        "sonic-ztp:sonic-ztp": {
+            "sonic-ztp:ZTP": {
+                "sonic-ztp:mode": {
+                    "profile" : "invalid"
+                }
+            }
+        }
+    },
+    "ZTP_INBAND_INVALID": {
+         "sonic-ztp:sonic-ztp": {
+            "sonic-ztp:ZTP": {
+                "sonic-ztp:mode": {
+                    "profile" : "active",
+                    "inband": "invalid"
+                }
+            }
+        }
+    },
+    "ZTP_OUTOFBAND_INVALID": {
+         "sonic-ztp:sonic-ztp": {
+            "sonic-ztp:ZTP": {
+                "sonic-ztp:mode": {
+                    "profile" : "active",
+                    "out-of-band": "invalid"
+                }
+            }
+        }
+    },
+    "ZTP_IPV4_INVALID": {
+         "sonic-ztp:sonic-ztp": {
+            "sonic-ztp:ZTP": {
+                "sonic-ztp:mode": {
+                    "profile" : "active",
+                    "ipv4": "invalid"
+                }
+            }
+        }
+    },
+    "ZTP_IPV6_INVALID": {
+         "sonic-ztp:sonic-ztp": {
+            "sonic-ztp:ZTP": {
+                "sonic-ztp:mode": {
+                    "profile" : "active",
+                    "ipv6": "invalid"
+                }
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-ztp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-ztp.yang
@@ -1,0 +1,70 @@
+module sonic-ztp {
+
+    yang-version 1.1;
+
+    namespace "http://github.com/sonic-net/sonic-ztp";
+    prefix ztp;
+
+    description "ZTP YANG Module for SONiC OS";
+
+    revision 2025-04-03 {
+        description "First Revision";
+    }
+
+    container sonic-ztp {
+
+        container ZTP {
+
+            description "ZTP part of config_db.json used only temporarily during ZTP provisioning";
+
+            container mode {
+
+                leaf profile {
+                    type enumeration {
+                        enum active;
+                    }
+                    description "Whether or not ZTP is active";
+                }
+
+                leaf inband {
+                    type boolean;
+                    default true;
+                    description "If in-band ports are allowed to be used for ZTP";
+                }
+
+                leaf out-of-band {
+                    type boolean;
+                    default true;
+                    description "If out-of-band ports are allowed to be used for ZTP";
+                }
+
+                leaf ipv4 {
+                    type boolean;
+                    default true;
+                    description "If ipv4 is allowed to be used for ZTP";
+                }
+
+                leaf ipv6 {
+                    type boolean;
+                    default true;
+                    description "If ipv6 is allowed to be used for ZTP";
+                }
+
+                leaf product-name {
+                    type string;
+                    description "Product string as returned from decode-syseeprom -p";
+                }
+
+                leaf serial-no {
+                    type string;
+                    description "Serial number as returned from decode-syseeprom -s";
+                }
+
+            }
+            /* end of container mode */
+        }
+        /* end of container ZTP */
+    }
+    /* end of top level container */
+}
+/* end of module sonic-ztp */


### PR DESCRIPTION
During ZTP, the process creates temporary CONFIG_DB settings and if yang validation is enabled, these settings can cause failures. Lets add a YANG model and tests so these won't fail even though these are temporary settings.

Failure might look like the below...
```
[342113.096731] sonic-ztp[789615]: main()
[342113.096785] sonic-ztp[789615]: File "/usr/local/bin/config_validator.py", line 40, in main
2025 Mar 11 15:43:01.942688 ztp-dut2 INFO sonic-ztp[789615]: main()
[342113.096855] sonic-ztp[789615]: raise Exception("Tables without yang models: " + str(yang_parser.tablesWithOutYang))
2025 Mar 11 15:43:01.942742 ztp-dut2 INFO sonic-ztp[789615]: File "/usr/local/bin/config_validator.py", line 40, in main
[342113.096926] sonic-ztp[789615]: Exception: Tables without yang models: {'ZTP': {'mode': {'inband': 'true', 'ipv4': 'true', 'ipv6': 'true', 'out-of-band': 'true', 'product-name': '9716-32D-O-AC-AB-F-US', 'profile': 'active', 'serial-no': '971632D2451040'}}}
2025 Mar 11 15:43:01.942811 ztp-dut2 INFO sonic-ztp[789615]: raise Exception("Tables without yang models: " + str(yang_parser.tablesWithOutYang))
2025 Mar 11 15:43:01.942882 ztp-dut2 INFO sonic-ztp[789615]: Exception: Tables without yang models: {'ZTP': {'mode': {'inband': 'true', 'ipv4': 'true', 'ipv6': 'true', 'out-of-band': 'true', 'product-name': '9716-32D-O-AC-AB-F-US', 'profile': 'active', 'serial-no': '971632D2451040'}}}
2025 Mar 11 15:43:01.967529 ztp-dut2 INFO sonic-ztp[788029]: sonic_yang(6):Note: Below table(s) have no YANG models: ZTP
```

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

