### PR TITLE
[Mellanox] Fix thermal_updater polling interval get issue

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@
 from . import utils
 from sonic_py_common import logger
 
+import re
 import sys
 import time
 
@@ -57,26 +58,78 @@ class ThermalUpdater:
         self._timer = utils.Timer()
         self._update_asic = update_asic
 
+    def wait_for_sysfs_nodes(self):
+        """
+        Wait for temperature sysfs nodes to be present before proceeding.
+        Returns:
+            bool: True if wait success else timeout
+        """
+        start_time = time.time()
+        logger.log_notice('Waiting for temperature sysfs nodes to be present...')
+        conditions = []
+
+        # ASIC temperature sysfs node
+        asic_count = DeviceDataManager.get_asic_count()
+        for asic_index in range(asic_count):
+            conditions.append(lambda idx=asic_index: os.path.exists(f'/sys/module/sx_core/asic{idx}/temperature/input'))
+
+        # Module temperature sysfs nodes
+        sfp_count = len(self._sfp_list) if self._sfp_list else 0
+        result = DeviceDataManager.wait_sysfs_ready(sfp_count)
+        end_time = time.time()
+        elapsed_time = end_time - start_time
+
+        if result:
+            logger.log_notice(f'Temperature sysfs nodes are ready. Wait time: {elapsed_time:.4f} seconds')
+        else:
+            logger.log_error(f'Timeout waiting for temperature sysfs nodes. Wait time: {elapsed_time:.4f} seconds')
+
+        return result
+
+    def _find_matching_key(self, dev_parameters, pattern):
+        """
+        Find the first key in dev_parameters that matches the given regex pattern.
+        Returns the matching key and its value, or (None, None) if no match found.
+        """
+        for key in dev_parameters.keys():
+            if re.match(pattern, key):
+                return key, dev_parameters[key]
+        return None, None
+
     def load_tc_config(self):
         asic_poll_interval = 1
         sfp_poll_interval = 10
         data = utils.load_json_file(TC_CONFIG_FILE, log_func=None)
         if not data:
-            logger.log_notice(f'{TC_CONFIG_FILE} does not exist, use default polling interval')
+            logger.log_error(f'{TC_CONFIG_FILE} does not exist, use default polling interval')
 
         if data:
             dev_parameters = data.get('dev_parameters')
-            if dev_parameters is not None:
-                asic_parameter = dev_parameters.get('asic')
+            if not dev_parameters:
+                logger.log_error('dev_parameters not configured or empty, using default intervals')
+            else:
+                # Find ASIC parameter using regex pattern
+                asic_key, asic_parameter = self._find_matching_key(dev_parameters, r'asic\\d*')
                 if asic_parameter is not None:
                     asic_poll_interval_config = asic_parameter.get('poll_time')
                     if asic_poll_interval_config:
-                        asic_poll_interval = int(asic_poll_interval_config) / 2
-                module_parameter = dev_parameters.get('module\\d+')
+                        asic_poll_interval = int(asic_poll_interval_config)
+                        logger.log_notice(f'ASIC parameter found with key "{asic_key}", poll_time: {asic_poll_interval_config}, interval: {asic_poll_interval}')
+                    else:
+                        logger.log_error(f'ASIC poll_time not configured in "{asic_key}", using default interval: {asic_poll_interval}')
+                else:
+                    logger.log_error(f'ASIC parameter not found (pattern: asic\\d*), using default interval: {asic_poll_interval}')
+                # Find Module parameter using regex pattern
+                module_key, module_parameter = self._find_matching_key(dev_parameters, r'module\\d+')
                 if module_parameter is not None:
                     sfp_poll_interval_config = module_parameter.get('poll_time')
                     if sfp_poll_interval_config:
-                        sfp_poll_interval = int(sfp_poll_interval_config) / 2
+                        sfp_poll_interval = int(sfp_poll_interval_config)
+                        logger.log_notice(f'Module parameter found with key "{module_key}", poll_time: {sfp_poll_interval_config}, interval: {sfp_poll_interval}')
+                    else:
+                        logger.log_error(f'Module poll_time not configured in "{module_key}", using default interval: {sfp_poll_interval}')
+                else:
+                    logger.log_error(f'Module parameter not found (pattern: module\\d+), using default interval: {sfp_poll_interval}')
 
         if self._update_asic:
             logger.log_notice(f'ASIC polling interval: {asic_poll_interval}')


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The thermal updater's `load_tc_config` method was unable to correctly parse tc_config files that use regex-based parameter.

#### How I did it
1. **Added `_find_matching_key` method**: Implements regex pattern matching to find parameter keys in dictionary.
2. **Updated `load_tc_config` method**:
   - Changed ASIC parameter lookup to use regex pattern `r'asic\\d*'`
   - Changed Module parameter lookup to use regex pattern `r'module\\d+'`
 
#### How to verify it
Test in switch, check if corrected parsed.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->
- [x] 202412
- [x] 202511

#### Tested branch (Please provide the tested image version)
202511