### PR TITLE
Enable ZTP by default in 202412

### DIFF
--- a/rules/config
+++ b/rules/config
@@ -52,7 +52,7 @@ DEFAULT_USERNAME = admin
 DEFAULT_PASSWORD = YourPaSsWoRd
 
 # ENABLE_ZTP - installs Zero Touch Provisioning support.
-# ENABLE_ZTP = y
+ENABLE_ZTP = y
 
 # INCLUDE_PDE - Enable platform development enviroment
 # INCLUDE_PDE = y


### PR DESCRIPTION
#### Why I did it

Enable Zero Touch Provisioning (ZTP) by default in the 202412 branch to support automated device provisioning out of the box.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Uncommented `ENABLE_ZTP = y` in `rules/config`.

#### How to verify it

Build the image and verify ZTP package is included and ZTP service starts on boot.

#### Which release branch to backport (provide reason below if selected)

N/A - this change is specific to 202412.

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version -->

#### Description for the changelog

Enable ZTP by default in 202412 branch.

#### A picture of a cute animal (not mandatory but encouraged)

```
 (\(\
 ( -.-)
 o_(")(")
```