### PR TITLE
[202503] Update sai_stats_support_mask to support flex counter in queue counter

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe-lt2.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe-lt2.config.bcm
@@ -1384,7 +1384,7 @@ bcm_device:
         global:
             ftem_mem_entries: 65536
             #enable port queue drop stats
-            sai_stats_support_mask: 0x880
+            sai_stats_support_mask: 0x884
             #disable vxlan tunnel stats
             sai_stats_disable_mask: 0x200
             #For PPIU Mode, Set resources for counters in global mode counters like ACL, etc

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe.config.bcm
@@ -1382,7 +1382,7 @@ bcm_device:
         global:
             ftem_mem_entries: 65536
             #enable port queue drop stats
-            sai_stats_support_mask: 0x884
+            sai_stats_support_mask: 0x880
             #disable vxlan tunnel stats
             sai_stats_disable_mask: 0x200
             #For PPIU Mode, Set resources for counters in global mode counters like ACL, etc

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe.config.bcm
@@ -1382,7 +1382,7 @@ bcm_device:
         global:
             ftem_mem_entries: 65536
             #enable port queue drop stats
-            sai_stats_support_mask: 0x880
+            sai_stats_support_mask: 0x884
             #disable vxlan tunnel stats
             sai_stats_disable_mask: 0x200
             #For PPIU Mode, Set resources for counters in global mode counters like ACL, etc

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32O64/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32O64/th5-a7060x6-64pe.config.bcm
@@ -1264,7 +1264,7 @@ bcm_device:
     0:
         global:
             ftem_mem_entries: 65536
-            sai_stats_support_mask: 0x880
+            sai_stats_support_mask: 0x884
             #disable vxlan tunnel stats
             sai_stats_disable_mask: 0x200
             #For PPIU Mode, Set resources for counters in global mode counters like ACL, etc

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32V128/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32V128/th5-a7060x6-64pe.config.bcm
@@ -1519,7 +1519,6 @@ bcm_device:
         global:
             ftem_mem_entries: 65536
             sai_stats_support_mask: 0x884
-            sai_stats_disable_mask: 0x200
             global_flexctr_ing_action_num_reserved: 20
             global_flexctr_ing_pool_num_reserved: 8
             global_flexctr_ing_op_profile_num_reserved: 20

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32V128/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32V128/th5-a7060x6-64pe.config.bcm
@@ -1518,7 +1518,8 @@ bcm_device:
     0:
         global:
             ftem_mem_entries: 65536
-            sai_stats_support_mask: 0x880
+            sai_stats_support_mask: 0x884
+            sai_stats_disable_mask: 0x200
             global_flexctr_ing_action_num_reserved: 20
             global_flexctr_ing_pool_num_reserved: 8
             global_flexctr_ing_op_profile_num_reserved: 20

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P64/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P64/th5-a7060x6-64pe.config.bcm
@@ -1129,7 +1129,7 @@ bcm_device:
     0:
         global:
             ftem_mem_entries: 65536
-            sai_stats_support_mask: 0x880
+            sai_stats_support_mask: 0x884
             #disable vxlan tunnel stats
             sai_stats_disable_mask: 0x200
             global_flexctr_ing_action_num_reserved: 20


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Cherry-pick https://github.com/sonic-net/sonic-buildimage/pull/24581

#### Why I did it
The change is required to support FLEX counter for queue counter.
CSP: CS00012425451

Below HWSKU are changed
- Arista-7060X6-64PE-B-O128
- Arista-7060X6-64PE-B-P32O64
- Arista-7060X6-64PE-B-P32V128
- Arista-7060X6-64PE-B-P64

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Update bcm config file.

#### How to verify it
The change is verified on a physical switch.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202503

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 20250305.26

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->
Update sai_stats_support_mask to support flex counter in queue counter.

#### Link to config_db schema for YANG module changes
No config change.

<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
