### PR TITLE
[Nokia-IXR7250E][Devicedata] Update the device data for Nokia IXR7250E LC media_settings.json

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/media_settings.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/media_settings.json
@@ -1,0 +1,3892 @@
+{
+    "PORT_MEDIA_SETTINGS": {
+        "1": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x80",
+                        "lane1": "0x80",
+                        "lane2": "0x80",
+                        "lane3": "0x80",
+                        "lane4": "0x80",
+                        "lane5": "0x80",
+                        "lane6": "0x80",
+                        "lane7": "0x80"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "2": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x80",
+                        "lane1": "0x80",
+                        "lane2": "0x80",
+                        "lane3": "0x80",
+                        "lane4": "0x80",
+                        "lane5": "0x80",
+                        "lane6": "0x80",
+                        "lane7": "0x80"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "3": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x80",
+                        "lane1": "0x80",
+                        "lane2": "0x80",
+                        "lane3": "0x80",
+                        "lane4": "0x80",
+                        "lane5": "0x80",
+                        "lane6": "0x80",
+                        "lane7": "0x80"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff4",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffff4"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "4": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x80",
+                        "lane1": "0x80",
+                        "lane2": "0x80",
+                        "lane3": "0x80",
+                        "lane4": "0x80",
+                        "lane5": "0x80",
+                        "lane6": "0x80",
+                        "lane7": "0x80"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x4",
+                        "lane1": "0x4",
+                        "lane2": "0x4",
+                        "lane3": "0x4",
+                        "lane4": "0x4",
+                        "lane5": "0x4",
+                        "lane6": "0x4",
+                        "lane7": "0x4"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "5": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x98",
+                        "lane1": "0x98",
+                        "lane2": "0x98",
+                        "lane3": "0x98",
+                        "lane4": "0x98",
+                        "lane5": "0x98",
+                        "lane6": "0x98",
+                        "lane7": "0x98"
+                    },
+                    "post1": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "6": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x88",
+                        "lane1": "0x88",
+                        "lane2": "0x88",
+                        "lane3": "0x88",
+                        "lane4": "0x88",
+                        "lane5": "0x88",
+                        "lane6": "0x88",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "7": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x84",
+                        "lane1": "0x84",
+                        "lane2": "0x84",
+                        "lane3": "0x84",
+                        "lane4": "0x84",
+                        "lane5": "0x84",
+                        "lane6": "0x84",
+                        "lane7": "0x84"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "8": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x90",
+                        "lane1": "0x90",
+                        "lane2": "0x90",
+                        "lane3": "0x90",
+                        "lane4": "0x90",
+                        "lane5": "0x90",
+                        "lane6": "0x90",
+                        "lane7": "0x90"
+                    },
+                    "post1": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "9": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x84",
+                        "lane1": "0x84",
+                        "lane2": "0x84",
+                        "lane3": "0x84",
+                        "lane4": "0x84",
+                        "lane5": "0x84",
+                        "lane6": "0x84",
+                        "lane7": "0x84"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "10": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x90",
+                        "lane1": "0x90",
+                        "lane2": "0x90",
+                        "lane3": "0x90",
+                        "lane4": "0x90",
+                        "lane5": "0x90",
+                        "lane6": "0x90",
+                        "lane7": "0x90"
+                    },
+                    "post1": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "11": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x84",
+                        "lane1": "0x84",
+                        "lane2": "0x84",
+                        "lane3": "0x84",
+                        "lane4": "0x84",
+                        "lane5": "0x84",
+                        "lane6": "0x84",
+                        "lane7": "0x84"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "12": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x90",
+                        "lane1": "0x90",
+                        "lane2": "0x90",
+                        "lane3": "0x90",
+                        "lane4": "0x90",
+                        "lane5": "0x90",
+                        "lane6": "0x90",
+                        "lane7": "0x90"
+                    },
+                    "post1": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "13": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x84",
+                        "lane1": "0x84",
+                        "lane2": "0x84",
+                        "lane3": "0x84",
+                        "lane4": "0x84",
+                        "lane5": "0x84",
+                        "lane6": "0x84",
+                        "lane7": "0x84"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },        
+        "14": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x90",
+                        "lane1": "0x90",
+                        "lane2": "0x90",
+                        "lane3": "0x90",
+                        "lane4": "0x90",
+                        "lane5": "0x90",
+                        "lane6": "0x90",
+                        "lane7": "0x90"
+                    },
+                    "post1": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "15": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x80",
+                        "lane1": "0x80",
+                        "lane2": "0x80",
+                        "lane3": "0x80",
+                        "lane4": "0x80",
+                        "lane5": "0x80",
+                        "lane6": "0x80",
+                        "lane7": "0x80"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x4",
+                        "lane1": "0x4",
+                        "lane2": "0x4",
+                        "lane3": "0x4",
+                        "lane4": "0x4",
+                        "lane5": "0x4",
+                        "lane6": "0x4",
+                        "lane7": "0x4"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "16": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x88",
+                        "lane1": "0x88",
+                        "lane2": "0x88",
+                        "lane3": "0x88",
+                        "lane4": "0x88",
+                        "lane5": "0x88",
+                        "lane6": "0x88",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x4",
+                        "lane1": "0x4",
+                        "lane2": "0x4",
+                        "lane3": "0x4",
+                        "lane4": "0x4",
+                        "lane5": "0x4",
+                        "lane6": "0x4",
+                        "lane7": "0x4"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "17": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x84",
+                        "lane1": "0x84",
+                        "lane2": "0x84",
+                        "lane3": "0x84",
+                        "lane4": "0x84",
+                        "lane5": "0x84",
+                        "lane6": "0x84",
+                        "lane7": "0x84"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "18": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x80",
+                        "lane1": "0x80",
+                        "lane2": "0x80",
+                        "lane3": "0x80",
+                        "lane4": "0x80",
+                        "lane5": "0x80",
+                        "lane6": "0x80",
+                        "lane7": "0x80"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "19": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x84",
+                        "lane1": "0x84",
+                        "lane2": "0x84",
+                        "lane3": "0x84",
+                        "lane4": "0x84",
+                        "lane5": "0x84",
+                        "lane6": "0x84",
+                        "lane7": "0x84"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "20": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x84",
+                        "lane1": "0x84",
+                        "lane2": "0x84",
+                        "lane3": "0x84",
+                        "lane4": "0x84",
+                        "lane5": "0x84",
+                        "lane6": "0x84",
+                        "lane7": "0x84"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "21": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x84",
+                        "lane1": "0x84",
+                        "lane2": "0x84",
+                        "lane3": "0x84",
+                        "lane4": "0x84",
+                        "lane5": "0x84",
+                        "lane6": "0x84",
+                        "lane7": "0x84"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x4",
+                        "lane1": "0x4",
+                        "lane2": "0x4",
+                        "lane3": "0x4",
+                        "lane4": "0x4",
+                        "lane5": "0x4",
+                        "lane6": "0x4",
+                        "lane7": "0x4"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "22": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x80",
+                        "lane1": "0x80",
+                        "lane2": "0x80",
+                        "lane3": "0x80",
+                        "lane4": "0x80",
+                        "lane5": "0x80",
+                        "lane6": "0x80",
+                        "lane7": "0x80"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x4",
+                        "lane1": "0x4",
+                        "lane2": "0x4",
+                        "lane3": "0x4",
+                        "lane4": "0x4",
+                        "lane5": "0x4",
+                        "lane6": "0x4",
+                        "lane7": "0x4"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "23": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x84",
+                        "lane1": "0x84",
+                        "lane2": "0x84",
+                        "lane3": "0x84",
+                        "lane4": "0x84",
+                        "lane5": "0x84",
+                        "lane6": "0x84",
+                        "lane7": "0x84"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x4",
+                        "lane1": "0x4",
+                        "lane2": "0x4",
+                        "lane3": "0x4",
+                        "lane4": "0x4",
+                        "lane5": "0x4",
+                        "lane6": "0x4",
+                        "lane7": "0x4"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "24": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x88",
+                        "lane1": "0x88",
+                        "lane2": "0x88",
+                        "lane3": "0x88",
+                        "lane4": "0x88",
+                        "lane5": "0x88",
+                        "lane6": "0x88",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "25": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x84",
+                        "lane1": "0x84",
+                        "lane2": "0x84",
+                        "lane3": "0x84",
+                        "lane4": "0x84",
+                        "lane5": "0x84",
+                        "lane6": "0x84",
+                        "lane7": "0x84"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "26": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x90",
+                        "lane1": "0x90",
+                        "lane2": "0x90",
+                        "lane3": "0x90",
+                        "lane4": "0x90",
+                        "lane5": "0x90",
+                        "lane6": "0x90",
+                        "lane7": "0x90"
+                    },
+                    "post1": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "27": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x84",
+                        "lane1": "0x84",
+                        "lane2": "0x84",
+                        "lane3": "0x84",
+                        "lane4": "0x84",
+                        "lane5": "0x84",
+                        "lane6": "0x84",
+                        "lane7": "0x84"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "28": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x90",
+                        "lane1": "0x90",
+                        "lane2": "0x90",
+                        "lane3": "0x90",
+                        "lane4": "0x90",
+                        "lane5": "0x90",
+                        "lane6": "0x90",
+                        "lane7": "0x90"
+                    },
+                    "post1": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "29": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x84",
+                        "lane1": "0x84",
+                        "lane2": "0x84",
+                        "lane3": "0x84",
+                        "lane4": "0x84",
+                        "lane5": "0x84",
+                        "lane6": "0x84",
+                        "lane7": "0x84"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "30": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x90",
+                        "lane1": "0x90",
+                        "lane2": "0x90",
+                        "lane3": "0x90",
+                        "lane4": "0x90",
+                        "lane5": "0x90",
+                        "lane6": "0x90",
+                        "lane7": "0x90"
+                    },
+                    "post1": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "31": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x84",
+                        "lane1": "0x84",
+                        "lane2": "0x84",
+                        "lane3": "0x84",
+                        "lane4": "0x84",
+                        "lane5": "0x84",
+                        "lane6": "0x84",
+                        "lane7": "0x84"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x4",
+                        "lane1": "0x4",
+                        "lane2": "0x4",
+                        "lane3": "0x4",
+                        "lane4": "0x4",
+                        "lane5": "0x4",
+                        "lane6": "0x4",
+                        "lane7": "0x4"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },        
+        "32": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x90",
+                        "lane1": "0x90",
+                        "lane2": "0x90",
+                        "lane3": "0x90",
+                        "lane4": "0x90",
+                        "lane5": "0x90",
+                        "lane6": "0x90",
+                        "lane7": "0x90"
+                    },
+                    "post1": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "33": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x84",
+                        "lane1": "0x84",
+                        "lane2": "0x84",
+                        "lane3": "0x84",
+                        "lane4": "0x84",
+                        "lane5": "0x84",
+                        "lane6": "0x84",
+                        "lane7": "0x84"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x4",
+                        "lane1": "0x4",
+                        "lane2": "0x4",
+                        "lane3": "0x4",
+                        "lane4": "0x4",
+                        "lane5": "0x4",
+                        "lane6": "0x4",
+                        "lane7": "0x4"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "34": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x88",
+                        "lane1": "0x88",
+                        "lane2": "0x88",
+                        "lane3": "0x88",
+                        "lane4": "0x88",
+                        "lane5": "0x88",
+                        "lane6": "0x88",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x4",
+                        "lane1": "0x4",
+                        "lane2": "0x4",
+                        "lane3": "0x4",
+                        "lane4": "0x4",
+                        "lane5": "0x4",
+                        "lane6": "0x4",
+                        "lane7": "0x4"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "35": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x84",
+                        "lane1": "0x84",
+                        "lane2": "0x84",
+                        "lane3": "0x84",
+                        "lane4": "0x84",
+                        "lane5": "0x84",
+                        "lane6": "0x84",
+                        "lane7": "0x84"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        },
+        "36": {
+            "QSFP-DD": {
+                "speed:400GAUI-8|50G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x80",
+                        "lane1": "0x80",
+                        "lane2": "0x80",
+                        "lane3": "0x80",
+                        "lane4": "0x80",
+                        "lane5": "0x80",
+                        "lane6": "0x80",
+                        "lane7": "0x80"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    }
+                }
+            },
+            "Default": {
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "media_type": "backplane",
+                    "main": {
+                        "lane0": "0x57",
+                        "lane1": "0x57",
+                        "lane2": "0x57",
+                        "lane3": "0x57"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffc"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffa",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/sonic-device-data/tests/media_checker
+++ b/src/sonic-device-data/tests/media_checker
@@ -11,7 +11,7 @@ si_param_list = ["preemphasis", "idriver", "ipredriver", \
                  "main", "pre1", "pre2", "pre3", \
                  "post1", "post2", "post3", "attn", \
                  "ob_m2lp", "ob_alev_out", "obplev", "obnlev", \
-                 "regn_bfm1p", "regn_bfm1n"]
+                 "regn_bfm1p", "regn_bfm1n", "media_type"]
 lane_speed_key_prefix = 'speed:'
 lane_prefix = "lane"
 comma_separator = ","
@@ -71,9 +71,11 @@ def check_media_dict(vendor_dict):
                     return False
 
                 lane_dict = settings_dict[si_param]
-                for lanes in lane_dict:
-                    if not check_lane_and_value(lanes, lane_dict[lanes]):
-                        return False
+                if isinstance(lane_dict, dict):
+                    for lanes in lane_dict:
+                        if not check_lane_and_value(lanes, lane_dict[lanes]):
+                            return False
+
     return True
 
 def check_valid_port(port_name):


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To add media_settings.json file for Nokia chassis LC
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added media_settings.json file for Nokia chassis LC
#### How to verify it
Ensure that system operates normally. Values can also be extracted manually via bcmsh, if desired, to ensure that post-speed-change from 400G to 100G match 100G SKU static bcm config file values
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

