### PR TITLE
[202506] [yang] VNET_ROUTE_TUNNEL yang model support for consistent hashing (#24684)

### DIFF
--- a/src/sonic-yang-mgmt/sonic_yang_ext.py
+++ b/src/sonic-yang-mgmt/sonic_yang_ext.py
@@ -35,6 +35,9 @@ LEAF_LIST_WITH_STRING_VALUE_DICT = {
     ('BUFFER_PORT_INGRESS_PROFILE_LIST', 'profile_list'): ',',
     ('PORT', 'adv_speeds'): ',',
     ('PORT', 'adv_interface_types'): ',',
+    ('VNET_ROUTE_TUNNEL', 'endpoint'): ',',
+    ('VNET_ROUTE_TUNNEL', 'mac_address'): ',',
+    ('VNET_ROUTE_TUNNEL', 'vni'): ',',
 }
 
 """

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -2740,13 +2740,20 @@ monitoring sessions for the vnet routes and is optional.
 ### VNET_ROUTE_TUNNEL
 
 VNET_ROUTE_TUNNEL table has vnet_name|prefix as the object key, where vnet_name is the name of the VNet and prefix is the ip4 prefix associated with the route tunnel. The table includes the following attributes:
-- ENDPOINT: The endpoint/nexthop tunnel IP (mandatory). It is used to identify the endpoint of the tunnel.
-- MAC_ADDRESS: The inner destination MAC address in the encapsulated packet (optional).  It should be a 12-hexadeimal digit value.
-- VNI: The VNI value in the encapsulated packet (optional). It should be a numeric value.
+- ENDPOINT: Comma-separated endpoint/nexthop tunnel IPs (mandatory). They are used to identify the endpoints of the tunnel.
+- MAC_ADDRESS: Comma-separated inner destination MAC addresses in the encapsulated packet (optional).  They should be 12-hexadecimal digit values.
+- VNI: Comma-separated VNI values in the encapsulated packet (optional). They should be numeric values.
+- CONSISTENT_HASHING_BUCKETS: Number of consistent hashing buckets to use, if consistent hashing is desired (optional). It should be a numeric value.
 
 ```
 {
   "VNET_ROUTE_TUNNEL": {
+        "Vnet_1000|100.200.1.1/32": {
+        "endpoint": "192.174.1.1,192.174.1.2",
+        "mac_address": "f8:25:84:98:22:a1,f8:25:84:98:22:a2",
+        "vni": "10010,10011",
+        "consistent_hashing_buckets": "10"
+    },
     "Vnet_2000|100.100.1.1/32": {
         "endpoint": "192.168.1.1",
         "mac_address": "f9:22:83:99:22:a2"

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2406,9 +2406,10 @@
         },
         "VNET_ROUTE_TUNNEL" : {
             "vnet1|10.0.0.0/24" : {
-                "endpoint": "192.168.1.2",
-                "mac_address": "f9:22:83:99:22:a2",
-                "vni": "10011"
+                "endpoint": "192.168.1.1,192.168.1.2",
+                "mac_address": "f9:22:83:99:22:a1,f9:22:83:99:22:a2",
+                "vni": "10011,10012",
+                "consistent_hashing_buckets": "10"
             }
         },
         "PORT_QOS_MAP": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vnet.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vnet.json
@@ -122,6 +122,6 @@
 
     "VNET_ROUTE_TUNNEL_TEST_INVALID_CONSISTENT_HASHING": {
         "desc": "VNET route tunnel configuration with invalid consistent_hashing_buckets value (exceeds uint16 max).",
-        "eStr": "does not satisfy the constraint"
+        "eStrKey": "InvalidValue"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vnet.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vnet.json
@@ -69,11 +69,59 @@
 
     "VNET_ROUTE_TUNNEL_TEST_MISSING_ENDPOINT": {
         "desc": "VNET route tunnel configuration with missing mandatory attribute (endpoint) in VNET_ROUTE_TUNNEL_LIST table.",
-        "eStr": "Missing required element \"endpoint\" in \"VNET_ROUTE_TUNNEL_LIST\"."
+        "eStrKey": "MinElements"
     },
 
     "VNET_ROUTE_TUNNEL_TEST_NONEXISTENT_VNET": {
         "desc": "VNET route tunnel configuration referencing a non-existent VNET name, violating the must condition.",
-        "eStr": "Leafref \"/sonic-vnet:sonic-vnet/sonic-vnet:VNET/sonic-vnet:VNET_LIST/sonic-vnet:name\" of value \"NonexistentVnet\" points to a non-existing leaf"
+        "eStrKey" : "LeafRef"
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_MULTI_ENDPOINT": {
+        "desc": "VNET route tunnel configuration with multiple comma-separated endpoint IPs in VNET_ROUTE_TUNNEL_LIST table."
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_MULTI_MAC": {
+        "desc": "VNET route tunnel configuration with multiple comma-separated MAC addresses in VNET_ROUTE_TUNNEL_LIST table."
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_MULTI_VNI": {
+        "desc": "VNET route tunnel configuration with multiple comma-separated VNI values in VNET_ROUTE_TUNNEL_LIST table."
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_MULTI_ALL": {
+        "desc": "VNET route tunnel configuration with multiple comma-separated values for all fields (endpoint, mac_address, vni) in VNET_ROUTE_TUNNEL_LIST table."
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_INVALID_MULTI_ENDPOINT": {
+        "desc": "VNET route tunnel configuration with invalid IP in comma-separated endpoint list.",
+        "eStrKey": "Pattern"
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_INVALID_MULTI_MAC": {
+        "desc": "VNET route tunnel configuration with invalid MAC in comma-separated mac_address list.",
+        "eStrKey": "Pattern"
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_INVALID_MULTI_VNI": {
+        "desc": "VNET route tunnel configuration with invalid VNI in comma-separated vni list.",
+        "eStrKey": "Range"
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_CONSISTENT_HASHING": {
+        "desc": "VNET route tunnel configuration with consistent_hashing_buckets field."
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_CONSISTENT_HASHING_MAX": {
+        "desc": "VNET route tunnel configuration with consistent_hashing_buckets maximum value (65535)."
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_CONSISTENT_HASHING_WITH_MULTI": {
+        "desc": "VNET route tunnel configuration with consistent_hashing_buckets and multiple endpoints."
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_INVALID_CONSISTENT_HASHING": {
+        "desc": "VNET route tunnel configuration with invalid consistent_hashing_buckets value (exceeds uint16 max).",
+        "eStr": "does not satisfy the constraint"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vnet.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vnet.json
@@ -208,7 +208,7 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix": "10.0.0.0/24",
-                        "endpoint": "192.168.1.1"
+                        "endpoint": ["192.168.1.1"]
                     }
                 ]
             }
@@ -248,14 +248,14 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": "192.168.1.1",
-                        "vni": "10011"
+                        "endpoint": ["192.168.1.1"],
+                        "vni": ["10011"]
                     },
                     {
                         "vnet_name": "Vnet2",
                         "prefix":"10.0.1.0/24",
-                        "endpoint": "192.168.1.2",
-                        "vni": "10012"
+                        "endpoint": ["192.168.1.2"],
+                        "vni": ["10012"]
                     }
                 ]
             }
@@ -290,9 +290,9 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": "192.168.1.1",
-                        "mac_address": "00:aa:bb:cc:dd:ee",
-                        "vni": "10011"
+                        "endpoint": ["192.168.1.1"],
+                        "mac_address": ["00:aa:bb:cc:dd:ee"],
+                        "vni": ["10011"]
                     }
                 ]
             }
@@ -327,14 +327,14 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": "192.168.1.1",
-                        "vni": "10011"
+                        "endpoint": ["192.168.1.1"],
+                        "vni": ["10011"]
                     },
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": "192.168.1.2",
-                        "vni": "10012"
+                        "endpoint": ["192.168.1.2"],
+                        "vni": ["10012"]
                     }
                 ]
             }
@@ -369,8 +369,8 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": "256.256.256.256",
-                        "vni": "10011"
+                        "endpoint": ["256.256.256.256"],
+                        "vni": ["10011"]
                     }
                 ]
             }
@@ -405,9 +405,9 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": "192.168.1.1",
-                        "mac_address": "GG:HH:II:JJ:KK:LL",
-                        "vni": "10011"
+                        "endpoint": ["192.168.1.1"],
+                        "mac_address": ["GG:HH:II:JJ:KK:LL"],
+                        "vni": ["10011"]
                     }
                 ]
             }
@@ -442,8 +442,8 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": "192.168.1.1",
-                        "vni": "16777216"
+                        "endpoint": ["192.168.1.1"],
+                        "vni": ["16777216"]
                     }
                 ]
             }
@@ -477,8 +477,8 @@
                 "VNET_ROUTE_TUNNEL_LIST": [
                     {
                         "vnet_name": "Vnet1",
-                        "endpoint": "192.168.1.1",
-                        "vni": "10011"
+                        "endpoint": ["192.168.1.1"],
+                        "vni": ["10011"]
                     }
                 ]
             }
@@ -513,8 +513,8 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"300.168.1.0/24",
-                        "endpoint": "192.168.1.1",
-                        "vni": "10011"
+                        "endpoint": ["192.168.1.1"],
+                        "vni": ["10011"]
                     }
                 ]
             }
@@ -549,7 +549,7 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "vni": "10011"
+                        "vni": ["10011"]
                     }
                 ]
             }
@@ -584,8 +584,405 @@
                     {
                         "vnet_name": "NonexistentVnet",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": "192.168.1.1",
-                        "vni": "10011"
+                        "endpoint": ["192.168.1.1"],
+                        "vni": ["10011"]
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_MULTI_ENDPOINT": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix":"10.0.0.0/24",
+                        "endpoint": ["192.168.1.1", "192.168.1.2", "192.168.1.3"]
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_MULTI_MAC": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix":"10.0.0.0/24",
+                        "endpoint": ["192.168.1.1"],
+                        "mac_address": ["00:aa:bb:cc:dd:ee", "11:22:33:44:55:66", "aa:bb:cc:dd:ee:ff"]
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_MULTI_VNI": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix":"10.0.0.0/24",
+                        "endpoint": ["192.168.1.1"],
+                        "vni": ["10011", "10012", "10013"]
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_MULTI_ALL": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix":"10.0.0.0/24",
+                        "endpoint": ["192.168.1.1", "192.168.1.2"],
+                        "mac_address": ["00:aa:bb:cc:dd:ee", "11:22:33:44:55:66"],
+                        "vni": ["10011", "10012"]
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_INVALID_MULTI_ENDPOINT": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix":"10.0.0.0/24",
+                        "endpoint": ["192.168.1.1", "256.256.256.256", "192.168.1.3"]
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_INVALID_MULTI_MAC": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix":"10.0.0.0/24",
+                        "endpoint": ["192.168.1.1"],
+                        "mac_address": ["00:aa:bb:cc:dd:ee", "ZZ:YY:XX:WW:VV:UU", "11:22:33:44:55:66"]
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_INVALID_MULTI_VNI": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix":"10.0.0.0/24",
+                        "endpoint": ["192.168.1.1"],
+                        "vni": ["10011", "16777216", "10013"]
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_CONSISTENT_HASHING": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix":"10.0.0.0/24",
+                        "endpoint": ["192.168.1.1"],
+                        "consistent_hashing_buckets": 128
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_CONSISTENT_HASHING_MAX": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix":"10.0.0.0/24",
+                        "endpoint": ["192.168.1.1"],
+                        "consistent_hashing_buckets": 65535
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_CONSISTENT_HASHING_WITH_MULTI": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix":"10.0.0.0/24",
+                        "endpoint": ["192.168.1.1", "192.168.1.2", "192.168.1.3"],
+                        "mac_address": ["00:aa:bb:cc:dd:ee", "11:22:33:44:55:66", "aa:bb:cc:dd:ee:ff"],
+                        "vni": ["10011", "10012", "10013"],
+                        "consistent_hashing_buckets": 256
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_INVALID_CONSISTENT_HASHING": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix":"10.0.0.0/24",
+                        "endpoint": ["192.168.1.1"],
+                        "consistent_hashing_buckets": 99999
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-vnet.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vnet.yang
@@ -123,20 +123,25 @@ module sonic-vnet {
                     type stypes:sonic-ip4-prefix;
                 }
                 
-                leaf endpoint {
-                    description "Endpoint/nexthop tunnel IP";
+                leaf-list endpoint {
+                    description "Endpoint/nexthop tunnel IPs";
                     type inet:ipv4-address;
-                    mandatory true;
+                    min-elements 1;
                 }
 
-                leaf mac_address {
-                    description "Inner dest mac in encapsulated packet";
+                leaf-list mac_address {
+                    description "Inner dest macs in encapsulated packet";
                     type yang:mac-address;
                 }
 
-                leaf vni {
-                    description "A valid and active vni value in encapsulated packet";
+                leaf-list vni {
+                    description "Valid and active vni values in encapsulated packet";
                     type stypes:vnid_type;
+                }
+
+                leaf consistent_hashing_buckets {
+                    description "Number of consistent hashing buckets to use, if consistent hashing is desired";
+                    type uint16;
                 }
             }
             /* end of list VNET_ROUTE_TUNNEL_LIST */


### PR DESCRIPTION
Master PR: https://github.com/sonic-net/sonic-buildimage/pull/24684

Why I did it
To support consistent ECMP for vxlan tunnels, according to specifications in sonic-net/SONiC#2099

Work item tracking
Microsoft ADO (number only):
How I did it
Added multi-value support for endpoint, mac and vni. Added consistent_hashing_buckets.

How to verify it
Run the tests added in this PR or build image with these changes and set the new attributes.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

