### PR TITLE
[202412] [Mellanox] Align sensors file for SN5640

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn5640-r0/sensors.conf
+++ b/device/mellanox/x86_64-nvidia_sn5640-r0/sensors.conf
@@ -68,9 +68,9 @@ chip "mp2891-i2c-*-63"
     label power2   "PMIC-2 VDD_T0 Rail Pwr (out1)"
     label power3   "PMIC-2 VDD_T1 Rail Pwr (out2)"
     label curr1    "PMIC-2 13V5 VDD_T0 VDD_T1 Rail Curr (in1)"
-    label curr2    "PMIC-2 VDD_T0 Rail Curr (out1)"
-    label curr3    "PMIC-2 VDD_T1 Rail Curr (out2)"
-    ignore curr4
+    label curr2    "PMIC-2 13V5 VDD_T0 VDD_T1 Rail Curr (in2)"
+    label curr3    "PMIC-2 VDD_T0 Rail Curr (out1)"
+    label curr4    "PMIC-2 VDD_T1 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe1a2g7-i2c-*-63"
@@ -83,9 +83,9 @@ chip "xdpe1a2g7-i2c-*-63"
     label power2   "PMIC-2 VDD_T0 Rail Pwr (out1)"
     label power3   "PMIC-2 VDD_T1 Rail Pwr (out2)"
     label curr1    "PMIC-2 13V5 VDD_T0 VDD_T1 Rail Curr (in1)"
-    label curr2    "PMIC-2 VDD_T0 Rail Curr (out1)"
-    label curr3    "PMIC-2 VDD_T1 Rail Curr (out2)"
-    ignore curr4
+    label curr2    "PMIC-2 13V5 VDD_T0 VDD_T1 Rail Curr (in2)"
+    label curr3    "PMIC-2 VDD_T0 Rail Curr (out1)"
+    label curr4    "PMIC-2 VDD_T1 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 
@@ -99,9 +99,9 @@ chip "mp2891-i2c-*-64"
     label power2   "PMIC-3 VDD_T2 Rail Pwr (out1)"
     label power3   "PMIC-3 VDD_T3 Rail Pwr (out2)"
     label curr1    "PMIC-3 13V5 VDD_T2 VDD_T3 Rail Curr (in1)"
-    label curr2    "PMIC-3 VDD_T2 Rail Curr (out1)"
-    label curr3    "PMIC-3 VDD_T3 Rail Curr (out2)"
-    ignore curr4
+    label curr2    "PMIC-3 13V5 VDD_T2 VDD_T3 Rail Curr (in2)"
+    label curr3    "PMIC-3 VDD_T2 Rail Curr (out1)"
+    label curr4    "PMIC-3 VDD_T3 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe1a2g7-i2c-*-64"
@@ -114,9 +114,9 @@ chip "xdpe1a2g7-i2c-*-64"
     label power2   "PMIC-3 VDD_T2 Rail Pwr (out1)"
     label power3   "PMIC-3 VDD_T3 Rail Pwr (out2)"
     label curr1    "PMIC-3 13V5 VDD_T2 VDD_T3 Rail Curr (in1)"
-    label curr2    "PMIC-3 VDD_T2 Rail Curr (out1)"
-    label curr3    "PMIC-3 VDD_T3 Rail Curr (out2)"
-    ignore curr4
+    label curr2    "PMIC-3 13V5 VDD_T2 VDD_T3 Rail Curr (in2)"
+    label curr3    "PMIC-3 VDD_T2 Rail Curr (out1)"
+    label curr4    "PMIC-3 VDD_T3 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 
@@ -130,9 +130,9 @@ chip "mp2891-i2c-*-65"
     label power2   "PMIC-4 VDD_T4 Rail Pwr (out1)"
     label power3   "PMIC-4 VDD_T5 Rail Pwr (out2)"
     label curr1    "PMIC-4 13V5 VDD_T4 VDD_T5 Rail Curr (in1)"
-    label curr2    "PMIC-4 VDD_T4 Rail Curr (out1)"
-    label curr3    "PMIC-4 VDD_T5 Rail Curr (out2)"
-    ignore curr4
+    label curr2    "PMIC-4 13V5 VDD_T4 VDD_T5 Rail Curr (in2)"
+    label curr3    "PMIC-4 VDD_T4 Rail Curr (out1)"
+    label curr4    "PMIC-4 VDD_T5 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe1a2g7-i2c-*-65"
@@ -145,9 +145,9 @@ chip "xdpe1a2g7-i2c-*-65"
     label power2   "PMIC-4 VDD_T4 Rail Pwr (out1)"
     label power3   "PMIC-4 VDD_T5 Rail Pwr (out2)"
     label curr1    "PMIC-4 13V5 VDD_T4 VDD_T5 Rail Curr (in1)"
-    label curr2    "PMIC-4 VDD_T4 Rail Curr (out1)"
-    label curr3    "PMIC-4 VDD_T5 Rail Curr (out2)"
-    ignore curr4
+    label curr2    "PMIC-4 13V5 VDD_T4 VDD_T5 Rail Curr (in2)"
+    label curr3    "PMIC-4 VDD_T4 Rail Curr (out1)"
+    label curr4    "PMIC-4 VDD_T5 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 
@@ -161,9 +161,9 @@ chip "mp2891-i2c-*-66"
     label power2   "PMIC-5 VDD_T6 Rail Pwr (out1)"
     label power3   "PMIC-5 VDD_T7 Rail Pwr (out2)"
     label curr1    "PMIC-5 13V5 VDD_T6 VDD_T7 Rail Curr (in1)"
-    label curr2    "PMIC-5 VDD_T6 Rail Curr (out1)"
-    label curr3    "PMIC-5 VDD_T7 Rail Curr (out2)"
-    ignore curr4
+    label curr2    "PMIC-5 13V5 VDD_T6 VDD_T7 Rail Curr (in2)"
+    label curr3    "PMIC-5 VDD_T6 Rail Curr (out1)"
+    label curr4    "PMIC-5 VDD_T7 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe1a2g7-i2c-*-66"
@@ -176,9 +176,9 @@ chip "xdpe1a2g7-i2c-*-66"
     label power2   "PMIC-5 VDD_T6 Rail Pwr (out1)"
     label power3   "PMIC-5 VDD_T7 Rail Pwr (out2)"
     label curr1    "PMIC-5 13V5 VDD_T6 VDD_T7 Rail Curr (in1)"
-    label curr2    "PMIC-5 VDD_T6 Rail Curr (out1)"
-    label curr3    "PMIC-5 VDD_T7 Rail Curr (out2)"
-    ignore curr4
+    label curr2    "PMIC-5 13V5 VDD_T6 VDD_T7 Rail Curr (in2)"
+    label curr3    "PMIC-5 VDD_T6 Rail Curr (out1)"
+    label curr4    "PMIC-5 VDD_T7 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 
@@ -192,9 +192,9 @@ chip "mp2891-i2c-*-67"
     label power2   "PMIC-6 DVDD_T0 Rail Pwr (out1)"
     label power3   "PMIC-6 DVDD_T1 Rail Pwr (out2)"
     label curr1    "PMIC-6 13V5 DVDD_T0 DVDD_T1 Rail Curr (in1)"
-    label curr2    "PMIC-6 DVDD_T0 Rail Curr (out1)"
-    label curr3    "PMIC-6 DVDD_T1 Rail Curr (out2)"
-    ignore curr4
+    label curr2    "PMIC-6 13V5 DVDD_T0 DVDD_T1 Rail Curr (in2)"
+    label curr3    "PMIC-6 DVDD_T0 Rail Curr (out1)"
+    label curr4    "PMIC-6 DVDD_T1 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe1a2g7-i2c-*-67"
@@ -207,9 +207,9 @@ chip "xdpe1a2g7-i2c-*-67"
     label power2   "PMIC-6 DVDD_T0 Rail Pwr (out1)"
     label power3   "PMIC-6 DVDD_T1 Rail Pwr (out2)"
     label curr1    "PMIC-6 13V5 DVDD_T0 DVDD_T1 Rail Curr (in1)"
-    label curr2    "PMIC-6 DVDD_T0 Rail Curr (out1)"
-    label curr3    "PMIC-6 DVDD_T1 Rail Curr (out2)"
-    ignore curr4
+    label curr2    "PMIC-6 13V5 DVDD_T0 DVDD_T1 Rail Curr (in2)"
+    label curr3    "PMIC-6 DVDD_T0 Rail Curr (out1)"
+    label curr4    "PMIC-6 DVDD_T1 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 
@@ -223,9 +223,9 @@ chip "mp2891-i2c-*-68"
     label power2   "PMIC-7 DVDD_T2 Rail Pwr (out1)"
     label power3   "PMIC-7 DVDD_T3 Rail Pwr (out2)"
     label curr1    "PMIC-7 13V5 DVDD_T2 DVDD_T3 Rail Curr (in1)"
-    label curr2    "PMIC-7 DVDD_T2 Rail Curr (out1)"
-    label curr3    "PMIC-7 DVDD_T3 Rail Curr (out2)"
-    ignore curr4
+    label curr2    "PMIC-7 13V5 DVDD_T2 DVDD_T3 Rail Curr (in2)"
+    label curr3    "PMIC-7 DVDD_T2 Rail Curr (out1)"
+    label curr4    "PMIC-7 DVDD_T3 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe1a2g7-i2c-*-68"
@@ -238,9 +238,9 @@ chip "xdpe1a2g7-i2c-*-68"
     label power2   "PMIC-7 DVDD_T2 Rail Pwr (out1)"
     label power3   "PMIC-7 DVDD_T3 Rail Pwr (out2)"
     label curr1    "PMIC-7 13V5 DVDD_T2 DVDD_T3 Rail Curr (in1)"
-    label curr2    "PMIC-7 DVDD_T2 Rail Curr (out1)"
-    label curr3    "PMIC-7 DVDD_T3 Rail Curr (out2)"
-    ignore curr4
+    label curr2    "PMIC-7 13V5 DVDD_T2 DVDD_T3 Rail Curr (in2)"
+    label curr3    "PMIC-7 DVDD_T2 Rail Curr (out1)"
+    label curr4    "PMIC-7 DVDD_T3 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 
@@ -254,9 +254,9 @@ chip "mp2891-i2c-*-69"
     label power2   "PMIC-8 DVDD_T4 Rail Pwr (out1)"
     label power3   "PMIC-8 DVDD_T5 Rail Pwr (out2)"
     label curr1    "PMIC-8 13V5 DVDD_T4 DVDD_T5 Rail Curr (in1)"
-    label curr2    "PMIC-8 DVDD_T4 Rail Curr (out1)"
-    label curr3    "PMIC-8 DVDD_T5 Rail Curr (out2)"
-    ignore curr4
+    label curr2    "PMIC-8 13V5 DVDD_T4 DVDD_T5 Rail Curr (in2)"
+    label curr3    "PMIC-8 DVDD_T4 Rail Curr (out1)"
+    label curr4    "PMIC-8 DVDD_T5 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe1a2g7-i2c-*-69"
@@ -269,9 +269,9 @@ chip "xdpe1a2g7-i2c-*-69"
     label power2   "PMIC-8 DVDD_T4 Rail Pwr (out1)"
     label power3   "PMIC-8 DVDD_T5 Rail Pwr (out2)"
     label curr1    "PMIC-8 13V5 DVDD_T4 DVDD_T5 Rail Curr (in1)"
-    label curr2    "PMIC-8 DVDD_T4 Rail Curr (out1)"
-    label curr3    "PMIC-8 DVDD_T5 Rail Curr (out2)"
-    ignore curr4
+    label curr2    "PMIC-8 13V5 DVDD_T4 DVDD_T5 Rail Curr (in2)"
+    label curr3    "PMIC-8 DVDD_T4 Rail Curr (out1)"
+    label curr4    "PMIC-8 DVDD_T5 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 
@@ -285,9 +285,9 @@ chip "mp2891-i2c-*-6a"
     label power2   "PMIC-9 DVDD_T6 Rail Pwr (out1)"
     label power3   "PMIC-9 DVDD_T7 Rail Pwr (out2)"
     label curr1    "PMIC-9 13V5 DVDD_T6 DVDD_T7 Rail Curr (in1)"
-    label curr2    "PMIC-9 DVDD_T6 Rail Curr (out1)"
-    label curr3    "PMIC-9 DVDD_T7 Rail Curr (out2)"
-    ignore curr4
+    label curr2    "PMIC-9 13V5 DVDD_T6 DVDD_T7 Rail Curr (in2)"
+    label curr3    "PMIC-9 DVDD_T6 Rail Curr (out1)"
+    label curr4    "PMIC-9 DVDD_T7 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe1a2g7-i2c-*-6a"
@@ -300,9 +300,9 @@ chip "xdpe1a2g7-i2c-*-6a"
     label power2   "PMIC-9 DVDD_T6 Rail Pwr (out1)"
     label power3   "PMIC-9 DVDD_T7 Rail Pwr (out2)"
     label curr1    "PMIC-9 13V5 DVDD_T6 DVDD_T7 Rail Curr (in1)"
-    label curr2    "PMIC-9 DVDD_T6 Rail Curr (out1)"
-    label curr3    "PMIC-9 DVDD_T7 Rail Curr (out2)"
-    ignore curr4
+    label curr2    "PMIC-9 13V5 DVDD_T6 DVDD_T7 Rail Curr (in2)"
+    label curr3    "PMIC-9 DVDD_T6 Rail Curr (out1)"
+    label curr4    "PMIC-9 DVDD_T7 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 
@@ -393,7 +393,6 @@ chip "dps460-i2c-*-59"
     label power2 "PSU-1(L) 12V Rail Pwr (out)"
     label curr1 "PSU-1(L) 220V Rail Curr (in)"
     label curr2 "PSU-1(L) 12V Rail Curr (out)"
-    set power2_cap 0
 chip "dps460-i2c-*-58"
     label in1 "PSU-2(L) 220V Rail (in)"
     ignore in2
@@ -408,7 +407,6 @@ chip "dps460-i2c-*-58"
     label power2 "PSU-2(L) 12V Rail Pwr (out)"
     label curr1 "PSU-2(L) 220V Rail Curr (in)"
     label curr2 "PSU-2(L) 12V Rail Curr (out)"
-    set power2_cap 0
 chip "dps460-i2c-*-5b"
     label in1 "PSU-3(R) 220V Rail (in)"
     ignore in2
@@ -423,7 +421,6 @@ chip "dps460-i2c-*-5b"
     label power2 "PSU-3(R) 12V Rail Pwr (out)"
     label curr1 "PSU-3(R) 220V Rail Curr (in)"
     label curr2 "PSU-3(R) 12V Rail Curr (out)"
-    set power2_cap 0
 chip "dps460-i2c-*-5a"
     label in1 "PSU-4(R) 220V Rail (in)"
     ignore in2
@@ -438,7 +435,6 @@ chip "dps460-i2c-*-5a"
     label power2 "PSU-4(R) 12V Rail Pwr (out)"
     label curr1 "PSU-4(R) 220V Rail Curr (in)"
     label curr2 "PSU-4(R) 12V Rail Curr (out)"
-    set power2_cap 0
 
 # Chassis fans
 chip "mlxreg_fan-isa-*"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Align Sensors conf to hw-mgmt file. 

Raising directly to 202412 since master branch is migrated to directly using sensors file from hw-management

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

