### PR TITLE
[msft-202405][yang-model] support reserving mem in high region for crashkernel

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/kdump.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/kdump.json
@@ -11,6 +11,12 @@
     "KDUMP_WITH_VALID_VALUES_4": {
         "desc": "Configuring the kdump with valid values."
     },
+    "KDUMP_WITH_VALID_MEM_HIGH": {
+        "desc": "Configuring the kdump with valid values and high suffix."
+    },
+    "KDUMP_WITH_VALID_MEM_HIGH_2": {
+        "desc": "Configuring the kdump with valid values and high suffix."
+    },
     "KDUMP_WITH_INVALID_NUM_DUMPS": {
         "desc": "Configuring kdump config with a invalid number of allowed kdumps.",
         "eStr": ["pattern", "does not satisfy"]
@@ -18,5 +24,13 @@
     "KDUMP_WITH_INVALID_MEMORY": {
         "desc": "Configuring kdump config with invalid memory config.",
         "eStr": ["pattern", "does not satisfy"]
+    },
+    "KDUMP_WITH_INVALID_MEM_HIGH": {
+        "desc": "Configuring kdump config with invalid value.",
+        "eStrKey": "Pattern"
+    },
+    "KDUMP_WITH_INVALID_MEM_HIGH_2": {
+        "desc": "Configuring kdump config with invalid suffix.",
+        "eStrKey": "Pattern"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/kdump.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/kdump.json
@@ -27,10 +27,10 @@
     },
     "KDUMP_WITH_INVALID_MEM_HIGH": {
         "desc": "Configuring kdump config with invalid value.",
-        "eStrKey": "Pattern"
+        "eStrKey": ["Pattern", "does not satisfy"]
     },
     "KDUMP_WITH_INVALID_MEM_HIGH_2": {
         "desc": "Configuring kdump config with invalid suffix.",
-        "eStrKey": "Pattern"
+        "eStrKey": ["Pattern", "does not satisfy"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/kdump.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/kdump.json
@@ -27,10 +27,10 @@
     },
     "KDUMP_WITH_INVALID_MEM_HIGH": {
         "desc": "Configuring kdump config with invalid value.",
-        "eStrKey": ["Pattern", "does not satisfy"]
+        "eStr": ["Pattern", "does not satisfy"]
     },
     "KDUMP_WITH_INVALID_MEM_HIGH_2": {
         "desc": "Configuring kdump config with invalid suffix.",
-        "eStrKey": ["Pattern", "does not satisfy"]
+        "eStr": ["Pattern", "does not satisfy"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/kdump.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/kdump.json
@@ -43,6 +43,48 @@
             }
         }
     },
+    "KDUMP_WITH_VALID_MEM_HIGH": {
+        "sonic-kdump:sonic-kdump": {
+            "sonic-kdump:KDUMP": {
+                "config": {
+                    "enabled": "true",
+                    "num_dumps": "3",
+                    "memory": "1G,high",
+                    "remote": "true",
+                    "ssh_string" : "ali@192.168.0.188",
+                    "ssh_path":  "/home/ali/.ssh/id_rsa"
+                }
+            }
+        }
+    },
+    "KDUMP_WITH_VALID_MEM_HIGH_2": {
+        "sonic-kdump:sonic-kdump": {
+            "sonic-kdump:KDUMP": {
+                "config": {
+                    "enabled": "true",
+                    "num_dumps": "3",
+                    "memory": "512M,high",
+                    "remote": "true",
+                    "ssh_string" : "ali@192.168.0.188",
+                    "ssh_path":  "/home/ali/.ssh/id_rsa"
+                }
+            }
+        }
+    },
+    "KDUMP_WITH_VALID_MEM_OFFSET_3": {
+        "sonic-kdump:sonic-kdump": {
+            "sonic-kdump:KDUMP": {
+                "config": {
+                    "enabled": "true",
+                    "num_dumps": "3",
+                    "memory": "512-4G:37M@10M,4G-8G:41M@20M,8G-:59M",
+                    "remote": "true",
+                    "ssh_string" : "ali@192.168.0.188",
+                    "ssh_path":  "/home/ali/.ssh/id_rsa"
+                }
+            }
+        }
+    },
 
     "KDUMP_WITH_INVALID_NUM_DUMPS": {
         "sonic-kdump:sonic-kdump": {
@@ -62,6 +104,34 @@
                     "enabled": "true",
                     "num_dumps": "3",
                     "memory": "666"
+                }
+            }
+        }
+    },
+    "KDUMP_WITH_INVALID_MEM_HIGH": {
+        "sonic-kdump:sonic-kdump": {
+            "sonic-kdump:KDUMP": {
+                "config": {
+                    "enabled": "true",
+                    "num_dumps": "3",
+                    "memory": "100,high",
+                    "remote": "true",
+                    "ssh_string" : "ali@192.168.0.188",
+                    "ssh_path":  "/home/ali/.ssh/id_rsa"
+                }
+            }
+        }
+    },
+    "KDUMP_WITH_INVALID_MEM_HIGH_2": {
+        "sonic-kdump:sonic-kdump": {
+            "sonic-kdump:KDUMP": {
+                "config": {
+                    "enabled": "true",
+                    "num_dumps": "3",
+                    "memory": "1G,highx",
+                    "remote": "true",
+                    "ssh_string" : "ali@192.168.0.188",
+                    "ssh_path":  "/home/ali/.ssh/id_rsa"
                 }
             }
         }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/kdump.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/kdump.json
@@ -50,9 +50,6 @@
                     "enabled": "true",
                     "num_dumps": "3",
                     "memory": "1G,high",
-                    "remote": "true",
-                    "ssh_string" : "ali@192.168.0.188",
-                    "ssh_path":  "/home/ali/.ssh/id_rsa"
                 }
             }
         }
@@ -64,28 +61,10 @@
                     "enabled": "true",
                     "num_dumps": "3",
                     "memory": "512M,high",
-                    "remote": "true",
-                    "ssh_string" : "ali@192.168.0.188",
-                    "ssh_path":  "/home/ali/.ssh/id_rsa"
                 }
             }
         }
     },
-    "KDUMP_WITH_VALID_MEM_OFFSET_3": {
-        "sonic-kdump:sonic-kdump": {
-            "sonic-kdump:KDUMP": {
-                "config": {
-                    "enabled": "true",
-                    "num_dumps": "3",
-                    "memory": "512-4G:37M@10M,4G-8G:41M@20M,8G-:59M",
-                    "remote": "true",
-                    "ssh_string" : "ali@192.168.0.188",
-                    "ssh_path":  "/home/ali/.ssh/id_rsa"
-                }
-            }
-        }
-    },
-
     "KDUMP_WITH_INVALID_NUM_DUMPS": {
         "sonic-kdump:sonic-kdump": {
             "sonic-kdump:KDUMP": {
@@ -115,9 +94,6 @@
                     "enabled": "true",
                     "num_dumps": "3",
                     "memory": "100,high",
-                    "remote": "true",
-                    "ssh_string" : "ali@192.168.0.188",
-                    "ssh_path":  "/home/ali/.ssh/id_rsa"
                 }
             }
         }
@@ -129,9 +105,6 @@
                     "enabled": "true",
                     "num_dumps": "3",
                     "memory": "1G,highx",
-                    "remote": "true",
-                    "ssh_string" : "ali@192.168.0.188",
-                    "ssh_path":  "/home/ali/.ssh/id_rsa"
                 }
             }
         }

--- a/src/sonic-yang-models/yang-models/sonic-kdump.yang
+++ b/src/sonic-yang-models/yang-models/sonic-kdump.yang
@@ -33,7 +33,7 @@ module sonic-kdump {
 
                 leaf memory {
                     type string {
-                        pattern "(((([0-9]+[MG]?)?(-([0-9]+[MG])?):)?[0-9]+[MG],?)+)";
+                        pattern "((((([0-9]+[MG]?)?(-([0-9]+[MG])?):)?[0-9]+[MG],?)+)|([0-9]+[MG],high))";
                     }
                     description
                         "Memory reserved for loading the crash handler kernel. The amount


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Cherry-pick https://github.com/sonic-net/sonic-buildimage/pull/24441 in msft-202405.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

