### PR TITLE
 [202412] zebra: fix speed timer race with RTM_NEWLINK on high-port-count devices

### DIFF
--- a/src/sonic-frr/patch/0146-zebra-fix-speed-timer-race-with-RTM_NEWLINK.patch
+++ b/src/sonic-frr/patch/0146-zebra-fix-speed-timer-race-with-RTM_NEWLINK.patch
@@ -1,0 +1,64 @@
+From 09fcb18e31e5ef8f4a680ae6dc789dd20fe8bcf5 Mon Sep 17 00:00:00 2001
+From: Deepak Singhal <deepsinghal@microsoft.com>
+Date: Mon, 30 Mar 2026 07:38:06 +0000
+Subject: [PATCH] zebra: fix speed timer race with RTM_NEWLINK on
+ high-port-count devices
+
+On high-port-count devices (512+ ports), the if_zebra_speed_update()
+timer can fire before RTM_NEWLINK assigns a real ifindex. This causes
+two problems:
+
+1. zebra_ns_link_ifp() is called with ifindex=IFINDEX_INTERNAL (0),
+   leading to an rbtree assertion failure (SIGABRT) when multiple
+   interfaces race.
+
+2. if_add_update() sets ZEBRA_INTERFACE_ACTIVE prematurely, causing
+   RTM_NEWLINK to take the update branch instead of the new-interface
+   branch. The interface is never linked into the per-NS ifindex rbtree,
+   breaking route and nexthop resolution on affected ports.
+
+Fix both issues:
+- Add IFINDEX_INTERNAL guard in zebra_ns_link_ifp() to prevent crash
+- Guard if_add_update() in speed timer to prevent premature ACTIVE flag
+
+Upstream: FRRouting/frr#19792, FRRouting/frr#19794, FRRouting/frr#19804
+Signed-off-by: Deepak Singhal <deepsinghal@microsoft.com>
+---
+ zebra/interface.c | 3 ++-
+ zebra/zebra_ns.c  | 6 ++++++
+ 2 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/zebra/interface.c b/zebra/interface.c
+index 5ce222cc04..9855d1c60b 100644
+--- a/zebra/interface.c
++++ b/zebra/interface.c
+@@ -69,7 +69,8 @@ static void if_zebra_speed_update(struct event *thread)
+ 		zlog_info("%s: %s old speed: %u new speed: %u", __func__,
+ 			  ifp->name, ifp->speed, new_speed);
+ 		ifp->speed = new_speed;
+-		if_add_update(ifp);
++		if (ifp->ifindex != IFINDEX_INTERNAL)
++			if_add_update(ifp);
+ 		changed = true;
+ 	}
+ 
+diff --git a/zebra/zebra_ns.c b/zebra/zebra_ns.c
+index 578dee7b7e..12c38e2f8e 100644
+--- a/zebra/zebra_ns.c
++++ b/zebra/zebra_ns.c
+@@ -49,6 +49,12 @@ void zebra_ns_link_ifp(struct zebra_ns *zns, struct interface *ifp)
+ 	struct zebra_if *zif;
+ 	struct ifp_tree_link *link, tlink = {};
+ 
++	if (ifp->ifindex == IFINDEX_INTERNAL) {
++		if (IS_ZEBRA_DEBUG_EVENT)
++			zlog_debug("%s: interface %s not ready, ignoring", __func__, ifp->name);
++		return;
++	}
++
+ 	zif = ifp->info;
+ 	assert(zif != NULL);
+ 
+-- 
+2.34.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -124,3 +124,4 @@
 0142-lib-Return-duplicate-prefix-list-entry-test.patch
 0144-mgmtd-remove-bogus-hedge-code-which-corrupted-active.patch
 0145-mgmtd-normalize-argument-order-to-copy-dst-src.patch
+0146-zebra-fix-speed-timer-race-with-RTM_NEWLINK.patch


### PR DESCRIPTION
 #### Why I did it
 
 Backport of sonic-net/sonic-buildimage#26458 to msft/202412 branch.
 
 Fixes ADO-37114309
 
 On high-port-count devices (512+ ports with 362+ routed L3 interfaces), the `if_zebra_speed_update()` 
timer fires before `RTM_NEWLINK` assigns a real ifindex. This causes two problems:
 
 1. `zebra_ns_link_ifp()` is called with `ifindex = IFINDEX_INTERNAL (0)`, leading to an rbtree assertion
 failure (SIGABRT) when multiple interfaces race.
 
 2. `if_add_update()` sets `ZEBRA_INTERFACE_ACTIVE` prematurely, causing `RTM_NEWLINK` to take the update
 branch instead of the new-interface branch. The interface is never linked into the per-NS ifindex 
rbtree, breaking route and nexthop resolution on affected ports.
 
 ##### Work item tracking
 - Microsoft ADO: 37114309
 
 #### How I did it
 
 Combined patch (Option A + Option C) as `0146-zebra-fix-speed-timer-race-with-RTM_NEWLINK.patch
 
 **Option A** — Guard in `zebra_ns_link_ifp()` to reject `IFINDEX_INTERNAL`, preventing the rbtree crash:
 ```c
 if (ifp->ifindex == IFINDEX_INTERNAL) {
     if (IS_ZEBRA_DEBUG_EVENT)
         zlog_debug("%s: interface %s not ready, ignoring", __func__, ifp->name);
     return;
 }

Option C — Guard in if_zebra_speed_update() to skip if_add_update() before RTM_NEWLINK assigns a real
ifindex:

 ifp->speed = new_speed;
 -if_add_update(ifp);
 +if (ifp->ifindex != IFINDEX_INTERNAL)
 +    if_add_update(ifp);

Note: The msft/202412 branch uses FRR 10.0.1 where Option A is not yet present (unlike public master
which has FRR 10.5.1 with Option A already included). This patch includes both fixes.
```

Files changed:

 - src/sonic-frr/patch/0146-zebra-fix-speed-timer-race-with-RTM_NEWLINK.patch (new)
 - src/sonic-frr/patch/series (added entry)

How to verify it
1. Fix is validated on Physcial Testbed with 512 physical ports, 362 router ports.
2. new written sonic-mgmt test is passing.

Complete tracking of issue/fixes in Master and other branches/new sonic-mgmt tests being tracked in this issue:
https://github.com/sonic-net/sonic-buildimage/issues/26457
 
