### PR TITLE
[Backport] Backport VNET_ROUTE_TUNNEL endpoint, mac_address and vni to leaf string to allow duplicate values and new metric field

### DIFF
--- a/src/sonic-yang-mgmt/sonic_yang_ext.py
+++ b/src/sonic-yang-mgmt/sonic_yang_ext.py
@@ -35,9 +35,6 @@ LEAF_LIST_WITH_STRING_VALUE_DICT = {
     ('BUFFER_PORT_INGRESS_PROFILE_LIST', 'profile_list'): ',',
     ('PORT', 'adv_speeds'): ',',
     ('PORT', 'adv_interface_types'): ',',
-    ('VNET_ROUTE_TUNNEL', 'endpoint'): ',',
-    ('VNET_ROUTE_TUNNEL', 'mac_address'): ',',
-    ('VNET_ROUTE_TUNNEL', 'vni'): ',',
 }
 
 """

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2409,7 +2409,8 @@
                 "endpoint": "192.168.1.1,192.168.1.2",
                 "mac_address": "f9:22:83:99:22:a1,f9:22:83:99:22:a2",
                 "vni": "10011,10012",
-                "consistent_hashing_buckets": "10"
+                "consistent_hashing_buckets": "10",
+                "metric": "0"
             }
         },
         "PORT_QOS_MAP": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vnet.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vnet.json
@@ -34,7 +34,7 @@
     },
 
     "VNET_ROUTE_TUNNEL_COMPLETE_TEST": {
-        "desc": "Complete VNET route tunnel configuration with all optional fields (including mac_address and vni) in VNET_ROUTE_TUNNEL_LIST table."
+        "desc": "Complete VNET route tunnel configuration with all optional fields (including mac_address, vni, and metric) in VNET_ROUTE_TUNNEL_LIST table."
     },
 
     "VNET_ROUTE_TUNNEL_TEST_DUPLICATE_NAME": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vnet.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vnet.json
@@ -53,8 +53,8 @@
     },
 
     "VNET_ROUTE_TUNNEL_TEST_INVALID_VNI": {
-        "desc": "VNET route tunnel configuration with invalid VXLAN ID (exceeding max value of 16777215) in VNET_ROUTE_TUNNEL_LIST table.",
-        "eStr": "Value \"16777216\" does not satisfy the constraint \"1..16777215\""
+        "desc": "VNET route tunnel configuration with invalid VXLAN ID in VNET_ROUTE_TUNNEL_LIST table.",
+        "eStrKey": "Pattern"
     },
 
     "VNET_ROUTE_TUNNEL_TEST_INVALID_NAME_FORMAT": {
@@ -69,7 +69,7 @@
 
     "VNET_ROUTE_TUNNEL_TEST_MISSING_ENDPOINT": {
         "desc": "VNET route tunnel configuration with missing mandatory attribute (endpoint) in VNET_ROUTE_TUNNEL_LIST table.",
-        "eStrKey": "MinElements"
+        "eStrKey": "Mandatory"
     },
 
     "VNET_ROUTE_TUNNEL_TEST_NONEXISTENT_VNET": {
@@ -105,7 +105,11 @@
 
     "VNET_ROUTE_TUNNEL_TEST_INVALID_MULTI_VNI": {
         "desc": "VNET route tunnel configuration with invalid VNI in comma-separated vni list.",
-        "eStrKey": "Range"
+        "eStrKey": "Pattern"
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_DUPLICATE_VNI": {
+        "desc": "VNET route tunnel configuration with duplicate VNI values in comma-separated vni string."
     },
 
     "VNET_ROUTE_TUNNEL_TEST_CONSISTENT_HASHING": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vnet.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vnet.json
@@ -208,7 +208,7 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix": "10.0.0.0/24",
-                        "endpoint": ["192.168.1.1"]
+                        "endpoint": "192.168.1.1"
                     }
                 ]
             }
@@ -248,14 +248,14 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": ["192.168.1.1"],
-                        "vni": ["10011"]
+                        "endpoint": "192.168.1.1",
+                        "vni": "10011"
                     },
                     {
                         "vnet_name": "Vnet2",
                         "prefix":"10.0.1.0/24",
-                        "endpoint": ["192.168.1.2"],
-                        "vni": ["10012"]
+                        "endpoint": "192.168.1.2",
+                        "vni": "10012"
                     }
                 ]
             }
@@ -290,9 +290,9 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": ["192.168.1.1"],
-                        "mac_address": ["00:aa:bb:cc:dd:ee"],
-                        "vni": ["10011"]
+                        "endpoint": "192.168.1.1",
+                        "mac_address": "00:aa:bb:cc:dd:ee",
+                        "vni": "10011"
                     }
                 ]
             }
@@ -327,14 +327,14 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": ["192.168.1.1"],
-                        "vni": ["10011"]
+                        "endpoint": "192.168.1.1",
+                        "vni": "10011"
                     },
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": ["192.168.1.2"],
-                        "vni": ["10012"]
+                        "endpoint": "192.168.1.2",
+                        "vni": "10012"
                     }
                 ]
             }
@@ -369,8 +369,8 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": ["256.256.256.256"],
-                        "vni": ["10011"]
+                        "endpoint": "256.256.256.256",
+                        "vni": "10011"
                     }
                 ]
             }
@@ -405,9 +405,9 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": ["192.168.1.1"],
-                        "mac_address": ["GG:HH:II:JJ:KK:LL"],
-                        "vni": ["10011"]
+                        "endpoint": "192.168.1.1",
+                        "mac_address": "GG:HH:II:JJ:KK:LL",
+                        "vni": "10011"
                     }
                 ]
             }
@@ -442,8 +442,8 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": ["192.168.1.1"],
-                        "vni": ["16777216"]
+                        "endpoint": "192.168.1.1",
+                        "vni": "16777216"
                     }
                 ]
             }
@@ -477,8 +477,8 @@
                 "VNET_ROUTE_TUNNEL_LIST": [
                     {
                         "vnet_name": "Vnet1",
-                        "endpoint": ["192.168.1.1"],
-                        "vni": ["10011"]
+                        "endpoint": "192.168.1.1",
+                        "vni": "10011"
                     }
                 ]
             }
@@ -513,8 +513,8 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"300.168.1.0/24",
-                        "endpoint": ["192.168.1.1"],
-                        "vni": ["10011"]
+                        "endpoint": "192.168.1.1",
+                        "vni": "10011"
                     }
                 ]
             }
@@ -549,7 +549,7 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "vni": ["10011"]
+                        "vni": "10011"
                     }
                 ]
             }
@@ -584,8 +584,8 @@
                     {
                         "vnet_name": "NonexistentVnet",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": ["192.168.1.1"],
-                        "vni": ["10011"]
+                        "endpoint": "192.168.1.1",
+                        "vni": "10011"
                     }
                 ]
             }
@@ -620,7 +620,7 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": ["192.168.1.1", "192.168.1.2", "192.168.1.3"]
+                        "endpoint": "192.168.1.1,192.168.1.2,192.168.1.3"
                     }
                 ]
             }
@@ -655,8 +655,8 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": ["192.168.1.1"],
-                        "mac_address": ["00:aa:bb:cc:dd:ee", "11:22:33:44:55:66", "aa:bb:cc:dd:ee:ff"]
+                        "endpoint": "192.168.1.1",
+                        "mac_address": "00:aa:bb:cc:dd:ee,11:22:33:44:55:66,aa:bb:cc:dd:ee:ff"
                     }
                 ]
             }
@@ -691,8 +691,8 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": ["192.168.1.1"],
-                        "vni": ["10011", "10012", "10013"]
+                        "endpoint": "192.168.1.1",
+                        "vni": "10011,10012,10013"
                     }
                 ]
             }
@@ -727,9 +727,9 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": ["192.168.1.1", "192.168.1.2"],
-                        "mac_address": ["00:aa:bb:cc:dd:ee", "11:22:33:44:55:66"],
-                        "vni": ["10011", "10012"]
+                        "endpoint": "192.168.1.1,192.168.1.2",
+                        "mac_address": "00:aa:bb:cc:dd:ee,11:22:33:44:55:66",
+                        "vni": "10011,10012"
                     }
                 ]
             }
@@ -764,7 +764,7 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": ["192.168.1.1", "256.256.256.256", "192.168.1.3"]
+                        "endpoint": "192.168.1.1,256.256.256.256,192.168.1.3"
                     }
                 ]
             }
@@ -799,8 +799,8 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": ["192.168.1.1"],
-                        "mac_address": ["00:aa:bb:cc:dd:ee", "ZZ:YY:XX:WW:VV:UU", "11:22:33:44:55:66"]
+                        "endpoint": "192.168.1.1",
+                        "mac_address": "00:aa:bb:cc:dd:ee,ZZ:YY:XX:WW:VV:UU,11:22:33:44:55:66"
                     }
                 ]
             }
@@ -835,8 +835,44 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": ["192.168.1.1"],
-                        "vni": ["10011", "16777216", "10013"]
+                        "endpoint": "192.168.1.1",
+                        "vni": "10011,00013"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_DUPLICATE_VNI": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix":"10.0.0.0/24",
+                        "endpoint": "192.168.1.1,192.168.1.2,192.168.1.3,192.168.1.4",
+                        "vni": "10011,10012,10011,10013"
                     }
                 ]
             }
@@ -871,7 +907,7 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": ["192.168.1.1"],
+                        "endpoint": "192.168.1.1",
                         "consistent_hashing_buckets": 128
                     }
                 ]
@@ -907,7 +943,7 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": ["192.168.1.1"],
+                        "endpoint": "192.168.1.1",
                         "consistent_hashing_buckets": 65535
                     }
                 ]
@@ -943,9 +979,9 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": ["192.168.1.1", "192.168.1.2", "192.168.1.3"],
-                        "mac_address": ["00:aa:bb:cc:dd:ee", "11:22:33:44:55:66", "aa:bb:cc:dd:ee:ff"],
-                        "vni": ["10011", "10012", "10013"],
+                        "endpoint": "192.168.1.1,192.168.1.2,192.168.1.3",
+                        "mac_address": "00:aa:bb:cc:dd:ee,11:22:33:44:55:66,aa:bb:cc:dd:ee:ff",
+                        "vni": "10011,10012,10013",
                         "consistent_hashing_buckets": 256
                     }
                 ]
@@ -981,7 +1017,7 @@
                     {
                         "vnet_name": "Vnet1",
                         "prefix":"10.0.0.0/24",
-                        "endpoint": ["192.168.1.1"],
+                        "endpoint": "192.168.1.1",
                         "consistent_hashing_buckets": 99999
                     }
                 ]

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vnet.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vnet.json
@@ -292,7 +292,8 @@
                         "prefix":"10.0.0.0/24",
                         "endpoint": "192.168.1.1",
                         "mac_address": "00:aa:bb:cc:dd:ee",
-                        "vni": "10011"
+                        "vni": "10011",
+                        "metric": 1
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-vnet.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vnet.yang
@@ -143,6 +143,11 @@ module sonic-vnet {
                     description "Number of consistent hashing buckets to use, if consistent hashing is desired";
                     type uint16;
                 }
+
+                leaf metric {
+                    description "Value that can be set to categorize or determine the type of route. This value does not affect route behavior.";
+                    type uint8;
+                }
             }
             /* end of list VNET_ROUTE_TUNNEL_LIST */
         }

--- a/src/sonic-yang-models/yang-models/sonic-vnet.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vnet.yang
@@ -123,20 +123,20 @@ module sonic-vnet {
                     type stypes:sonic-ip4-prefix;
                 }
                 
-                leaf-list endpoint {
+                leaf endpoint {
                     description "Endpoint/nexthop tunnel IPs";
-                    type inet:ipv4-address;
-                    min-elements 1;
+                    type stypes:ipv4-address-list;
+                    mandatory true;
                 }
 
-                leaf-list mac_address {
+                leaf mac_address {
                     description "Inner dest macs in encapsulated packet";
-                    type yang:mac-address;
+                    type stypes:mac-address-list;
                 }
 
-                leaf-list vni {
+                leaf vni {
                     description "Valid and active vni values in encapsulated packet";
-                    type stypes:vnid_type;
+                    type stypes:vnid-list;
                 }
 
                 leaf consistent_hashing_buckets {

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -51,6 +51,19 @@ module sonic-types {
       }
     }
 
+    typedef ipv4-address-list {
+        type string {
+            pattern '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+                + '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'
+                + '(%[\p{N}\p{L}]+)?'
+                + '(,(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+                + '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'
+                + '(%[\p{N}\p{L}]+)?)*';
+        }
+        description
+            "Comma-separated IPv4 addresses";
+    }
+
     typedef admin_status {
         type enumeration {
             enum up;
@@ -268,6 +281,14 @@ module sonic-types {
         }
     }
 
+    typedef mac-address-list {
+        type string {
+            pattern '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5})(,([0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}))*';
+        }
+        description
+            "Comma-separated MAC addresses";
+    }
+
     typedef hostname {
         type string {
             length 1..63;
@@ -280,6 +301,15 @@ module sonic-types {
         }
         description
             "VXLAN Network Identifier";
+    }
+
+    typedef vnid-list {
+        type string {
+            pattern '([1-9][0-9]{0,6}|1[0-5][0-9]{6}|16[0-6][0-9]{5}|167[0-6][0-9]{4}|1677[0-6][0-9]{3}|16777[01][0-9]{2}|1677720[0-9]|1677721[0-5])'
+                + '(,([1-9][0-9]{0,6}|1[0-5][0-9]{6}|16[0-6][0-9]{5}|167[0-6][0-9]{4}|1677[0-6][0-9]{3}|16777[01][0-9]{2}|1677720[0-9]|1677721[0-5]))*';
+        }
+        description
+            "Comma-separated VNIs";
     }
 
     typedef tc_type {


### PR DESCRIPTION
Backport request for the following PRs:
https://github.com/sonic-net/sonic-buildimage/pull/24998 Allow duplicate values for endpoint, mac, and vni.
https://github.com/sonic-net/sonic-buildimage/pull/25019 Add metric field