### PR TITLE
Fix auditd container monit startup issue

### DIFF
--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -210,10 +210,6 @@ def main():
         print("Expected containers not running: " + ", ".join(not_running_containers))
         sys.exit(3)
 
-    unexpected_running_containers = current_running_containers.difference(expected_running_containers)
-    if unexpected_running_containers:
-        print("Unexpected running containers: " + ", ".join(unexpected_running_containers))
-        sys.exit(4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why I did it
New containers (e.g., auditd) can fail to launch because monit blocks them when they are not yet in the expected container list. This change is also needed for containers deployed via Kubernetes that are not present in the image.

## How I did it
Skip the unexpected container check logic in `container_checker`.

## How to verify it
Verify that newly added containers are not blocked by monit on startup.

---
Ported from sonic-net/sonic-buildimage PR [#21979](https://github.com/sonic-net/sonic-buildimage/pull/21979) (commit 7a6961374) to the 202405 branch.