### PR TITLE
Cherry-pick PR #25933 : Enhance FRR daemon readiness monitoring with detailed diagnostics

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/frr.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/frr.py
@@ -19,15 +19,39 @@ class FRR(object):
         :param seconds: number of seconds to wait, until raise an error
         """
         stop_time = datetime.datetime.now() + datetime.timedelta(seconds=seconds)
-        log_info("Start waiting for FRR daemons: %s" % str(datetime.datetime.now()))
+        start_time = datetime.datetime.now()
+
+        log_info("Start waiting for FRR daemons (timeout=%ds): %s" % (seconds, str(start_time)))
+        log_info("Required daemons: %s" % str(self.daemons))
+
+        retry_count = 0
+
         while datetime.datetime.now() < stop_time:
+            retry_count += 1
             ret_code, out, err = run_command(["vtysh", "-c", "show daemons"], hide_errors=True)
+
             if ret_code == 0 and all(daemon in out for daemon in self.daemons):
-                log_info("All required daemons have connected to vtysh: %s" % str(datetime.datetime.now()))
+                elapsed = (datetime.datetime.now() - start_time).total_seconds()
+                log_info("All required daemons have connected to vtysh after %.1fs (attempt %d): %s" %
+                        (elapsed, retry_count, str(datetime.datetime.now())))
                 return
+
+            # Log status on each retry
+            current_time = datetime.datetime.now()
+            elapsed = (current_time - start_time).total_seconds()
+            remaining = (stop_time - current_time).total_seconds()
+
+            if ret_code == 0:
+                found_daemons = [d for d in self.daemons if d in out]
+                missing_daemons = [d for d in self.daemons if d not in out]
+                log_warn("Waiting for daemons (%.1fs elapsed, %.1fs remaining, attempt %d): found=%s missing=%s" %
+                        (elapsed, remaining, retry_count, found_daemons, missing_daemons))
             else:
-                log_warn("Can't read daemon status from FRR: %s" % str(err))
-            time.sleep(0.1)  # sleep 100 ms
+                log_warn("Can't read daemon status from FRR (%.1fs elapsed, %.1fs remaining, attempt %d): %s" %
+                        (elapsed, remaining, retry_count, str(err)))
+
+            time.sleep(1.0)
+
         raise RuntimeError("FRR daemons hasn't been started in %d seconds" % seconds)
 
     @staticmethod

--- a/src/sonic-bgpcfgd/bgpcfgd/frr.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/frr.py
@@ -25,32 +25,32 @@ class FRR(object):
         log_info("Required daemons: %s" % str(self.daemons))
 
         retry_count = 0
+        poll_interval = 0.1
+        next_log_time = start_time
 
         while datetime.datetime.now() < stop_time:
             retry_count += 1
             ret_code, out, err = run_command(["vtysh", "-c", "show daemons"], hide_errors=True)
-
-            if ret_code == 0 and all(daemon in out for daemon in self.daemons):
-                elapsed = (datetime.datetime.now() - start_time).total_seconds()
-                log_info("All required daemons have connected to vtysh after %.1fs (attempt %d): %s" %
-                        (elapsed, retry_count, str(datetime.datetime.now())))
-                return
-
-            # Log status on each retry
             current_time = datetime.datetime.now()
             elapsed = (current_time - start_time).total_seconds()
-            remaining = (stop_time - current_time).total_seconds()
 
-            if ret_code == 0:
-                found_daemons = [d for d in self.daemons if d in out]
-                missing_daemons = [d for d in self.daemons if d not in out]
-                log_warn("Waiting for daemons (%.1fs elapsed, %.1fs remaining, attempt %d): found=%s missing=%s" %
-                        (elapsed, remaining, retry_count, found_daemons, missing_daemons))
-            else:
-                log_warn("Can't read daemon status from FRR (%.1fs elapsed, %.1fs remaining, attempt %d): %s" %
-                        (elapsed, remaining, retry_count, str(err)))
+            if ret_code == 0 and all(daemon in out for daemon in self.daemons):
+                log_info("All required daemons have connected to vtysh after %.1fs (attempt %d): %s" %
+                        (elapsed, retry_count, str(current_time)))
+                return
 
-            time.sleep(1.0)
+            if current_time >= next_log_time:
+                if ret_code == 0:
+                    found_daemons = [d for d in self.daemons if d in out]
+                    missing_daemons = [d for d in self.daemons if d not in out]
+                    log_warn("Waiting for daemons (%.1fs elapsed, attempt %d): found=%s missing=%s" %
+                            (elapsed, retry_count, found_daemons, missing_daemons))
+                else:
+                    log_warn("Can't read daemon status from FRR (%.1fs elapsed, attempt %d): %s" %
+                            (elapsed, retry_count, str(err)))
+                next_log_time = current_time + datetime.timedelta(seconds=1)
+
+            time.sleep(poll_interval)
 
         raise RuntimeError("FRR daemons hasn't been started in %d seconds" % seconds)
 

--- a/src/sonic-bgpcfgd/bgpcfgd/main.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/main.py
@@ -44,7 +44,7 @@ def do_work():
     thr = threading.Thread(target = st_rt_timer.run)
     thr.start()
     frr = FRR(["bgpd", "zebra", "staticd"])
-    frr.wait_for_daemons(seconds=20)
+    frr.wait_for_daemons(seconds=120)
 
     # Wait for mgmtd initial config load to avoid "Lock already taken on DS" error
     log_notice("Checking mgmtd datastore readiness...")


### PR DESCRIPTION
Cherry Picking PR #25933 Enhance FRR daemon readiness monitoring with detailed diagnostics from sonic-net:master to sonic-buildimage-msft.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

