### PR TITLE
New FRR show command "show ip route [json] failed" to display only failed routes

### DIFF
--- a/src/sonic-frr/patch/0056-zebra-show-ip-route-failed.patch
+++ b/src/sonic-frr/patch/0056-zebra-show-ip-route-failed.patch
@@ -1,0 +1,129 @@
+diff --git a/zebra/zebra_vty.c b/zebra/zebra_vty.c
+index 8a73ae3d2..909e1acf8 100644
+--- a/zebra/zebra_vty.c
++++ b/zebra/zebra_vty.c
+@@ -76,7 +76,7 @@ static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi,
+ 			    const struct prefix *longer_prefix_p,
+ 			    bool supernets_only, int type,
+ 			    unsigned short ospf_instance_id, uint32_t tableid,
+-			    bool show_ng, struct route_show_ctx *ctx);
++			    bool show_ng, bool failed_only, struct route_show_ctx *ctx);
+ static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
+ 				     int mcast, bool use_fib, bool show_ng);
+ static void vty_show_ip_route_summary(struct vty *vty,
+@@ -159,7 +159,7 @@ DEFUN (show_ip_rpf,
+ 
+ 	return do_show_ip_route(vty, VRF_DEFAULT_NAME, AFI_IP, SAFI_MULTICAST,
+ 				false, uj, 0, NULL, false, 0, 0, 0, false,
+-				&ctx);
++				false, &ctx);
+ }
+ 
+ DEFUN (show_ip_rpf_addr,
+@@ -855,7 +855,7 @@ static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
+ 				 const struct prefix *longer_prefix_p,
+ 				 bool supernets_only, int type,
+ 				 unsigned short ospf_instance_id, bool use_json,
+-				 uint32_t tableid, bool show_ng,
++				 uint32_t tableid, bool show_ng, bool failed_only,
+ 				 struct route_show_ctx *ctx)
+ {
+ 	struct route_node *rn;
+@@ -889,6 +889,9 @@ static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
+ 			if (use_fib && re != dest->selected_fib)
+ 				continue;
+ 
++			if (failed_only && !CHECK_FLAG(re->status, ROUTE_ENTRY_FAILED))
++				continue;
++
+ 			if (tag && re->tag != tag)
+ 				continue;
+ 
+@@ -968,7 +971,7 @@ static void do_show_ip_route_all(struct vty *vty, struct zebra_vrf *zvrf,
+ 				 const struct prefix *longer_prefix_p,
+ 				 bool supernets_only, int type,
+ 				 unsigned short ospf_instance_id, bool show_ng,
+-				 struct route_show_ctx *ctx)
++				 bool failed_only, struct route_show_ctx *ctx)
+ {
+ 	struct zebra_router_table *zrt;
+ 	struct rib_table_info *info;
+@@ -986,7 +989,7 @@ static void do_show_ip_route_all(struct vty *vty, struct zebra_vrf *zvrf,
+ 		do_show_ip_route(vty, zvrf_name(zvrf), afi, SAFI_UNICAST,
+ 				 use_fib, use_json, tag, longer_prefix_p,
+ 				 supernets_only, type, ospf_instance_id,
+-				 zrt->tableid, show_ng, ctx);
++				 zrt->tableid, show_ng, failed_only, ctx);
+ 	}
+ }
+ 
+@@ -996,7 +999,7 @@ static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi,
+ 			    const struct prefix *longer_prefix_p,
+ 			    bool supernets_only, int type,
+ 			    unsigned short ospf_instance_id, uint32_t tableid,
+-			    bool show_ng, struct route_show_ctx *ctx)
++			    bool show_ng, bool failed_only, struct route_show_ctx *ctx)
+ {
+ 	struct route_table *table;
+ 	struct zebra_vrf *zvrf = NULL;
+@@ -1029,7 +1032,7 @@ static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi,
+ 
+ 	do_show_route_helper(vty, zvrf, table, afi, use_fib, tag,
+ 			     longer_prefix_p, supernets_only, type,
+-			     ospf_instance_id, use_json, tableid, show_ng, ctx);
++			     ospf_instance_id, use_json, tableid, show_ng, failed_only, ctx);
+ 
+ 	return CMD_SUCCESS;
+ }
+@@ -1743,7 +1746,7 @@ DEFPY (show_route,
+ 	   }]\
+ 	   [" FRR_IP6_REDIST_STR_ZEBRA "$type_str]\
+ 	 >\
+-        [<json$json|nexthop-group$ng>]",
++        [<json$json|nexthop-group$ng>] [failed$failed]",
+        SHOW_STR
+        IP_STR
+        "IP forwarding table\n"
+@@ -1773,7 +1776,8 @@ DEFPY (show_route,
+        "Show route matching the specified Network/Mask pair only\n"
+        FRR_IP6_REDIST_HELP_STR_ZEBRA
+        JSON_STR
+-       "Nexthop Group Information\n")
++       "Nexthop Group Information\n"
++       "Show only failed routes\n")
+ {
+ 	afi_t afi = ipv4 ? AFI_IP : AFI_IP6;
+ 	struct vrf *vrf;
+@@ -1813,14 +1817,14 @@ DEFPY (show_route,
+ 					vty, zvrf, afi, !!fib, !!json, tag,
+ 					prefix_str ? prefix : NULL,
+ 					!!supernets_only, type,
+-					ospf_instance_id, !!ng, &ctx);
++					ospf_instance_id, !!ng, !!failed, &ctx);
+ 			else
+ 				do_show_ip_route(
+ 					vty, zvrf_name(zvrf), afi, SAFI_UNICAST,
+ 					!!fib, !!json, tag,
+ 					prefix_str ? prefix : NULL,
+ 					!!supernets_only, type,
+-					ospf_instance_id, table, !!ng, &ctx);
++					ospf_instance_id, table, !!ng, !!failed, &ctx);
+ 		}
+ 	} else {
+ 		vrf_id_t vrf_id = VRF_DEFAULT;
+@@ -1839,13 +1843,13 @@ DEFPY (show_route,
+ 			do_show_ip_route_all(vty, zvrf, afi, !!fib, !!json, tag,
+ 					     prefix_str ? prefix : NULL,
+ 					     !!supernets_only, type,
+-					     ospf_instance_id, !!ng, &ctx);
++					     ospf_instance_id, !!ng, !!failed, &ctx);
+ 		else
+ 			do_show_ip_route(vty, vrf->name, afi, SAFI_UNICAST,
+ 					 !!fib, !!json, tag,
+ 					 prefix_str ? prefix : NULL,
+ 					 !!supernets_only, type,
+-					 ospf_instance_id, table, !!ng, &ctx);
++					 ospf_instance_id, table, !!ng, !!failed, &ctx);
+ 	}
+ 
+ 	return CMD_SUCCESS;

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -53,3 +53,4 @@
 0053-Patch-to-send-tag-value-associated-with-route-via-ne.patch
 0054-make-route-node-lock-atomic.patch
 0055-zebra-Fix-crash-on-macvlan-link-down-up.patch
+0056-zebra-show-ip-route-failed.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Need a new show command to display only failed routes, instead of displaying the whole routing table and then filtering failed routes. Display of whole routing table on scaled setups causes high memory spikes, and is not suitable for a periodic route_check on failed routes

##### Work item tracking
- Microsoft ADO **(number only)**:
36250624

#### How I did it
Added a new additional option parameter <failed> and in the implementation, filter routes early if the ROUTE_INSTALL_FAILED flag is not set. 

#### How to verify it
Loaded the image on the chassis, and could verify that the device is stable.
the new command is available. the output is as expected.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)
NA
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)
202405

```
admin@svcstr-7800-lc3-1:~$ vtysh -n 0

Hello, this is FRRouting (version 8.5.4).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

svcstr-7800-lc3-1# show ip route 
  <cr>            
  A.B.C.D         Network in the IP routing table to display
  A.B.C.D/M       IP prefix <network>/<length>, e.g., 35.0.0.0/8
  babel           Babel routing protocol (Babel)
  bgp             Border Gateway Protocol (BGP)
  connected       Connected routes (directly attached subnet or host)
  eigrp           Enhanced Interior Gateway Routing Protocol (EIGRP)
  failed          Show only failed routes
  isis            Intermediate System to Intermediate System (IS-IS)
  json            JavaScript Object Notation
  kernel          Kernel routes (not installed via the zebra RIB)
  nexthop-group   Nexthop Group Information
  nhrp            Next Hop Resolution Protocol (NHRP)
  openfabric      OpenFabric Routing Protocol
  ospf            Open Shortest Path First (OSPFv2)
  rip             Routing Information Protocol (RIP)
  static          Statically configured routes
  summary         Summary of all routes
  supernets-only  Show supernet entries only
  table           Table to display
  tag             Show only routes with tag
  vnc             Virtual Network Control (VNC)
  vrf             Specify the VRF
svcstr-7800-lc3-1# show ip route failed 
  <cr>  
svcstr-7800-lc3-1# show ip route failed 
svcstr-7800-lc3-1# show ip route json   
  <cr>    
  failed  Show only failed routes
svcstr-7800-lc3-1# show ip route json failed
{
}
svcstr-7800-lc3-1# 

svcstr-7800-lc3-1# show ipv6 route 
  <cr>           
  X:X::X:X       IPv6 Address
  X:X::X:X/M     IPv6 prefix
  babel          Babel routing protocol (Babel)
  bgp            Border Gateway Protocol (BGP)
  connected      Connected routes (directly attached subnet or host)
  failed         Show only failed routes
  isis           Intermediate System to Intermediate System (IS-IS)
  json           JavaScript Object Notation
  kernel         Kernel routes (not installed via the zebra RIB)
  nexthop-group  Nexthop Group Information
  nhrp           Next Hop Resolution Protocol (NHRP)
  openfabric     OpenFabric Routing Protocol
  ospf6          Open Shortest Path First (IPv6) (OSPFv3)
  ripng          Routing Information Protocol next-generation (IPv6) (RIPng)
  static         Statically configured routes
  summary        Summary of all routes
  table          Table to display
  tag            Show only routes with tag
  vnc            Virtual Network Control (VNC)
  vrf            Specify the VRF
svcstr-7800-lc3-1# show ipv6 route failed 
  <cr>  
svcstr-7800-lc3-1# show ipv6 route failed 
svcstr-7800-lc3-1# show ipv6 route json   
  <cr>    
  failed  Show only failed routes
svcstr-7800-lc3-1# show ipv6 route json failed 
{
}
svcstr-7800-lc3-1# 
```
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

