### PR TITLE
Revert "[202405][frr]: Force disable next hop group support"

### DIFF
--- a/dockers/docker-fpm-frr/docker_init.sh
+++ b/dockers/docker-fpm-frr/docker_init.sh
@@ -49,10 +49,6 @@ write_default_zebra_config()
         echo "no fpm use-next-hop-groups" >> $FILE_NAME
         echo "fpm address 127.0.0.1" >> $FILE_NAME
     }
-
-    grep -q '^no zebra nexthop kernel enable' $FILE_NAME || {
-        echo "no zebra nexthop kernel enable" >> $FILE_NAME
-    }
 }
 
 if [[ ! -z "$NAMESPACE_ID" ]]; then

--- a/dockers/docker-fpm-frr/frr/zebra/zebra.conf.j2
+++ b/dockers/docker-fpm-frr/frr/zebra/zebra.conf.j2
@@ -7,8 +7,6 @@
 {% endblock banner %}
 !
 {% block fpm %}
-! Force disable next hop group support
-no zebra nexthop kernel enable
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
 !

--- a/platform/vs/docker-sonic-vs/frr/zebra.conf
+++ b/platform/vs/docker-sonic-vs/frr/zebra.conf
@@ -1,3 +1,3 @@
-no zebra nexthop kernel enable
 no fpm use-next-hop-groups
+
 fpm address 127.0.0.1

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/zebra.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/zebra.conf
@@ -4,8 +4,6 @@
 ! file: zebra.conf
 !
 !
-! Force disable next hop group support
-no zebra nexthop kernel enable
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-vni-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-vni-zebra.conf
@@ -4,8 +4,6 @@
 ! file: zebra.conf
 !
 !
-! Force disable next hop group support
-no zebra nexthop kernel enable
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-zebra.conf
@@ -4,8 +4,6 @@
 ! file: zebra.conf
 !
 !
-! Force disable next hop group support
-no zebra nexthop kernel enable
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/zebra_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/zebra_frr.conf
@@ -4,8 +4,6 @@
 ! file: zebra.conf
 !
 !
-! Force disable next hop group support
-no zebra nexthop kernel enable
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/zebra_frr_dualtor.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/zebra_frr_dualtor.conf
@@ -4,8 +4,6 @@
 ! file: zebra.conf
 !
 !
-! Force disable next hop group support
-no zebra nexthop kernel enable
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-vni-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-vni-zebra.conf
@@ -4,8 +4,6 @@
 ! file: zebra.conf
 !
 !
-! Force disable next hop group support
-no zebra nexthop kernel enable
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-zebra.conf
@@ -4,8 +4,6 @@
 ! file: zebra.conf
 !
 !
-! Force disable next hop group support
-no zebra nexthop kernel enable
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/zebra_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/zebra_frr.conf
@@ -4,8 +4,6 @@
 ! file: zebra.conf
 !
 !
-! Force disable next hop group support
-no zebra nexthop kernel enable
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/zebra_frr_dualtor.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/zebra_frr_dualtor.conf
@@ -4,8 +4,6 @@
 ! file: zebra.conf
 !
 !
-! Force disable next hop group support
-no zebra nexthop kernel enable
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
 !


### PR DESCRIPTION
This reverts the changes from PR #23294 which added 'no zebra nexthop kernel enable' configuration to FRR zebra.

Reverted changes:
- Removed nexthop kernel disable configuration from zebra.conf.j2 template
- Removed the runtime check in docker_init.sh
- Removed the configuration from virtual switch zebra.conf
- Removed configuration from all test zebra configuration files

This restores the original behavior before PR #23294 was applied.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
PR https://github.com/sonic-net/sonic-buildimage/pull/23294 causes regression https://github.com/sonic-net/sonic-buildimage/issues/24742, https://github.com/sonic-net/sonic-buildimage/issues/24607

##### Work item tracking
- Microsoft ADO **(number only)**:
36236153

#### How I did it
revert PR https://github.com/sonic-net/sonic-buildimage/pull/23294/files

#### How to verify it
Verified by removing the command from vty shell
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)
202405
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

Signed-off-by: Deepak Singhal[deepsinghal@microsoft.com](mailto:zitingguo@microsoft.com)

