### PR TITLE
Added Change to parse Vlan Config without any VlanInterface binded to it

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1033,7 +1033,7 @@ def parse_dpg(dpg, hname):
             else:
                 vlantype_name = vlantype.text
             vintfmbr = vintf.find(str(QName(ns, "AttachTo"))).text
-            vmbr_list = vintfmbr.split(';')
+            vmbr_list = vintfmbr.split(';') if vintfmbr else []
             if vlantype_name != "Tagged":
                 for member in vmbr_list:
                     untagged_vlan_mbr[member].add(vlanid)
@@ -1046,7 +1046,7 @@ def parse_dpg(dpg, hname):
                 vlantype_name = ""
             else:
                 vlantype_name = vlantype.text
-            vmbr_list = vintfmbr.split(';')
+            vmbr_list = vintfmbr.split(';') if vintfmbr else []
             for i, member in enumerate(vmbr_list):
                 vmbr_list[i] = port_alias_map.get(member, member)
                 sonic_vlan_member_name = "Vlan%s" % (vlanid)


### PR DESCRIPTION
What I did:

Added Change to parse Vlan Config without any VlanInterface binded to it

How I verify:

Before fix:

```
ABDOSI@xxxx-0101-0040-12xx~$ sonic-cfggen -m minigraph.xml -v DEVICE_METADATA
Traceback (most recent call last):
  File "/usr/local/bin/sonic-cfggen", line 510, in <module>
    main()
  File "/usr/local/bin/sonic-cfggen", line 393, in main
    deep_update(data, parse_xml(minigraph, platform, asic_name=asic_name))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/minigraph.py", line 2097, in parse_xml
    (intfs, lo_intfs, mvrf, mgmt_intf, voq_inband_intfs, vlans, vlan_members, dhcp_relay_table, pcs, pc_members, acls, acl_table_types, vni, tunnel_intfs, dpg_ecmp_content, static_routes, tunnel_intfs_qos_remap_config) = parse_dpg(child, hostname)
                                                                                                                                                                                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/minigraph.py", line 1045, in parse_dpg
    vmbr_list = vintfmbr.split(';')

```

After fix:

Parsing is fine