### PR TITLE
[Arista][202405] Enable interrupts on all cores

### DIFF
--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/sai_postinit_cmd.soc
@@ -1,29 +1,60 @@
-INTeRrupt ENAble id=1550
-INTeRrupt ENAble id=1551
-INTeRrupt ENAble id=1552
-INTeRrupt ENAble id=1553
-INTeRrupt ENAble id=1554
-INTeRrupt ENAble id=1555
-INTeRrupt ENAble id=1556
-INTeRrupt ENAble id=1557
-INTeRrupt ENAble id=1558
-INTeRrupt ENAble id=1559
-INTeRrupt ENAble id=1560
-INTeRrupt ENAble id=1561
-INTeRrupt ENAble id=1562
-INTeRrupt ENAble id=1563
-INTeRrupt ENAble id=1564
-INTeRrupt ENAble id=1565
-INTeRrupt ENAble id=1566
-INTeRrupt ENAble id=1567
+# Core=0
+INTeRrupt ENAble id=1550 p=0
+INTeRrupt ENAble id=1551 p=0
+INTeRrupt ENAble id=1552 p=0
+INTeRrupt ENAble id=1553 p=0
+INTeRrupt ENAble id=1554 p=0
+INTeRrupt ENAble id=1555 p=0
+INTeRrupt ENAble id=1556 p=0
+INTeRrupt ENAble id=1557 p=0
+INTeRrupt ENAble id=1558 p=0
+INTeRrupt ENAble id=1559 p=0
+INTeRrupt ENAble id=1560 p=0
+INTeRrupt ENAble id=1561 p=0
+INTeRrupt ENAble id=1562 p=0
+INTeRrupt ENAble id=1563 p=0
+INTeRrupt ENAble id=1564 p=0
+INTeRrupt ENAble id=1565 p=0
+INTeRrupt ENAble id=1566 p=0
+INTeRrupt ENAble id=1567 p=0
 
-INTeRrupt ENAble id=1296
-INTeRrupt ENAble id=1297
-INTeRrupt ENAble id=1298
-INTeRrupt ENAble id=1299
-INTeRrupt ENAble id=1661
-INTeRrupt ENAble id=1662
+INTeRrupt ENAble id=1296 p=0
+INTeRrupt ENAble id=1297 p=0
+INTeRrupt ENAble id=1298 p=0
+INTeRrupt ENAble id=1299 p=0
+INTeRrupt ENAble id=1661 p=0
+INTeRrupt ENAble id=1662 p=0
 
-INTeRrupt ENAble id=1093
+INTeRrupt ENAble id=1093 p=0
+
+# Core=1
+INTeRrupt ENAble id=1550 p=1
+INTeRrupt ENAble id=1551 p=1
+INTeRrupt ENAble id=1552 p=1
+INTeRrupt ENAble id=1553 p=1
+INTeRrupt ENAble id=1554 p=1
+INTeRrupt ENAble id=1555 p=1
+INTeRrupt ENAble id=1556 p=1
+INTeRrupt ENAble id=1557 p=1
+INTeRrupt ENAble id=1558 p=1
+INTeRrupt ENAble id=1559 p=1
+INTeRrupt ENAble id=1560 p=1
+INTeRrupt ENAble id=1561 p=1
+INTeRrupt ENAble id=1562 p=1
+INTeRrupt ENAble id=1563 p=1
+INTeRrupt ENAble id=1564 p=1
+INTeRrupt ENAble id=1565 p=1
+INTeRrupt ENAble id=1566 p=1
+INTeRrupt ENAble id=1567 p=1
+
+INTeRrupt ENAble id=1296 p=1
+INTeRrupt ENAble id=1297 p=1
+INTeRrupt ENAble id=1298 p=1
+INTeRrupt ENAble id=1299 p=1
+INTeRrupt ENAble id=1661 p=1
+INTeRrupt ENAble id=1662 p=1
+
+INTeRrupt ENAble id=1093 p=1
+
 debug intr error
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/sai_postinit_cmd.soc
@@ -1,29 +1,60 @@
-INTeRrupt ENAble id=1550
-INTeRrupt ENAble id=1551
-INTeRrupt ENAble id=1552
-INTeRrupt ENAble id=1553
-INTeRrupt ENAble id=1554
-INTeRrupt ENAble id=1555
-INTeRrupt ENAble id=1556
-INTeRrupt ENAble id=1557
-INTeRrupt ENAble id=1558
-INTeRrupt ENAble id=1559
-INTeRrupt ENAble id=1560
-INTeRrupt ENAble id=1561
-INTeRrupt ENAble id=1562
-INTeRrupt ENAble id=1563
-INTeRrupt ENAble id=1564
-INTeRrupt ENAble id=1565
-INTeRrupt ENAble id=1566
-INTeRrupt ENAble id=1567
+# Core=0
+INTeRrupt ENAble id=1550 p=0
+INTeRrupt ENAble id=1551 p=0
+INTeRrupt ENAble id=1552 p=0
+INTeRrupt ENAble id=1553 p=0
+INTeRrupt ENAble id=1554 p=0
+INTeRrupt ENAble id=1555 p=0
+INTeRrupt ENAble id=1556 p=0
+INTeRrupt ENAble id=1557 p=0
+INTeRrupt ENAble id=1558 p=0
+INTeRrupt ENAble id=1559 p=0
+INTeRrupt ENAble id=1560 p=0
+INTeRrupt ENAble id=1561 p=0
+INTeRrupt ENAble id=1562 p=0
+INTeRrupt ENAble id=1563 p=0
+INTeRrupt ENAble id=1564 p=0
+INTeRrupt ENAble id=1565 p=0
+INTeRrupt ENAble id=1566 p=0
+INTeRrupt ENAble id=1567 p=0
 
-INTeRrupt ENAble id=1296
-INTeRrupt ENAble id=1297
-INTeRrupt ENAble id=1298
-INTeRrupt ENAble id=1299
-INTeRrupt ENAble id=1661
-INTeRrupt ENAble id=1662
+INTeRrupt ENAble id=1296 p=0
+INTeRrupt ENAble id=1297 p=0
+INTeRrupt ENAble id=1298 p=0
+INTeRrupt ENAble id=1299 p=0
+INTeRrupt ENAble id=1661 p=0
+INTeRrupt ENAble id=1662 p=0
 
-INTeRrupt ENAble id=1093
+INTeRrupt ENAble id=1093 p=0
+
+# Core=1
+INTeRrupt ENAble id=1550 p=1
+INTeRrupt ENAble id=1551 p=1
+INTeRrupt ENAble id=1552 p=1
+INTeRrupt ENAble id=1553 p=1
+INTeRrupt ENAble id=1554 p=1
+INTeRrupt ENAble id=1555 p=1
+INTeRrupt ENAble id=1556 p=1
+INTeRrupt ENAble id=1557 p=1
+INTeRrupt ENAble id=1558 p=1
+INTeRrupt ENAble id=1559 p=1
+INTeRrupt ENAble id=1560 p=1
+INTeRrupt ENAble id=1561 p=1
+INTeRrupt ENAble id=1562 p=1
+INTeRrupt ENAble id=1563 p=1
+INTeRrupt ENAble id=1564 p=1
+INTeRrupt ENAble id=1565 p=1
+INTeRrupt ENAble id=1566 p=1
+INTeRrupt ENAble id=1567 p=1
+
+INTeRrupt ENAble id=1296 p=1
+INTeRrupt ENAble id=1297 p=1
+INTeRrupt ENAble id=1298 p=1
+INTeRrupt ENAble id=1299 p=1
+INTeRrupt ENAble id=1661 p=1
+INTeRrupt ENAble id=1662 p=1
+
+INTeRrupt ENAble id=1093 p=1
+
 debug intr error
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/sai_postinit_cmd.soc
@@ -1,30 +1,62 @@
-INTeRrupt ENAble id=2209
-INTeRrupt ENAble id=2210
-INTeRrupt ENAble id=2211
-INTeRrupt ENAble id=2212
-INTeRrupt ENAble id=2213
-INTeRrupt ENAble id=2214
-INTeRrupt ENAble id=2215
-INTeRrupt ENAble id=2216
-INTeRrupt ENAble id=2217
-INTeRrupt ENAble id=2218
-INTeRrupt ENAble id=2219
-INTeRrupt ENAble id=2220
-INTeRrupt ENAble id=2221
-INTeRrupt ENAble id=2222
-INTeRrupt ENAble id=2223
-INTeRrupt ENAble id=2224
-INTeRrupt ENAble id=2225
-INTeRrupt ENAble id=2226
+# Core=0
+INTeRrupt ENAble id=2209 p=0
+INTeRrupt ENAble id=2210 p=0
+INTeRrupt ENAble id=2211 p=0
+INTeRrupt ENAble id=2212 p=0
+INTeRrupt ENAble id=2213 p=0
+INTeRrupt ENAble id=2214 p=0
+INTeRrupt ENAble id=2215 p=0
+INTeRrupt ENAble id=2216 p=0
+INTeRrupt ENAble id=2217 p=0
+INTeRrupt ENAble id=2218 p=0
+INTeRrupt ENAble id=2219 p=0
+INTeRrupt ENAble id=2220 p=0
+INTeRrupt ENAble id=2221 p=0
+INTeRrupt ENAble id=2222 p=0
+INTeRrupt ENAble id=2223 p=0
+INTeRrupt ENAble id=2224 p=0
+INTeRrupt ENAble id=2225 p=0
+INTeRrupt ENAble id=2226 p=0
 
-INTeRrupt ENAble id=482
-INTeRrupt ENAble id=483
-INTeRrupt ENAble id=484
-INTeRrupt ENAble id=485
-INTeRrupt ENAble id=486
-INTeRrupt ENAble id=487
-INTeRrupt ENAble id=488
+INTeRrupt ENAble id=482 p=0
+INTeRrupt ENAble id=483 p=0
+INTeRrupt ENAble id=484 p=0
+INTeRrupt ENAble id=485 p=0
+INTeRrupt ENAble id=486 p=0
+INTeRrupt ENAble id=487 p=0
+INTeRrupt ENAble id=488 p=0
 
-INTeRrupt ENAble id=1597
+INTeRrupt ENAble id=1597 p=0
+
+# Core=1
+INTeRrupt ENAble id=2209 p=1
+INTeRrupt ENAble id=2210 p=1
+INTeRrupt ENAble id=2211 p=1
+INTeRrupt ENAble id=2212 p=1
+INTeRrupt ENAble id=2213 p=1
+INTeRrupt ENAble id=2214 p=1
+INTeRrupt ENAble id=2215 p=1
+INTeRrupt ENAble id=2216 p=1
+INTeRrupt ENAble id=2217 p=1
+INTeRrupt ENAble id=2218 p=1
+INTeRrupt ENAble id=2219 p=1
+INTeRrupt ENAble id=2220 p=1
+INTeRrupt ENAble id=2221 p=1
+INTeRrupt ENAble id=2222 p=1
+INTeRrupt ENAble id=2223 p=1
+INTeRrupt ENAble id=2224 p=1
+INTeRrupt ENAble id=2225 p=1
+INTeRrupt ENAble id=2226 p=1
+
+INTeRrupt ENAble id=482 p=1
+INTeRrupt ENAble id=483 p=1
+INTeRrupt ENAble id=484 p=1
+INTeRrupt ENAble id=485 p=1
+INTeRrupt ENAble id=486 p=1
+INTeRrupt ENAble id=487 p=1
+INTeRrupt ENAble id=488 p=1
+
+INTeRrupt ENAble id=1597 p=1
+
 debug intr error
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/sai_postinit_cmd.soc
@@ -1,30 +1,62 @@
-INTeRrupt ENAble id=2209
-INTeRrupt ENAble id=2210
-INTeRrupt ENAble id=2211
-INTeRrupt ENAble id=2212
-INTeRrupt ENAble id=2213
-INTeRrupt ENAble id=2214
-INTeRrupt ENAble id=2215
-INTeRrupt ENAble id=2216
-INTeRrupt ENAble id=2217
-INTeRrupt ENAble id=2218
-INTeRrupt ENAble id=2219
-INTeRrupt ENAble id=2220
-INTeRrupt ENAble id=2221
-INTeRrupt ENAble id=2222
-INTeRrupt ENAble id=2223
-INTeRrupt ENAble id=2224
-INTeRrupt ENAble id=2225
-INTeRrupt ENAble id=2226
+# Core=0
+INTeRrupt ENAble id=2209 p=0
+INTeRrupt ENAble id=2210 p=0
+INTeRrupt ENAble id=2211 p=0
+INTeRrupt ENAble id=2212 p=0
+INTeRrupt ENAble id=2213 p=0
+INTeRrupt ENAble id=2214 p=0
+INTeRrupt ENAble id=2215 p=0
+INTeRrupt ENAble id=2216 p=0
+INTeRrupt ENAble id=2217 p=0
+INTeRrupt ENAble id=2218 p=0
+INTeRrupt ENAble id=2219 p=0
+INTeRrupt ENAble id=2220 p=0
+INTeRrupt ENAble id=2221 p=0
+INTeRrupt ENAble id=2222 p=0
+INTeRrupt ENAble id=2223 p=0
+INTeRrupt ENAble id=2224 p=0
+INTeRrupt ENAble id=2225 p=0
+INTeRrupt ENAble id=2226 p=0
 
-INTeRrupt ENAble id=482
-INTeRrupt ENAble id=483
-INTeRrupt ENAble id=484
-INTeRrupt ENAble id=485
-INTeRrupt ENAble id=486
-INTeRrupt ENAble id=487
-INTeRrupt ENAble id=488
+INTeRrupt ENAble id=482 p=0
+INTeRrupt ENAble id=483 p=0
+INTeRrupt ENAble id=484 p=0
+INTeRrupt ENAble id=485 p=0
+INTeRrupt ENAble id=486 p=0
+INTeRrupt ENAble id=487 p=0
+INTeRrupt ENAble id=488 p=0
 
-INTeRrupt ENAble id=1597
+INTeRrupt ENAble id=1597 p=0
+
+# Core=1
+INTeRrupt ENAble id=2209 p=1
+INTeRrupt ENAble id=2210 p=1
+INTeRrupt ENAble id=2211 p=1
+INTeRrupt ENAble id=2212 p=1
+INTeRrupt ENAble id=2213 p=1
+INTeRrupt ENAble id=2214 p=1
+INTeRrupt ENAble id=2215 p=1
+INTeRrupt ENAble id=2216 p=1
+INTeRrupt ENAble id=2217 p=1
+INTeRrupt ENAble id=2218 p=1
+INTeRrupt ENAble id=2219 p=1
+INTeRrupt ENAble id=2220 p=1
+INTeRrupt ENAble id=2221 p=1
+INTeRrupt ENAble id=2222 p=1
+INTeRrupt ENAble id=2223 p=1
+INTeRrupt ENAble id=2224 p=1
+INTeRrupt ENAble id=2225 p=1
+INTeRrupt ENAble id=2226 p=1
+
+INTeRrupt ENAble id=482 p=1
+INTeRrupt ENAble id=483 p=1
+INTeRrupt ENAble id=484 p=1
+INTeRrupt ENAble id=485 p=1
+INTeRrupt ENAble id=486 p=1
+INTeRrupt ENAble id=487 p=1
+INTeRrupt ENAble id=488 p=1
+
+INTeRrupt ENAble id=1597 p=1
+
 debug intr error
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/sai_postinit_cmd.soc
@@ -1,30 +1,62 @@
-INTeRrupt ENAble id=2209
-INTeRrupt ENAble id=2210
-INTeRrupt ENAble id=2211
-INTeRrupt ENAble id=2212
-INTeRrupt ENAble id=2213
-INTeRrupt ENAble id=2214
-INTeRrupt ENAble id=2215
-INTeRrupt ENAble id=2216
-INTeRrupt ENAble id=2217
-INTeRrupt ENAble id=2218
-INTeRrupt ENAble id=2219
-INTeRrupt ENAble id=2220
-INTeRrupt ENAble id=2221
-INTeRrupt ENAble id=2222
-INTeRrupt ENAble id=2223
-INTeRrupt ENAble id=2224
-INTeRrupt ENAble id=2225
-INTeRrupt ENAble id=2226
+# Core=0
+INTeRrupt ENAble id=2209 p=0
+INTeRrupt ENAble id=2210 p=0
+INTeRrupt ENAble id=2211 p=0
+INTeRrupt ENAble id=2212 p=0
+INTeRrupt ENAble id=2213 p=0
+INTeRrupt ENAble id=2214 p=0
+INTeRrupt ENAble id=2215 p=0
+INTeRrupt ENAble id=2216 p=0
+INTeRrupt ENAble id=2217 p=0
+INTeRrupt ENAble id=2218 p=0
+INTeRrupt ENAble id=2219 p=0
+INTeRrupt ENAble id=2220 p=0
+INTeRrupt ENAble id=2221 p=0
+INTeRrupt ENAble id=2222 p=0
+INTeRrupt ENAble id=2223 p=0
+INTeRrupt ENAble id=2224 p=0
+INTeRrupt ENAble id=2225 p=0
+INTeRrupt ENAble id=2226 p=0
 
-INTeRrupt ENAble id=482
-INTeRrupt ENAble id=483
-INTeRrupt ENAble id=484
-INTeRrupt ENAble id=485
-INTeRrupt ENAble id=486
-INTeRrupt ENAble id=487
-INTeRrupt ENAble id=488
+INTeRrupt ENAble id=482 p=0
+INTeRrupt ENAble id=483 p=0
+INTeRrupt ENAble id=484 p=0
+INTeRrupt ENAble id=485 p=0
+INTeRrupt ENAble id=486 p=0
+INTeRrupt ENAble id=487 p=0
+INTeRrupt ENAble id=488 p=0
 
-INTeRrupt ENAble id=1597
+INTeRrupt ENAble id=1597 p=0
+
+# Core=1
+INTeRrupt ENAble id=2209 p=1
+INTeRrupt ENAble id=2210 p=1
+INTeRrupt ENAble id=2211 p=1
+INTeRrupt ENAble id=2212 p=1
+INTeRrupt ENAble id=2213 p=1
+INTeRrupt ENAble id=2214 p=1
+INTeRrupt ENAble id=2215 p=1
+INTeRrupt ENAble id=2216 p=1
+INTeRrupt ENAble id=2217 p=1
+INTeRrupt ENAble id=2218 p=1
+INTeRrupt ENAble id=2219 p=1
+INTeRrupt ENAble id=2220 p=1
+INTeRrupt ENAble id=2221 p=1
+INTeRrupt ENAble id=2222 p=1
+INTeRrupt ENAble id=2223 p=1
+INTeRrupt ENAble id=2224 p=1
+INTeRrupt ENAble id=2225 p=1
+INTeRrupt ENAble id=2226 p=1
+
+INTeRrupt ENAble id=482 p=1
+INTeRrupt ENAble id=483 p=1
+INTeRrupt ENAble id=484 p=1
+INTeRrupt ENAble id=485 p=1
+INTeRrupt ENAble id=486 p=1
+INTeRrupt ENAble id=487 p=1
+INTeRrupt ENAble id=488 p=1
+
+INTeRrupt ENAble id=1597 p=1
+
 debug intr error
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/sai_postinit_cmd.soc
@@ -1,30 +1,62 @@
-INTeRrupt ENAble id=2209
-INTeRrupt ENAble id=2210
-INTeRrupt ENAble id=2211
-INTeRrupt ENAble id=2212
-INTeRrupt ENAble id=2213
-INTeRrupt ENAble id=2214
-INTeRrupt ENAble id=2215
-INTeRrupt ENAble id=2216
-INTeRrupt ENAble id=2217
-INTeRrupt ENAble id=2218
-INTeRrupt ENAble id=2219
-INTeRrupt ENAble id=2220
-INTeRrupt ENAble id=2221
-INTeRrupt ENAble id=2222
-INTeRrupt ENAble id=2223
-INTeRrupt ENAble id=2224
-INTeRrupt ENAble id=2225
-INTeRrupt ENAble id=2226
+# Core=0
+INTeRrupt ENAble id=2209 p=0
+INTeRrupt ENAble id=2210 p=0
+INTeRrupt ENAble id=2211 p=0
+INTeRrupt ENAble id=2212 p=0
+INTeRrupt ENAble id=2213 p=0
+INTeRrupt ENAble id=2214 p=0
+INTeRrupt ENAble id=2215 p=0
+INTeRrupt ENAble id=2216 p=0
+INTeRrupt ENAble id=2217 p=0
+INTeRrupt ENAble id=2218 p=0
+INTeRrupt ENAble id=2219 p=0
+INTeRrupt ENAble id=2220 p=0
+INTeRrupt ENAble id=2221 p=0
+INTeRrupt ENAble id=2222 p=0
+INTeRrupt ENAble id=2223 p=0
+INTeRrupt ENAble id=2224 p=0
+INTeRrupt ENAble id=2225 p=0
+INTeRrupt ENAble id=2226 p=0
 
-INTeRrupt ENAble id=482
-INTeRrupt ENAble id=483
-INTeRrupt ENAble id=484
-INTeRrupt ENAble id=485
-INTeRrupt ENAble id=486
-INTeRrupt ENAble id=487
-INTeRrupt ENAble id=488
+INTeRrupt ENAble id=482 p=0
+INTeRrupt ENAble id=483 p=0
+INTeRrupt ENAble id=484 p=0
+INTeRrupt ENAble id=485 p=0
+INTeRrupt ENAble id=486 p=0
+INTeRrupt ENAble id=487 p=0
+INTeRrupt ENAble id=488 p=0
 
-INTeRrupt ENAble id=1597
+INTeRrupt ENAble id=1597 p=0
+
+# Core=1
+INTeRrupt ENAble id=2209 p=1
+INTeRrupt ENAble id=2210 p=1
+INTeRrupt ENAble id=2211 p=1
+INTeRrupt ENAble id=2212 p=1
+INTeRrupt ENAble id=2213 p=1
+INTeRrupt ENAble id=2214 p=1
+INTeRrupt ENAble id=2215 p=1
+INTeRrupt ENAble id=2216 p=1
+INTeRrupt ENAble id=2217 p=1
+INTeRrupt ENAble id=2218 p=1
+INTeRrupt ENAble id=2219 p=1
+INTeRrupt ENAble id=2220 p=1
+INTeRrupt ENAble id=2221 p=1
+INTeRrupt ENAble id=2222 p=1
+INTeRrupt ENAble id=2223 p=1
+INTeRrupt ENAble id=2224 p=1
+INTeRrupt ENAble id=2225 p=1
+INTeRrupt ENAble id=2226 p=1
+
+INTeRrupt ENAble id=482 p=1
+INTeRrupt ENAble id=483 p=1
+INTeRrupt ENAble id=484 p=1
+INTeRrupt ENAble id=485 p=1
+INTeRrupt ENAble id=486 p=1
+INTeRrupt ENAble id=487 p=1
+INTeRrupt ENAble id=488 p=1
+
+INTeRrupt ENAble id=1597 p=1
+
 debug intr error
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/sai_postinit_cmd.soc
@@ -1,30 +1,62 @@
-INTeRrupt ENAble id=2209
-INTeRrupt ENAble id=2210
-INTeRrupt ENAble id=2211
-INTeRrupt ENAble id=2212
-INTeRrupt ENAble id=2213
-INTeRrupt ENAble id=2214
-INTeRrupt ENAble id=2215
-INTeRrupt ENAble id=2216
-INTeRrupt ENAble id=2217
-INTeRrupt ENAble id=2218
-INTeRrupt ENAble id=2219
-INTeRrupt ENAble id=2220
-INTeRrupt ENAble id=2221
-INTeRrupt ENAble id=2222
-INTeRrupt ENAble id=2223
-INTeRrupt ENAble id=2224
-INTeRrupt ENAble id=2225
-INTeRrupt ENAble id=2226
+# Core=0
+INTeRrupt ENAble id=2209 p=0
+INTeRrupt ENAble id=2210 p=0
+INTeRrupt ENAble id=2211 p=0
+INTeRrupt ENAble id=2212 p=0
+INTeRrupt ENAble id=2213 p=0
+INTeRrupt ENAble id=2214 p=0
+INTeRrupt ENAble id=2215 p=0
+INTeRrupt ENAble id=2216 p=0
+INTeRrupt ENAble id=2217 p=0
+INTeRrupt ENAble id=2218 p=0
+INTeRrupt ENAble id=2219 p=0
+INTeRrupt ENAble id=2220 p=0
+INTeRrupt ENAble id=2221 p=0
+INTeRrupt ENAble id=2222 p=0
+INTeRrupt ENAble id=2223 p=0
+INTeRrupt ENAble id=2224 p=0
+INTeRrupt ENAble id=2225 p=0
+INTeRrupt ENAble id=2226 p=0
 
-INTeRrupt ENAble id=482
-INTeRrupt ENAble id=483
-INTeRrupt ENAble id=484
-INTeRrupt ENAble id=485
-INTeRrupt ENAble id=486
-INTeRrupt ENAble id=487
-INTeRrupt ENAble id=488
+INTeRrupt ENAble id=482 p=0
+INTeRrupt ENAble id=483 p=0
+INTeRrupt ENAble id=484 p=0
+INTeRrupt ENAble id=485 p=0
+INTeRrupt ENAble id=486 p=0
+INTeRrupt ENAble id=487 p=0
+INTeRrupt ENAble id=488 p=0
 
-INTeRrupt ENAble id=1597
+INTeRrupt ENAble id=1597 p=0
+
+# Core=1
+INTeRrupt ENAble id=2209 p=1
+INTeRrupt ENAble id=2210 p=1
+INTeRrupt ENAble id=2211 p=1
+INTeRrupt ENAble id=2212 p=1
+INTeRrupt ENAble id=2213 p=1
+INTeRrupt ENAble id=2214 p=1
+INTeRrupt ENAble id=2215 p=1
+INTeRrupt ENAble id=2216 p=1
+INTeRrupt ENAble id=2217 p=1
+INTeRrupt ENAble id=2218 p=1
+INTeRrupt ENAble id=2219 p=1
+INTeRrupt ENAble id=2220 p=1
+INTeRrupt ENAble id=2221 p=1
+INTeRrupt ENAble id=2222 p=1
+INTeRrupt ENAble id=2223 p=1
+INTeRrupt ENAble id=2224 p=1
+INTeRrupt ENAble id=2225 p=1
+INTeRrupt ENAble id=2226 p=1
+
+INTeRrupt ENAble id=482 p=1
+INTeRrupt ENAble id=483 p=1
+INTeRrupt ENAble id=484 p=1
+INTeRrupt ENAble id=485 p=1
+INTeRrupt ENAble id=486 p=1
+INTeRrupt ENAble id=487 p=1
+INTeRrupt ENAble id=488 p=1
+
+INTeRrupt ENAble id=1597 p=1
+
 debug intr error
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/sai_postinit_cmd.soc
@@ -1,30 +1,62 @@
-INTeRrupt ENAble id=2209
-INTeRrupt ENAble id=2210
-INTeRrupt ENAble id=2211
-INTeRrupt ENAble id=2212
-INTeRrupt ENAble id=2213
-INTeRrupt ENAble id=2214
-INTeRrupt ENAble id=2215
-INTeRrupt ENAble id=2216
-INTeRrupt ENAble id=2217
-INTeRrupt ENAble id=2218
-INTeRrupt ENAble id=2219
-INTeRrupt ENAble id=2220
-INTeRrupt ENAble id=2221
-INTeRrupt ENAble id=2222
-INTeRrupt ENAble id=2223
-INTeRrupt ENAble id=2224
-INTeRrupt ENAble id=2225
-INTeRrupt ENAble id=2226
+# Core=0
+INTeRrupt ENAble id=2209 p=0
+INTeRrupt ENAble id=2210 p=0
+INTeRrupt ENAble id=2211 p=0
+INTeRrupt ENAble id=2212 p=0
+INTeRrupt ENAble id=2213 p=0
+INTeRrupt ENAble id=2214 p=0
+INTeRrupt ENAble id=2215 p=0
+INTeRrupt ENAble id=2216 p=0
+INTeRrupt ENAble id=2217 p=0
+INTeRrupt ENAble id=2218 p=0
+INTeRrupt ENAble id=2219 p=0
+INTeRrupt ENAble id=2220 p=0
+INTeRrupt ENAble id=2221 p=0
+INTeRrupt ENAble id=2222 p=0
+INTeRrupt ENAble id=2223 p=0
+INTeRrupt ENAble id=2224 p=0
+INTeRrupt ENAble id=2225 p=0
+INTeRrupt ENAble id=2226 p=0
 
-INTeRrupt ENAble id=482
-INTeRrupt ENAble id=483
-INTeRrupt ENAble id=484
-INTeRrupt ENAble id=485
-INTeRrupt ENAble id=486
-INTeRrupt ENAble id=487
-INTeRrupt ENAble id=488
+INTeRrupt ENAble id=482 p=0
+INTeRrupt ENAble id=483 p=0
+INTeRrupt ENAble id=484 p=0
+INTeRrupt ENAble id=485 p=0
+INTeRrupt ENAble id=486 p=0
+INTeRrupt ENAble id=487 p=0
+INTeRrupt ENAble id=488 p=0
 
-INTeRrupt ENAble id=1597
+INTeRrupt ENAble id=1597 p=0
+
+# Core=1
+INTeRrupt ENAble id=2209 p=1
+INTeRrupt ENAble id=2210 p=1
+INTeRrupt ENAble id=2211 p=1
+INTeRrupt ENAble id=2212 p=1
+INTeRrupt ENAble id=2213 p=1
+INTeRrupt ENAble id=2214 p=1
+INTeRrupt ENAble id=2215 p=1
+INTeRrupt ENAble id=2216 p=1
+INTeRrupt ENAble id=2217 p=1
+INTeRrupt ENAble id=2218 p=1
+INTeRrupt ENAble id=2219 p=1
+INTeRrupt ENAble id=2220 p=1
+INTeRrupt ENAble id=2221 p=1
+INTeRrupt ENAble id=2222 p=1
+INTeRrupt ENAble id=2223 p=1
+INTeRrupt ENAble id=2224 p=1
+INTeRrupt ENAble id=2225 p=1
+INTeRrupt ENAble id=2226 p=1
+
+INTeRrupt ENAble id=482 p=1
+INTeRrupt ENAble id=483 p=1
+INTeRrupt ENAble id=484 p=1
+INTeRrupt ENAble id=485 p=1
+INTeRrupt ENAble id=486 p=1
+INTeRrupt ENAble id=487 p=1
+INTeRrupt ENAble id=488 p=1
+
+INTeRrupt ENAble id=1597 p=1
+
 debug intr error
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1


### PR DESCRIPTION
Backport of https://github.com/sonic-net/sonic-buildimage/pull/25936
But only including the chassis SKUs

