### PR TITLE
Cherry Pick PR #26506 : [snmp] Set v1trapaddress to avoid expensive get_myaddr() on every trap

### DIFF
--- a/dockers/docker-fpm-frr/snmp.conf
+++ b/dockers/docker-fpm-frr/snmp.conf
@@ -5,3 +5,7 @@
 # Check that a snmpwalk to 1.3.6.1.2.1.15 gives an output
 # Further verification: 1.3.6.1.2.1.15.2.0 = INTEGER: 65000 the returned value should be the confiugred ASN
 agentXSocket    tcp:localhost:3161
+# Set v1trapaddress to avoid the expensive net-snmp get_myaddr() ioctl
+# enumeration on every trap. The agent_addr field is only used in SNMPv1
+# TRAP PDUs and is discarded by AgentX before reaching the snmp container.
+v1trapaddress   169.254.0.1

--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -141,6 +141,14 @@ load   12 10 5
 #
 # Note: disabled snmp traps due to side effect of causing snmpd to listen on all ports (0.0.0.0)
 #
+# Set v1trapaddress to avoid the expensive net-snmp get_myaddr() ioctl
+# enumeration on every trap. The agent_addr field is only used in SNMPv1
+# TRAP PDUs; v2c/v3 does not have this field.
+# When a v1 trap receiver is configured, let snmpd resolve the real address.
+{% if not (SNMP_TRAP_CONFIG and SNMP_TRAP_CONFIG['v1TrapDest']) %}
+v1trapaddress 169.254.0.1
+{% endif %}
+#
 #   send SNMPv1  traps
 {% if SNMP_TRAP_CONFIG and SNMP_TRAP_CONFIG['v1TrapDest'] %}
 {% set v1SnmpTrapIp = SNMP_TRAP_CONFIG['v1TrapDest']['DestIp'] %}


### PR DESCRIPTION
Cherry Picking PR #26506 Set v1trapaddress to avoid expensive get_myaddr() on every trap from sonic-net:master to sonic-buildimage-msft.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

