### PR TITLE
[lldp] Fix transient MAC address Port ID during LLDP daemon startup

### DIFF
--- a/dockers/docker-lldp/lldpd.conf.j2
+++ b/dockers/docker-lldp/lldpd.conf.j2
@@ -19,5 +19,24 @@ configure ports eth0 lldp portidsubtype local {{ mgmt_if.port_name }}
 configure system ip management pattern {{ mgmt_if.ipv4 }}
 {% endif %}
 configure system hostname {{ DEVICE_METADATA['localhost']['hostname'] }}
+{# Configure port ID subtype for front-panel ports at startup.
+   Without this, lldpd uses MAC address as default Port ID. When lldpd
+   auto-resumes after config processing, the first LLDP frame would carry
+   MAC-based Port IDs. Peers see a transient MSAP change when lldpmgrd
+   later reconfigures portidsubtype, causing unnecessary neighbor flaps.
+   Special ports (inband/recirculation/backplane) are excluded to match
+   lldpmgrd behavior which skips these port types. #}
+{% if PORT %}
+{% for port_name in PORT|sort %}
+{% if not port_name.startswith('Ethernet-IB') and not port_name.startswith('Ethernet-Rec') and not port_name.startswith('Ethernet-BP') %}
+{% set port_alias = PORT[port_name].alias|default('') %}
+{% if port_alias %}
+configure ports {{ port_name }} lldp portidsubtype local {{ port_alias }}
+{% else %}
+configure ports {{ port_name }} lldp portidsubtype local {{ port_name }}
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {# pause lldpd operations until all interfaces are well configured, resume command will run in lldpmgrd #}
 pause


### PR DESCRIPTION
#### What I did
Adapted [sonic-net/sonic-buildimage#26144](https://github.com/sonic-net/sonic-buildimage/pull/26144) to the `202412` branch.

When lldpd starts (or restarts), it defaults to using MAC addresses as Port IDs for all interfaces. The lldpmgrd daemon later reconfigures each port with the correct interface alias via lldpcli, but there is a 2-3 second window where lldpd has already auto-resumed and sent LLDP frames with MAC-based Port IDs.

This causes peers to see a transient MSAP change: first a neighbor entry with MAC Port ID appears, then a shutdown frame, then a new entry with the correct interface name. This neighbor flapping can trigger monitoring alerts and confuse network management systems.

#### How I did it
Added portidsubtype configuration for all front-panel ports directly in the `lldpd.conf.j2` Jinja2 template. These configs are processed during lldpd startup config loading, before the auto-resume fires, ensuring the very first LLDP frame carries the correct interface alias as Port ID.

- Sort PORT iteration with `|sort` for deterministic config ordering
- Filter out special ports (Ethernet-IB/Rec/BP) matching lldpmgrd behavior
- Fallback to port_name when alias is missing or empty
- Add unit test with PORT table covering aliases, special ports, and missing alias scenarios

#### How to verify it
Run the sonic-config-engine unit tests:
```
cd src/sonic-config-engine && python -m pytest tests/test_j2files.py::TestJ2Files::test_lldp -v
```

Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>