### PR TITLE
[202412] pmon: add missing devices due to unprivileged mode (#24463)

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -27,6 +27,20 @@ link_namespace() {
 }
 {%- endif %}
 
+{%- if docker_container_name == "pmon" %}
+get_pmon_device_mounts() {
+    local devregex='i2c-[0-9]+|ipmi[0-9]+|sd[a-z]+|mmcblk[0-9].*|nvme[0-9].*|uio.*|watchdog[0-9]*'
+    local devpathregex="$(echo "$devregex" | sed -E 's#(^|\|)#\1/dev/#g')"
+    for device in $(find /dev/ -maxdepth 1 | grep -E "$devpathregex"); do
+        if [ ! -L "$device" ] && [ -b "$device" -o -c "$device" ]; then
+            echo "--device=$device"
+        else
+            echo "--mount=type=bind,source=$device,destination=$device"
+        fi
+    done
+}
+{%- endif %}
+
 function updateSyslogConf()
 {
     # On multiNPU platforms, change the syslog target ip to docker0 ip to allow logs from containers
@@ -693,6 +707,7 @@ start() {
 {%- endif %}
 {%- if docker_container_name == "pmon" %}
     -v /usr/share/sonic/firmware:/usr/share/sonic/firmware:rw \
+    $(get_pmon_device_mounts) \
 {%- endif %}
 {%- if docker_container_name == "swss" %}
         -e ASIC_VENDOR={{ sonic_asic_platform }} \


### PR DESCRIPTION
Cherry-pick from https://github.com/sonic-net/sonic-buildimage/pull/24463

This change refactors the current mechanism to mount stuff in the containers. It lists all the top level content under /dev and mount them inside docker. Block and character devices are mounted using the --device parameter while other files are mounted using --mount. Symlinks populated by udev or files containing : are not elegible for --device

#### Why I did it
The transition of pmon from a privileged container to unprivileged now prevents it from accessing host devices. The "solution" consists of mounting individual host devices into at container creation time. Some devices are currently missing including many i2c-*, mmcblk* and uio* for our platforms.

####Work item tracking
Microsoft ADO (number only):

#### How I did it
Refactored the part of docker_image_ctl.j2 that generates the --device arguments for pmon. Instead of having many different ways of handling and figuring what to mount it makes more sense to aggregate them into a single logic.

This logic iterates over all the top level entries of the host /dev folder. When an entry matches the regex of devices to handle (i2c, sd, nvme, mmcblk, ipmi, ...) it generates the appropriate argument for the docker container create cli. Some extra logic was added to mount block and character devices using the --device argument and others such as symlinks using the --mount option.

The symlink handling was added because some platform use udev scripts to create symlinks for devices. They have to be managed differently.
Also note that the --device argument only accepts devices that do not have a colon within.

#### How to verify it
Run the following command and make sure pmon is running and healthy systemctl stop pmon; docker rm pmon; systemctl start pmon

Then ensure all desired devices/mounts are present by checking docker inspect pmon

#### Description for the changelog
pmon: add missing devices due to unprivileged mode