### PR TITLE
[libyang] Fix hash table resize assertion failure for large configurations

### DIFF
--- a/src/libyang/patch/libyang-increase-lyht-min-size.patch
+++ b/src/libyang/patch/libyang-increase-lyht-min-size.patch
@@ -1,0 +1,12 @@
+diff --git a/src/hash_table.h b/src/hash_table.h
+--- a/src/hash_table.h
++++ b/src/hash_table.h
+@@ -53,7 +53,7 @@
+ #define LYHT_SHRINK_PERCENTAGE 25
+ 
+ /** never shrink beyond this size */
+-#define LYHT_MIN_SIZE 8
++#define LYHT_MIN_SIZE 65536
+ 
+ /**
+  * @brief Generic hash table record.

--- a/src/libyang/patch/series
+++ b/src/libyang/patch/series
@@ -4,3 +4,4 @@ swig.patch
 large_file_support_arm32.patch
 debian-packaging-files.patch
 libyang-leaf-must.patch
+libyang-increase-lyht-min-size.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Check pick https://github.com/sonic-net/sonic-buildimage/pull/25430

Fix critical minigraph loading failure caused by libyang hash table resize assertion failure.

Root Cause: libyang 1.0.73 has a known bug in hash table resize logic. When the hash table resizes during large config processing, the lydict_val_eq function uses incorrect string length comparison, causing false equality matches and insertion failures.

Fix: Increase LYHT_MIN_SIZE from 8 to 65536. This prevents resize operations for configs with <50,000 unique strings, avoiding the buggy code path entirely. Memory impact is negligible (~2-4MB, <0.05% of device memory).

##### Work item tracking
- Microsoft ADO **(number only)**: 36733961

#### How I did it
1. Added patch file libyang-increase-lyht-min-size.patch
2. Updated series to include the new patch

#### How to verify it
Build verification: Rebuild libyang package

Manual test on device:

Before fix: Crashes at some number of BGP entries with assertion failure
After fix: Successfully loads all BGP entries

Test results:

Full minigraph loading test: Device successfully completes Hardconfig stage with original minigraph that previously failed.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

