### PR TITLE
[202503][x86_64-arista_7280dr3a_36] Set the LAG CRC to improve hashing

### DIFF
--- a/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/0/jr2p-a7280dra3-36-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/0/jr2p-a7280dra3-36-36x400G.config.bcm
@@ -985,3 +985,4 @@ xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4
 sai_pfc_dlr_init_capability=0
 sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
+sai_lag_default_crc_hash=1

--- a/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/1/jr2p-a7280dra3-36-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/1/jr2p-a7280dra3-36-36x400G.config.bcm
@@ -984,3 +984,4 @@ xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=2
 sai_pfc_dlr_init_capability=0
 sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
+sai_lag_default_crc_hash=1

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -361,3 +361,4 @@ fabric_num_pipes
 fabric_pipe_map_uc
 fabric_pipe_map_mc
 system_contains_multiple_pipe_device
+sai_lag_default_crc_hash


### PR DESCRIPTION
msft-202503 cast of https://github.com/sonic-net/sonic-buildimage/pull/24999

We saw a sonic-mgmt test failing due to poor hashing 
`fib/test_fib.py::test_fib::test_hash[ipv6]`

BRCM added a new soc property to let us select the CRC used.
This change selects a CRC that sees better distribution in the test.
CS00012420434