### PR TITLE
Bump sleep to 5 seconds for DB config file generation

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -151,10 +151,10 @@ function waitForAllInstanceDatabaseConfigJsonFilesReady()
 		done
             done
         fi
-        # Delay a second to allow all instance database_config.json files to be completely generated and fully accessible.
+        # Delay 5 seconds to allow all instance database_config.json files to be completely generated and fully accessible.
         # This delay is needed to make sure that the database_config.json files are correctly rendered from j2 template
-        # files ( renderning takes some time )
-        sleep 1
+        # files ( rendering takes some time )
+        sleep 5
     fi
 }
 {%- endif %}


### PR DESCRIPTION
Increased delay to ensure database_config.json files are accessible.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently, we are getting the following error syslog on the devices that have slow performance NPU:
```
2026-01-15T22:04:54.011303+00:00 sonic sonic-db-cli: :- parseDatabaseConfig: Sonic database config file syntax error >> [json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal 
2026-01-15T22:04:54.011303+00:00 sonic sonic-db-cli: :- parseDatabaseConfig: Sonic database config file syntax error >> [json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal
2026-01-15T22:04:54.011570+00:00 sonic sonic-db-cli: :- initializeGlobalConfig: Sonic database config file syntax error >> Sonic database config file syntax error >> [json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal
2026-01-15T22:04:54.011785+00:00 sonic database.sh[12147]: An exception of type Sonic database config file syntax error >> Sonic database config file syntax error >> [json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal occurred. Arguments: 
2026-01-15T22:04:54.011980+00:00 sonic database.sh[12147]: sonic-db-cli -n asic8 PING
...
```
This is because the device needs more time to get all the database_config.json files to be ready. Therefore, we decided to bump the sleep time to 5 seconds.

##### Work item tracking
- Microsoft ADO **(number only)**: 36433179

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

