### PR TITLE
[submodule][202603] Fix sonic-sairedis .gitmodules URL and branch for 202603

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
 	branch = 202511
 [submodule "sonic-sairedis"]
 	path = src/sonic-sairedis
-	url = https://github.com/sonic-net/sonic-sairedis
-	branch = 202511
+	url = https://github.com/Azure/sonic-sairedis.msft
+	branch = 202603
 [submodule "sonic-swss"]
 	path = src/sonic-swss
 	url = https://github.com/sonic-net/sonic-swss


### PR DESCRIPTION
#### Why I did it

The .gitmodules entry for sonic-sairedis still pointed to the public upstream repo (https://github.com/sonic-net/sonic-sairedis) with branch 202511. Since the 202603 branch now uses Azure/sonic-sairedis.msft as the submodule source, the URL and branch need to be updated to match. Without this fix, the build pipeline fails because it cannot resolve the submodule commit from the wrong repository.

#### How I did it

Updated .gitmodules:
- URL: `https://github.com/sonic-net/sonic-sairedis` → `https://github.com/Azure/sonic-sairedis.msft`
- Branch: `202511` → `202603`

#### How to verify it

- Build pipeline should pass (submodule checkout succeeds)
- `git submodule update --init src/sonic-sairedis` should resolve correctly on the 202603 branch

#### Which release branch to backport (provide reason below if selected)

N/A — this is a 202603 branch-specific fix.

#### Description for the changelog

Fix sonic-sairedis .gitmodules URL and branch for 202603 feature branch