### PR TITLE
[202503] Add fec: rs to port config for ports with >=50G per lane

### DIFF
--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -374,13 +374,19 @@ class BreakoutCfg(object):
 
                 lanes = self._lanes[lane_id:lane_id + lanes_per_port]
 
-                ports[interface_name] = {
+                port_config = {
                     'alias': self._breakout_capabilities[alias_id],
                     'lanes': ','.join(lanes),
                     'speed': str(entry.default_speed),
                     'index': self._indexes[lane_id],
                     'subport': "0" if total_num_ports == 1 else str(alias_id + 1)
                 }
+                
+                # If the lane speed is greater than 50G, enable FEC
+                if entry.default_speed // lanes_per_port >= 50000:
+                    port_config['fec'] = 'rs'
+
+                ports[interface_name] = port_config
 
                 lane_id += lanes_per_port
                 alias_id += 1


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
cherry-pick https://github.com/Azure/sonic-buildimage-msft/pull/1950 to 202503.

#### Why I did it
Ports with lane speed >=50G use PAM4 modulation and should indicate "fec": "rs" in the port config.

##### Work item tracking
* Microsoft ADO **(number only)**:
* This fixes issue [Enhancement:FEC not configured for PAM4 speeds #23561](https://github.com/sonic-net/sonic-buildimage/issues/23561)

#### How I did it
Check the lane speed and add "fec": "rs" for lanes with speed at least 50G.

#### How to verify it
`sonic-cfggen -k <device-name> --print-data | grep Ethernet0 -C 10` Make sure that fec rs is there by default if it's a PAM4 speed. Otherwise don’t insert anything To verify whether “fec”: “rs” is only being added for lane speeds above 50G, we used these 3 test inputs and show their respective outputs. Test Input 1:

```
        "Ethernet0": {
            "autoneg": "off",
            "default_brkout_mode": "1x800G"
        },
```

Should have fec because the lane speed is greater than 50G. Output:

```
        "Ethernet0": {
            "alias": "Port1",
            "lanes": "9,10,11,12,13,14,15,16",
            "speed": "800000",
            "index": "1",
            "subport": "0",
            "fec": "rs",
            "autoneg": "off"
        },
```

Test Input 2:

```
        "Ethernet0": {
            "autoneg": "off",
            "default_brkout_mode": "4x25G"
        },
```

Should not have fec because the lane speed is less than 50G. Output:

```
        "Ethernet0": {
            "alias": "Port1/1",
            "lanes": "9,10",
            "speed": "25000",
            "index": "1",
            "subport": "1",
            "autoneg": "off"
        },
```

Test Input 3:

```
        "Ethernet0": {
            "autoneg": "off",
            "default_brkout_mode": "8x50G"
        },
```

Should have fec because lane speed is 50G. Output:

```
        "Ethernet0": {
            "alias": "Port1/1",
            "lanes": "9",
            "speed": "50000",
            "index": "1",
            "subport": "1",
            "fec": "rs",
            "autoneg": "off"
        }
```

#### Which release branch to backport (provide reason below if selected)
* [ ]  202205
* [ ]  202211
* [ ]  202305
* [ ]  202311
* [ ]  202405
* [ ]  202411
* [ ]  202505

#### Tested branch (Please provide the tested image version)
* [ ]
* [ ]

#### Description for the changelog
#### Link to config_db schema for YANG module changes
#### A picture of a cute animal (not mandatory but encouraged)

