### PR TITLE
[202405][Arista] Update TM port header type to support runtime speed change

### DIFF
--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
@@ -485,16 +485,16 @@ ucode_port_154.BCM8869X=RCY_MIRROR.27:core_1.142
 
 port_priorities.BCM8869X=8
 
-tm_port_header_type_in_0.BCM8869X=INJECTED_2_PP
+tm_port_header_type_in_0.BCM8869X=INJECTED
 tm_port_header_type_out_0.BCM8869X=CPU
 
-tm_port_header_type_in_200.BCM8869X=INJECTED_2_PP
+tm_port_header_type_in_200.BCM8869X=INJECTED
 tm_port_header_type_out_200.BCM8869X=ETH
-tm_port_header_type_in_201.BCM8869X=INJECTED_2_PP
+tm_port_header_type_in_201.BCM8869X=INJECTED
 tm_port_header_type_out_201.BCM8869X=ETH
-tm_port_header_type_in_202.BCM8869X=INJECTED_2_PP
+tm_port_header_type_in_202.BCM8869X=INJECTED
 tm_port_header_type_out_202.BCM8869X=ETH
-tm_port_header_type_in_203.BCM8869X=INJECTED_2_PP
+tm_port_header_type_in_203.BCM8869X=INJECTED
 tm_port_header_type_out_203.BCM8869X=ETH
 
 sat_enable.BCM8869X=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -240,16 +240,16 @@ stable_size=800000000
 #########################
 #########################
 
-tm_port_header_type_in_0=INJECTED_2_PP
+tm_port_header_type_in_0=INJECTED
 tm_port_header_type_out_0=CPU
 
-tm_port_header_type_in_200=INJECTED_2_PP
+tm_port_header_type_in_200=INJECTED
 tm_port_header_type_out_200=ETH
-tm_port_header_type_in_201=INJECTED_2_PP
+tm_port_header_type_in_201=INJECTED
 tm_port_header_type_out_201=ETH
-tm_port_header_type_in_202=INJECTED_2_PP
+tm_port_header_type_in_202=INJECTED
 tm_port_header_type_out_202=ETH
-tm_port_header_type_in_203=INJECTED_2_PP
+tm_port_header_type_in_203=INJECTED
 tm_port_header_type_out_203=ETH
 
 ### RCY

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -240,16 +240,16 @@ stable_size=800000000
 #########################
 #########################
 
-tm_port_header_type_in_0=INJECTED_2_PP
+tm_port_header_type_in_0=INJECTED
 tm_port_header_type_out_0=CPU
 
-tm_port_header_type_in_200=INJECTED_2_PP
+tm_port_header_type_in_200=INJECTED
 tm_port_header_type_out_200=ETH
-tm_port_header_type_in_201=INJECTED_2_PP
+tm_port_header_type_in_201=INJECTED
 tm_port_header_type_out_201=ETH
-tm_port_header_type_in_202=INJECTED_2_PP
+tm_port_header_type_in_202=INJECTED
 tm_port_header_type_out_202=ETH
-tm_port_header_type_in_203=INJECTED_2_PP
+tm_port_header_type_in_203=INJECTED
 tm_port_header_type_out_203=ETH
 
 ### RCY

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -258,16 +258,16 @@ stable_size=800000000
 #########################
 #########################
 
-tm_port_header_type_in_0=INJECTED_2_PP
+tm_port_header_type_in_0=INJECTED
 tm_port_header_type_out_0=CPU
 
-tm_port_header_type_in_200=INJECTED_2_PP
+tm_port_header_type_in_200=INJECTED
 tm_port_header_type_out_200=ETH
-tm_port_header_type_in_201=INJECTED_2_PP
+tm_port_header_type_in_201=INJECTED
 tm_port_header_type_out_201=ETH
-tm_port_header_type_in_202=INJECTED_2_PP
+tm_port_header_type_in_202=INJECTED
 tm_port_header_type_out_202=ETH
-tm_port_header_type_in_203=INJECTED_2_PP
+tm_port_header_type_in_203=INJECTED
 tm_port_header_type_out_203=ETH
 
 ### RCY

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -258,16 +258,16 @@ stable_size=800000000
 #########################
 #########################
 
-tm_port_header_type_in_0=INJECTED_2_PP
+tm_port_header_type_in_0=INJECTED
 tm_port_header_type_out_0=CPU
 
-tm_port_header_type_in_200=INJECTED_2_PP
+tm_port_header_type_in_200=INJECTED
 tm_port_header_type_out_200=ETH
-tm_port_header_type_in_201=INJECTED_2_PP
+tm_port_header_type_in_201=INJECTED
 tm_port_header_type_out_201=ETH
-tm_port_header_type_in_202=INJECTED_2_PP
+tm_port_header_type_in_202=INJECTED
 tm_port_header_type_out_202=ETH
-tm_port_header_type_in_203=INJECTED_2_PP
+tm_port_header_type_in_203=INJECTED
 tm_port_header_type_out_203=ETH
 
 ### RCY

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -240,16 +240,16 @@ stable_size=800000000
 #########################
 #########################
 
-tm_port_header_type_in_0=INJECTED_2_PP
+tm_port_header_type_in_0=INJECTED
 tm_port_header_type_out_0=CPU
 
-tm_port_header_type_in_200=INJECTED_2_PP
+tm_port_header_type_in_200=INJECTED
 tm_port_header_type_out_200=ETH
-tm_port_header_type_in_201=INJECTED_2_PP
+tm_port_header_type_in_201=INJECTED
 tm_port_header_type_out_201=ETH
-tm_port_header_type_in_202=INJECTED_2_PP
+tm_port_header_type_in_202=INJECTED
 tm_port_header_type_out_202=ETH
-tm_port_header_type_in_203=INJECTED_2_PP
+tm_port_header_type_in_203=INJECTED
 tm_port_header_type_out_203=ETH
 
 ### RCY

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -240,16 +240,16 @@ stable_size=800000000
 #########################
 #########################
 
-tm_port_header_type_in_0=INJECTED_2_PP
+tm_port_header_type_in_0=INJECTED
 tm_port_header_type_out_0=CPU
 
-tm_port_header_type_in_200=INJECTED_2_PP
+tm_port_header_type_in_200=INJECTED
 tm_port_header_type_out_200=ETH
-tm_port_header_type_in_201=INJECTED_2_PP
+tm_port_header_type_in_201=INJECTED
 tm_port_header_type_out_201=ETH
-tm_port_header_type_in_202=INJECTED_2_PP
+tm_port_header_type_in_202=INJECTED
 tm_port_header_type_out_202=ETH
-tm_port_header_type_in_203=INJECTED_2_PP
+tm_port_header_type_in_203=INJECTED
 tm_port_header_type_out_203=ETH
 
 ### RCY


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/sonic-net/sonic-buildimage/pull/24575 for msft-202405 to speed up the merge process to msft-202405.

