### PR TITLE
[DPU] Update SDK to 25.7-RC12

### DIFF
--- a/platform/nvidia-bluefield/recipes/sdk.mk
+++ b/platform/nvidia-bluefield/recipes/sdk.mk
@@ -19,7 +19,7 @@ SDK_BASE_PATH = $(PLATFORM_PATH)/sdk-src/sonic-bluefield-packages/bin
 
 # Place here URL where SDK sources exist
 SDK_SOURCE_BASE_URL =
-SDK_VERSION = 25.7-RC11
+SDK_VERSION = 25.7-RC12
 
 SDK_COLLECTX_URL = https://linux.mellanox.com/public/repo/doca/1.5.2/debian12/aarch64/
 


### PR DESCRIPTION
#### Why I did it

To include latest fixes and new functionality

#### How I did it

* SDK_VERSION_DPU 25.7-RC11 -> 25.7-RC12


#### How to verify it
Build an image and run tests from "sonic-mgmt".

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog

#### A picture of a cute animal (not mandatory but encouraged)