### PR TITLE
[Nokia] Enable interrupts for all cores in BCM DNX devices

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/sai_postinit_cmd.soc
@@ -1,30 +1,62 @@
-INTeRrupt ENAble id=2209
-INTeRrupt ENAble id=2210
-INTeRrupt ENAble id=2211
-INTeRrupt ENAble id=2212
-INTeRrupt ENAble id=2213
-INTeRrupt ENAble id=2214
-INTeRrupt ENAble id=2215
-INTeRrupt ENAble id=2216
-INTeRrupt ENAble id=2217
-INTeRrupt ENAble id=2218
-INTeRrupt ENAble id=2219
-INTeRrupt ENAble id=2220
-INTeRrupt ENAble id=2221
-INTeRrupt ENAble id=2222
-INTeRrupt ENAble id=2223
-INTeRrupt ENAble id=2224
-INTeRrupt ENAble id=2225
-INTeRrupt ENAble id=2226
+#core 0
+INTeRrupt ENAble id=2209 p=0
+INTeRrupt ENAble id=2210 p=0
+INTeRrupt ENAble id=2211 p=0
+INTeRrupt ENAble id=2212 p=0
+INTeRrupt ENAble id=2213 p=0
+INTeRrupt ENAble id=2214 p=0
+INTeRrupt ENAble id=2215 p=0
+INTeRrupt ENAble id=2216 p=0
+INTeRrupt ENAble id=2217 p=0
+INTeRrupt ENAble id=2218 p=0
+INTeRrupt ENAble id=2219 p=0
+INTeRrupt ENAble id=2220 p=0
+INTeRrupt ENAble id=2221 p=0
+INTeRrupt ENAble id=2222 p=0
+INTeRrupt ENAble id=2223 p=0
+INTeRrupt ENAble id=2224 p=0
+INTeRrupt ENAble id=2225 p=0
+INTeRrupt ENAble id=2226 p=0
 
-INTeRrupt ENAble id=482
-INTeRrupt ENAble id=483
-INTeRrupt ENAble id=484
-INTeRrupt ENAble id=485
-INTeRrupt ENAble id=486
-INTeRrupt ENAble id=487
-INTeRrupt ENAble id=488
+INTeRrupt ENAble id=482 p=0
+INTeRrupt ENAble id=483 p=0
+INTeRrupt ENAble id=484 p=0
+INTeRrupt ENAble id=485 p=0
+INTeRrupt ENAble id=486 p=0
+INTeRrupt ENAble id=487 p=0
+INTeRrupt ENAble id=488 p=0
 
-INTeRrupt ENAble id=1597
+INTeRrupt ENAble id=1597 p=0
+
+#core 1
+INTeRrupt ENAble id=2209 p=1
+INTeRrupt ENAble id=2210 p=1
+INTeRrupt ENAble id=2211 p=1
+INTeRrupt ENAble id=2212 p=1
+INTeRrupt ENAble id=2213 p=1
+INTeRrupt ENAble id=2214 p=1
+INTeRrupt ENAble id=2215 p=1
+INTeRrupt ENAble id=2216 p=1
+INTeRrupt ENAble id=2217 p=1
+INTeRrupt ENAble id=2218 p=1
+INTeRrupt ENAble id=2219 p=1
+INTeRrupt ENAble id=2220 p=1
+INTeRrupt ENAble id=2221 p=1
+INTeRrupt ENAble id=2222 p=1
+INTeRrupt ENAble id=2223 p=1
+INTeRrupt ENAble id=2224 p=1
+INTeRrupt ENAble id=2225 p=1
+INTeRrupt ENAble id=2226 p=1
+
+INTeRrupt ENAble id=482 p=1
+INTeRrupt ENAble id=483 p=1
+INTeRrupt ENAble id=484 p=1
+INTeRrupt ENAble id=485 p=1
+INTeRrupt ENAble id=486 p=1
+INTeRrupt ENAble id=487 p=1
+INTeRrupt ENAble id=488 p=1
+
+INTeRrupt ENAble id=1597 p=1
+
 debug intr error
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/sai_postinit_cmd.soc
@@ -1,30 +1,62 @@
-INTeRrupt ENAble id=2209
-INTeRrupt ENAble id=2210
-INTeRrupt ENAble id=2211
-INTeRrupt ENAble id=2212
-INTeRrupt ENAble id=2213
-INTeRrupt ENAble id=2214
-INTeRrupt ENAble id=2215
-INTeRrupt ENAble id=2216
-INTeRrupt ENAble id=2217
-INTeRrupt ENAble id=2218
-INTeRrupt ENAble id=2219
-INTeRrupt ENAble id=2220
-INTeRrupt ENAble id=2221
-INTeRrupt ENAble id=2222
-INTeRrupt ENAble id=2223
-INTeRrupt ENAble id=2224
-INTeRrupt ENAble id=2225
-INTeRrupt ENAble id=2226
+#core 0
+INTeRrupt ENAble id=2209 p=0
+INTeRrupt ENAble id=2210 p=0
+INTeRrupt ENAble id=2211 p=0
+INTeRrupt ENAble id=2212 p=0
+INTeRrupt ENAble id=2213 p=0
+INTeRrupt ENAble id=2214 p=0
+INTeRrupt ENAble id=2215 p=0
+INTeRrupt ENAble id=2216 p=0
+INTeRrupt ENAble id=2217 p=0
+INTeRrupt ENAble id=2218 p=0
+INTeRrupt ENAble id=2219 p=0
+INTeRrupt ENAble id=2220 p=0
+INTeRrupt ENAble id=2221 p=0
+INTeRrupt ENAble id=2222 p=0
+INTeRrupt ENAble id=2223 p=0
+INTeRrupt ENAble id=2224 p=0
+INTeRrupt ENAble id=2225 p=0
+INTeRrupt ENAble id=2226 p=0
 
-INTeRrupt ENAble id=482
-INTeRrupt ENAble id=483
-INTeRrupt ENAble id=484
-INTeRrupt ENAble id=485
-INTeRrupt ENAble id=486
-INTeRrupt ENAble id=487
-INTeRrupt ENAble id=488
+INTeRrupt ENAble id=482 p=0
+INTeRrupt ENAble id=483 p=0
+INTeRrupt ENAble id=484 p=0
+INTeRrupt ENAble id=485 p=0
+INTeRrupt ENAble id=486 p=0
+INTeRrupt ENAble id=487 p=0
+INTeRrupt ENAble id=488 p=0
 
-INTeRrupt ENAble id=1597
+INTeRrupt ENAble id=1597 p=0
+
+#core 1
+INTeRrupt ENAble id=2209 p=1
+INTeRrupt ENAble id=2210 p=1
+INTeRrupt ENAble id=2211 p=1
+INTeRrupt ENAble id=2212 p=1
+INTeRrupt ENAble id=2213 p=1
+INTeRrupt ENAble id=2214 p=1
+INTeRrupt ENAble id=2215 p=1
+INTeRrupt ENAble id=2216 p=1
+INTeRrupt ENAble id=2217 p=1
+INTeRrupt ENAble id=2218 p=1
+INTeRrupt ENAble id=2219 p=1
+INTeRrupt ENAble id=2220 p=1
+INTeRrupt ENAble id=2221 p=1
+INTeRrupt ENAble id=2222 p=1
+INTeRrupt ENAble id=2223 p=1
+INTeRrupt ENAble id=2224 p=1
+INTeRrupt ENAble id=2225 p=1
+INTeRrupt ENAble id=2226 p=1
+
+INTeRrupt ENAble id=482 p=1
+INTeRrupt ENAble id=483 p=1
+INTeRrupt ENAble id=484 p=1
+INTeRrupt ENAble id=485 p=1
+INTeRrupt ENAble id=486 p=1
+INTeRrupt ENAble id=487 p=1
+INTeRrupt ENAble id=488 p=1
+
+INTeRrupt ENAble id=1597 p=1
+
 debug intr error
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/sai_postinit_cmd.soc
@@ -36,33 +36,65 @@ phy set 17 reg=0xd137 data=0      lane=2
 phy set 17 reg=0xd138 data=0      lane=2
 phy set 17 reg=0xd133 data=0x1804 lane=2
 
-INTeRrupt ENAble id=2209
-INTeRrupt ENAble id=2210
-INTeRrupt ENAble id=2211
-INTeRrupt ENAble id=2212
-INTeRrupt ENAble id=2213
-INTeRrupt ENAble id=2214
-INTeRrupt ENAble id=2215
-INTeRrupt ENAble id=2216
-INTeRrupt ENAble id=2217
-INTeRrupt ENAble id=2218
-INTeRrupt ENAble id=2219
-INTeRrupt ENAble id=2220
-INTeRrupt ENAble id=2221
-INTeRrupt ENAble id=2222
-INTeRrupt ENAble id=2223
-INTeRrupt ENAble id=2224
-INTeRrupt ENAble id=2225
-INTeRrupt ENAble id=2226
+#core 0
+INTeRrupt ENAble id=2209 p=0
+INTeRrupt ENAble id=2210 p=0
+INTeRrupt ENAble id=2211 p=0
+INTeRrupt ENAble id=2212 p=0
+INTeRrupt ENAble id=2213 p=0
+INTeRrupt ENAble id=2214 p=0
+INTeRrupt ENAble id=2215 p=0
+INTeRrupt ENAble id=2216 p=0
+INTeRrupt ENAble id=2217 p=0
+INTeRrupt ENAble id=2218 p=0
+INTeRrupt ENAble id=2219 p=0
+INTeRrupt ENAble id=2220 p=0
+INTeRrupt ENAble id=2221 p=0
+INTeRrupt ENAble id=2222 p=0
+INTeRrupt ENAble id=2223 p=0
+INTeRrupt ENAble id=2224 p=0
+INTeRrupt ENAble id=2225 p=0
+INTeRrupt ENAble id=2226 p=0
 
-INTeRrupt ENAble id=482
-INTeRrupt ENAble id=483
-INTeRrupt ENAble id=484
-INTeRrupt ENAble id=485
-INTeRrupt ENAble id=486
-INTeRrupt ENAble id=487
-INTeRrupt ENAble id=488
+INTeRrupt ENAble id=482 p=0
+INTeRrupt ENAble id=483 p=0
+INTeRrupt ENAble id=484 p=0
+INTeRrupt ENAble id=485 p=0
+INTeRrupt ENAble id=486 p=0
+INTeRrupt ENAble id=487 p=0
+INTeRrupt ENAble id=488 p=0
 
-INTeRrupt ENAble id=1597
+INTeRrupt ENAble id=1597 p=0
+
+#core 1
+INTeRrupt ENAble id=2209 p=1
+INTeRrupt ENAble id=2210 p=1
+INTeRrupt ENAble id=2211 p=1
+INTeRrupt ENAble id=2212 p=1
+INTeRrupt ENAble id=2213 p=1
+INTeRrupt ENAble id=2214 p=1
+INTeRrupt ENAble id=2215 p=1
+INTeRrupt ENAble id=2216 p=1
+INTeRrupt ENAble id=2217 p=1
+INTeRrupt ENAble id=2218 p=1
+INTeRrupt ENAble id=2219 p=1
+INTeRrupt ENAble id=2220 p=1
+INTeRrupt ENAble id=2221 p=1
+INTeRrupt ENAble id=2222 p=1
+INTeRrupt ENAble id=2223 p=1
+INTeRrupt ENAble id=2224 p=1
+INTeRrupt ENAble id=2225 p=1
+INTeRrupt ENAble id=2226 p=1
+
+INTeRrupt ENAble id=482 p=1
+INTeRrupt ENAble id=483 p=1
+INTeRrupt ENAble id=484 p=1
+INTeRrupt ENAble id=485 p=1
+INTeRrupt ENAble id=486 p=1
+INTeRrupt ENAble id=487 p=1
+INTeRrupt ENAble id=488 p=1
+
+INTeRrupt ENAble id=1597 p=1
+
 debug intr error
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/sai_postinit_cmd.soc
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/sai_postinit_cmd.soc
@@ -13,33 +13,65 @@ phy set 8 reg=0xd137 data=0      lane=1
 phy set 8 reg=0xd138 data=0      lane=1
 phy set 8 reg=0xd133 data=0x1802 lane=1
 
-INTeRrupt ENAble id=2209
-INTeRrupt ENAble id=2210
-INTeRrupt ENAble id=2211
-INTeRrupt ENAble id=2212
-INTeRrupt ENAble id=2213
-INTeRrupt ENAble id=2214
-INTeRrupt ENAble id=2215
-INTeRrupt ENAble id=2216
-INTeRrupt ENAble id=2217
-INTeRrupt ENAble id=2218
-INTeRrupt ENAble id=2219
-INTeRrupt ENAble id=2220
-INTeRrupt ENAble id=2221
-INTeRrupt ENAble id=2222
-INTeRrupt ENAble id=2223
-INTeRrupt ENAble id=2224
-INTeRrupt ENAble id=2225
-INTeRrupt ENAble id=2226
+#core 0
+INTeRrupt ENAble id=2209 p=0
+INTeRrupt ENAble id=2210 p=0
+INTeRrupt ENAble id=2211 p=0
+INTeRrupt ENAble id=2212 p=0
+INTeRrupt ENAble id=2213 p=0
+INTeRrupt ENAble id=2214 p=0
+INTeRrupt ENAble id=2215 p=0
+INTeRrupt ENAble id=2216 p=0
+INTeRrupt ENAble id=2217 p=0
+INTeRrupt ENAble id=2218 p=0
+INTeRrupt ENAble id=2219 p=0
+INTeRrupt ENAble id=2220 p=0
+INTeRrupt ENAble id=2221 p=0
+INTeRrupt ENAble id=2222 p=0
+INTeRrupt ENAble id=2223 p=0
+INTeRrupt ENAble id=2224 p=0
+INTeRrupt ENAble id=2225 p=0
+INTeRrupt ENAble id=2226 p=0
 
-INTeRrupt ENAble id=482
-INTeRrupt ENAble id=483
-INTeRrupt ENAble id=484
-INTeRrupt ENAble id=485
-INTeRrupt ENAble id=486
-INTeRrupt ENAble id=487
-INTeRrupt ENAble id=488
+INTeRrupt ENAble id=482 p=0
+INTeRrupt ENAble id=483 p=0
+INTeRrupt ENAble id=484 p=0
+INTeRrupt ENAble id=485 p=0
+INTeRrupt ENAble id=486 p=0
+INTeRrupt ENAble id=487 p=0
+INTeRrupt ENAble id=488 p=0
 
-INTeRrupt ENAble id=1597
+INTeRrupt ENAble id=1597 p=0
+
+#core 1
+INTeRrupt ENAble id=2209 p=1
+INTeRrupt ENAble id=2210 p=1
+INTeRrupt ENAble id=2211 p=1
+INTeRrupt ENAble id=2212 p=1
+INTeRrupt ENAble id=2213 p=1
+INTeRrupt ENAble id=2214 p=1
+INTeRrupt ENAble id=2215 p=1
+INTeRrupt ENAble id=2216 p=1
+INTeRrupt ENAble id=2217 p=1
+INTeRrupt ENAble id=2218 p=1
+INTeRrupt ENAble id=2219 p=1
+INTeRrupt ENAble id=2220 p=1
+INTeRrupt ENAble id=2221 p=1
+INTeRrupt ENAble id=2222 p=1
+INTeRrupt ENAble id=2223 p=1
+INTeRrupt ENAble id=2224 p=1
+INTeRrupt ENAble id=2225 p=1
+INTeRrupt ENAble id=2226 p=1
+
+INTeRrupt ENAble id=482 p=1
+INTeRrupt ENAble id=483 p=1
+INTeRrupt ENAble id=484 p=1
+INTeRrupt ENAble id=485 p=1
+INTeRrupt ENAble id=486 p=1
+INTeRrupt ENAble id=487 p=1
+INTeRrupt ENAble id=488 p=1
+
+INTeRrupt ENAble id=1597 p=1
+
 debug intr error
 Modreg FMAC_RSF_CONFIGURATION RSF_N_RX_ERR_MARK_EN=1


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
BCM interrupts are not enabled for all the cores and it is enabled only for core=0
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Enabled the interrupt for every core in the device.
#### How to verify it
Verified in the DNX devices that the interrupts are enabled for all the devices.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

