### PR TITLE
Fix yang model tests in msft-202405

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/kdump.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/kdump.json
@@ -27,10 +27,10 @@
     },
     "KDUMP_WITH_INVALID_MEM_HIGH": {
         "desc": "Configuring kdump config with invalid value.",
-        "eStr": ["Pattern", "does not satisfy"]
+        "eStr": ["pattern", "does not satisfy"]
     },
     "KDUMP_WITH_INVALID_MEM_HIGH_2": {
         "desc": "Configuring kdump config with invalid suffix.",
-        "eStr": ["Pattern", "does not satisfy"]
+        "eStr": ["pattern", "does not satisfy"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/kdump.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/kdump.json
@@ -49,7 +49,7 @@
                 "config": {
                     "enabled": "true",
                     "num_dumps": "3",
-                    "memory": "1G,high",
+                    "memory": "1G,high"
                 }
             }
         }
@@ -60,7 +60,7 @@
                 "config": {
                     "enabled": "true",
                     "num_dumps": "3",
-                    "memory": "512M,high",
+                    "memory": "512M,high"
                 }
             }
         }
@@ -93,7 +93,7 @@
                 "config": {
                     "enabled": "true",
                     "num_dumps": "3",
-                    "memory": "100,high",
+                    "memory": "100,high"
                 }
             }
         }
@@ -104,7 +104,7 @@
                 "config": {
                     "enabled": "true",
                     "num_dumps": "3",
-                    "memory": "1G,highx",
+                    "memory": "1G,highx"
                 }
             }
         }


### PR DESCRIPTION
When cherry-pick sonic-net/sonic-buildimage#24441 in msft-202405,  Some typo and mistakes were made in https://github.com/Azure/sonic-buildimage-msft/pull/1851. Fix them accordingly.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

