### PR TITLE
[Arista] boot0: Arm linecard watchdog before kexec

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -911,11 +911,31 @@ regular_install() {
     run_hooks post-install
 }
 
+run_quirks() {
+    # only run in Aboot
+    if $in_aboot && [ -f "/etc/cmdline" ]; then
+        if in_array "$aboot_machine" "arista_7800r3a_36p_lc" "arista_7800r3a_36d_lc" \
+                                     "arista_7800r3a_36d2_lc" "arista_7800r3ak_36d2_lc" \
+                                     "arista_7800r3a_36dm2_lc" "arista_7800r3ak_36dm2_lc"; then
+            info "Arming watchdog for 60s"
+            setpci -s 08:00.0 COMMAND=0002
+            addr=$(( 0x$(setpci -s 08:00.0 BASE_ADDRESS_0) + 0x120 ))
+            devmem "$addr" 32 0xc0002328
+        elif in_array "$aboot_machine" "arista_7800r3_48cq2_lc" "arista_7800r3_48cqm2_lc"; then
+            info "Arming watchdog for 60s"
+            setpci -s 07:00.0 COMMAND=0002
+            addr=$(( 0x$(setpci -s 07:00.0 BASE_ADDRESS_0) + 0x120 ))
+            devmem "$addr" 32 0xc0002328
+        fi
+    fi
+}
+
 secureboot_boot() {
     # boot material is extracted and generated in RAM.
     # SONiC starts as a live OS.
     info "Preparing image for secureboot"
     prepare_image_secureboot
+    run_quirks
     update_next_boot
     run_kexec
 }
@@ -924,6 +944,7 @@ regular_boot() {
     # boot uses the image installed on the flash
     write_regular_configs "$image_path"
     run_hooks pre-kexec
+    run_quirks
     update_next_boot
     run_kexec
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Arm the watchdog before kexec. The watchdog will be separately disarmed during driver initialization via an already merged platform library change.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

