### PR TITLE
Add fec: rs to port config for ports with >=50G per lane

### DIFF
--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -374,18 +374,8 @@ class BreakoutCfg(object):
 
                 lanes = self._lanes[lane_id:lane_id + lanes_per_port]
 
-                alias = self._breakout_capabilities[alias_id]
-                # If alias follows new SONiC port naming convention (e.g. et[sX]pY[abcd]),
-                # we can derive subport directly based on the breakout mode. Otherwise,
-                # fallback to the old method.
-                if m := re.match(r"et(s\d+)?p\d+([a-l])?", alias):
-                    breakout = m.groups()[-1]
-                    subport = "0" if not breakout else str(ord(breakout) - ord('a') + 1)
-                else:
-                    subport = "0" if total_num_ports == 1 else str(alias_id + 1)
-
                 port_config = {
-                    'alias': alias,
+                    'alias': self._breakout_capabilities[alias_id],
                     'lanes': ','.join(lanes),
                     'speed': str(entry.default_speed),
                     'index': self._indexes[lane_id],

--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -374,13 +374,29 @@ class BreakoutCfg(object):
 
                 lanes = self._lanes[lane_id:lane_id + lanes_per_port]
 
-                ports[interface_name] = {
-                    'alias': self._breakout_capabilities[alias_id],
+                alias = self._breakout_capabilities[alias_id]
+                # If alias follows new SONiC port naming convention (e.g. et[sX]pY[abcd]),
+                # we can derive subport directly based on the breakout mode. Otherwise,
+                # fallback to the old method.
+                if m := re.match(r"et(s\d+)?p\d+([a-l])?", alias):
+                    breakout = m.groups()[-1]
+                    subport = "0" if not breakout else str(ord(breakout) - ord('a') + 1)
+                else:
+                    subport = "0" if total_num_ports == 1 else str(alias_id + 1)
+
+                port_config = {
+                    'alias': alias,
                     'lanes': ','.join(lanes),
                     'speed': str(entry.default_speed),
                     'index': self._indexes[lane_id],
                     'subport': "0" if total_num_ports == 1 else str(alias_id + 1)
                 }
+                
+                # If the lane speed is greater than 50G, enable FEC
+                if entry.default_speed // lanes_per_port >= 50000:
+                    port_config['fec'] = 'rs'
+
+                ports[interface_name] = port_config
 
                 lane_id += lanes_per_port
                 alias_id += 1


### PR DESCRIPTION
Why I did it
Ports with lane speed >=50G use PAM4 modulation and should indicate "fec": "rs" in the port config.

This fixes issue Enhancement:FEC not configured for PAM4 speeds #23561


#### Why I did it

Ports with lane speed >=50G use PAM4 modulation and should indicate "fec": "rs" in the port config. Without this, the FEC configuration is missing for PAM4 speeds, which can lead to link stability issues.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Modified `portconfig.py` to automatically set `"fec": "rs"` for ports where the lane speed is >=50G (PAM4 modulation). Updated the logic to detect lane speed based on port speed and number of lanes, and apply the appropriate FEC configuration.

#### How to verify it
1. Generate port configuration for platforms with ports using >=50G per lane (e.g., 400G ports with 8 lanes, 200G ports with 4 lanes)
2. Verify that the generated config includes `"fec": "rs"` for these ports
3. Run the updated unit tests: `test_cfggen_platformJson.py`

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)
- [x] 202412 branch 

#### Description for the changelog
Add automatic FEC RS configuration for ports with lane speed >=50G (PAM4 modulation)

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

