### PR TITLE
[lldp] Replace per-port portidsubtype loop with global ifname directive

### DIFF
--- a/dockers/docker-lldp/lldpd.conf.j2
+++ b/dockers/docker-lldp/lldpd.conf.j2
@@ -19,24 +19,7 @@ configure ports eth0 lldp portidsubtype local {{ mgmt_if.port_name }}
 configure system ip management pattern {{ mgmt_if.ipv4 }}
 {% endif %}
 configure system hostname {{ DEVICE_METADATA['localhost']['hostname'] }}
-{# Configure port ID subtype for front-panel ports at startup.
-   Without this, lldpd uses MAC address as default Port ID. When lldpd
-   auto-resumes after config processing, the first LLDP frame would carry
-   MAC-based Port IDs. Peers see a transient MSAP change when lldpmgrd
-   later reconfigures portidsubtype, causing unnecessary neighbor flaps.
-   Special ports (inband/recirculation/backplane) are excluded to match
-   lldpmgrd behavior which skips these port types. #}
-{% if PORT %}
-{% for port_name in PORT|sort %}
-{% if not port_name.startswith('Ethernet-IB') and not port_name.startswith('Ethernet-Rec') and not port_name.startswith('Ethernet-BP') %}
-{% set port_alias = PORT[port_name].alias|default('') %}
-{% if port_alias %}
-configure ports {{ port_name }} lldp portidsubtype local {{ port_alias }}
-{% else %}
-configure ports {{ port_name }} lldp portidsubtype local {{ port_name }}
-{% endif %}
-{% endif %}
-{% endfor %}
-{% endif %}
+{# Use ifname globally to avoid MAC-as-Port-ID; lldpmgrd sets alias per port later. #}
+configure lldp portidsubtype ifname
 {# pause lldpd operations until all interfaces are well configured, resume command will run in lldpmgrd #}
 pause

--- a/src/sonic-config-engine/tests/sample_output/py3/lldp_conf/lldpd-ipv4-iface.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/lldp_conf/lldpd-ipv4-iface.conf
@@ -1,4 +1,5 @@
 configure ports eth0 lldp portidsubtype local eth0
 configure system ip management pattern 10.0.0.100
 configure system hostname switch-t0
+configure lldp portidsubtype ifname
 pause

--- a/src/sonic-config-engine/tests/sample_output/py3/lldp_conf/lldpd-ipv6-iface.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/lldp_conf/lldpd-ipv6-iface.conf
@@ -1,2 +1,3 @@
 configure system hostname switch-t0
+configure lldp portidsubtype ifname
 pause


### PR DESCRIPTION
### Description of PR

Summary:
Cherry-pick of https://github.com/sonic-net/sonic-buildimage/pull/26873 for the 202412 branch.

Replace the per-port `portidsubtype` configuration loop in `lldpd.conf.j2` with a single global `configure lldp portidsubtype ifname` directive.

The per-port loop was added by [#26144](https://github.com/sonic-net/sonic-buildimage/pull/26144) to prevent MAC-based Port IDs on the first LLDP frame, but it causes **LLDP neighbor churns on high-scale systems** — startup delays proportional to port count (e.g., 20+ seconds on 512-port systems) lead to neighbor table instability.

[#26873](https://github.com/sonic-net/sonic-buildimage/pull/26873) fixes this by using the global `configure lldp portidsubtype ifname` directive instead. The trade-off is that the Port ID in the first LLDP packet uses the kernel interface name (e.g., `Ethernet64`) rather than the platform alias (e.g., `etp9a`). After lldpmgrd configures the per-port alias, subsequent packets use the correct alias. The key improvement is that the Port ID is **no longer a MAC address**, which was the original problem #26144 aimed to solve.

**Observed behavior:**

```
# First LLDP packet — Port ID is kernel interface name (not MAC, not alias)
ARISTA01T1#show lldp nei
Port          Neighbor Device ID       Neighbor Port ID    TTL
---------- ------------------------ ---------------------- ---
Et1           str5-sn5640-6            Ethernet64          120

# After lldpmgrd sets alias — Port ID becomes platform alias
ARISTA01T1#show lldp nei
Port          Neighbor Device ID       Neighbor Port ID    TTL
---------- ------------------------ ---------------------- ---
Et1           str5-sn5640-6            etp9a               120
```

**Note:** The original PR had conflicts on 202412 because the `lldpd-ipv4-iface-with-ports.conf` test file does not exist on this branch, and the `lldpd-ipv6-iface.conf` has a different baseline. These conflicts are resolved in this PR.

### Type of change

- [x] Bug fix

### Back port request
- [x] 202412

### Approach
#### What is the motivation for this PR?

[#26144](https://github.com/sonic-net/sonic-buildimage/pull/26144) introduced per-port portidsubtype configuration to prevent MAC-based Port IDs. However, on high-scale systems this causes LLDP neighbor churns due to slow startup. [#26873](https://github.com/sonic-net/sonic-buildimage/pull/26873) fixes it with a global directive that eliminates the startup delay while still avoiding MAC-based Port IDs.

#### How did you do it?

Applied the same change as sonic-net/sonic-buildimage#26873 with conflict resolution:
1. `lldpd.conf.j2`: Replaced the per-port Jinja2 loop with global `configure lldp portidsubtype ifname`
2. `lldpd-ipv4-iface.conf`: Added `configure lldp portidsubtype ifname` before `pause`
3. `lldpd-ipv6-iface.conf`: Added `configure lldp portidsubtype ifname` before `pause`
4. `lldpd-ipv4-iface-with-ports.conf`: Does not exist on 202412, skipped

#### How did you verify/test it?

Verified the generated config matches expected output format. The original PR was tested on sonic-net master. Observed LLDP behavior on str5-sn5640-6 confirms Port ID transitions from kernel ifname to alias after lldpmgrd configures it.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A