### PR TITLE
[202506 cherry-pick] Add unnumber bgp support and prefix list yang support

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
@@ -14,15 +14,25 @@
   neighbor {{ neighbor_addr }} shutdown
 {% endif %}
 !
-{% if neighbor_addr | ipv4 %}
+{% if neighbor_addr | is_interface %}
+  neighbor {{ neighbor_addr }} interface peer-group PEER_UNNUMBERED
+{% if 'v6only' not in bgp_session or bgp_session['v6only'] != 'true' %}
+  address-family ipv4
+{%   if 'rrclient' in bgp_session and bgp_session['rrclient'] | int != 0 %}
+    neighbor {{ neighbor_addr }} route-reflector-client
+{%   endif %}
+    neighbor {{ neighbor_addr }} activate
+  exit-address-family
+{% endif %}
+  address-family ipv6
+{%   if 'rrclient' in bgp_session and bgp_session['rrclient'] | int != 0 %}
+    neighbor {{ neighbor_addr }} route-reflector-client
+{%   endif %}
+    neighbor {{ neighbor_addr }} activate
+  exit-address-family
+{% elif neighbor_addr | ipv4 %}
   address-family ipv4
     neighbor {{ neighbor_addr }} peer-group PEER_V4
-!
-{% elif neighbor_addr | ipv6 %}
-  address-family ipv6
-    neighbor {{ neighbor_addr }} peer-group PEER_V6
-!
-{% endif %}
 !
 {%   if 'rrclient' in bgp_session and bgp_session['rrclient'] | int != 0 %}
     neighbor {{ neighbor_addr }} route-reflector-client
@@ -34,6 +44,21 @@
 !
     neighbor {{ neighbor_addr }} activate
   exit-address-family
+{% elif neighbor_addr | ipv6 %}
+  address-family ipv6
+    neighbor {{ neighbor_addr }} peer-group PEER_V6
+!
+{%   if 'rrclient' in bgp_session and bgp_session['rrclient'] | int != 0 %}
+    neighbor {{ neighbor_addr }} route-reflector-client
+{%   endif %}
+!
+{%   if 'nhopself' in bgp_session and bgp_session['nhopself'] | int != 0 %}
+    neighbor {{ neighbor_addr }} next-hop-self
+{%   endif %}
+!
+    neighbor {{ neighbor_addr }} activate
+  exit-address-family
+{% endif %}
 !
 {% if bgp_session["asn"] == bgp_asn and CONFIG_DB__DEVICE_METADATA['localhost']['type'] == "SpineChassisFrontendRouter" %}
   address-family l2vpn evpn

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/peer-group.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/peer-group.conf.j2
@@ -3,17 +3,24 @@
 !
   neighbor PEER_V4 peer-group
   neighbor PEER_V6 peer-group
+  neighbor PEER_UNNUMBERED peer-group
+  neighbor PEER_UNNUMBERED capability extended-nexthop
   address-family ipv4
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
     neighbor PEER_V4 allowas-in 1
+    neighbor PEER_UNNUMBERED allowas-in 1
 {% elif CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'LeafRouter' %}
 {%   if CONFIG_DB__BGP_BBR['status'] == 'enabled' %}
     neighbor PEER_V4 allowas-in 1
+    neighbor PEER_UNNUMBERED allowas-in 1
 {%   endif %}
 {% endif %}
     neighbor PEER_V4 soft-reconfiguration inbound
     neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
     neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V4 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V4 out
 {% if (CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'UpstreamLC') or CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperSpineRouter' %}
     table-map SELECTIVE_ROUTE_DOWNLOAD_V4
 {% endif %}
@@ -21,14 +28,19 @@
   address-family ipv6
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
     neighbor PEER_V6 allowas-in 1
+    neighbor PEER_UNNUMBERED allowas-in 1
 {% elif CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'LeafRouter' %}
 {%   if CONFIG_DB__BGP_BBR['status'] == 'enabled' %}
     neighbor PEER_V6 allowas-in 1
+    neighbor PEER_UNNUMBERED allowas-in 1
 {%   endif %}
 {% endif %}
     neighbor PEER_V6 soft-reconfiguration inbound
     neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
     neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V6 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V6 out
 {% if (CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'UpstreamLC') or CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperSpineRouter' %}
     table-map SELECTIVE_ROUTE_DOWNLOAD_V6
 {% endif %}

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/internal/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/internal/instance.conf.j2
@@ -6,7 +6,23 @@
   neighbor {{ neighbor_addr }} timers 3 10
   neighbor {{ neighbor_addr }} timers connect 10
 !
-{% if neighbor_addr | ipv4 %}
+{% if neighbor_addr | is_interface %}
+  neighbor {{ neighbor_addr }} interface peer-group PEER_UNNUMBERED
+{% if 'v6only' not in bgp_session or bgp_session['v6only'] != 'true' %}
+  address-family ipv4
+{%   if 'rrclient' in bgp_session and bgp_session['rrclient'] | int != 0 %}
+    neighbor {{ neighbor_addr }} route-reflector-client
+{%   endif %}
+    neighbor {{ neighbor_addr }} activate
+  exit-address-family
+{% endif %}
+  address-family ipv6
+{%   if 'rrclient' in bgp_session and bgp_session['rrclient'] | int != 0 %}
+    neighbor {{ neighbor_addr }} route-reflector-client
+{%   endif %}
+    neighbor {{ neighbor_addr }} activate
+  exit-address-family
+{% elif neighbor_addr | ipv4 %}
   address-family ipv4
     neighbor {{ neighbor_addr }} peer-group INTERNAL_PEER_V4
 !
@@ -14,6 +30,12 @@
     neighbor {{ neighbor_addr }} next-hop-self force
 {%   endif %}
 !
+{%   if 'rrclient' in bgp_session and bgp_session['rrclient'] | int != 0 %}
+    neighbor {{ neighbor_addr }} route-reflector-client
+{%   endif %}
+!
+    neighbor {{ neighbor_addr }} activate
+  exit-address-family
 {% elif neighbor_addr | ipv6 %}
   address-family ipv6
     neighbor {{ neighbor_addr }} peer-group INTERNAL_PEER_V6
@@ -21,15 +43,14 @@
 {%   if CONFIG_DB__DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' or CONFIG_DB__DEVICE_METADATA['localhost']['switch_type'] == 'chassis-packet' %}
     neighbor {{ neighbor_addr }} next-hop-self force
 {%   endif %}
-{% endif %}
 !
 {%   if 'rrclient' in bgp_session and bgp_session['rrclient'] | int != 0 %}
     neighbor {{ neighbor_addr }} route-reflector-client
 {%   endif %}
 !
-!
     neighbor {{ neighbor_addr }} activate
   exit-address-family
+{% endif %}
 !
 ! end of template: bgpd/templates/internal/instance.conf.j2
 !

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/internal/peer-group.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/internal/peer-group.conf.j2
@@ -3,6 +3,8 @@
 !
   neighbor INTERNAL_PEER_V4 peer-group
   neighbor INTERNAL_PEER_V6 peer-group
+  neighbor PEER_UNNUMBERED peer-group
+  neighbor PEER_UNNUMBERED capability extended-nexthop
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['switch_type'] == 'chassis-packet' %}
   neighbor INTERNAL_PEER_V4 update-source Loopback4096
   neighbor INTERNAL_PEER_V4 ttl-security hops 1
@@ -16,6 +18,11 @@
     neighbor INTERNAL_PEER_V4 route-map FROM_BGP_INTERNAL_PEER_V4 in
     neighbor INTERNAL_PEER_V4 route-map TO_BGP_INTERNAL_PEER_V4 out
     neighbor INTERNAL_PEER_V4 send-community
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED allowas-in 1
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_INTERNAL_PEER_V4 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_INTERNAL_PEER_V4 out
+    neighbor PEER_UNNUMBERED send-community
   exit-address-family
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['switch_type'] == 'chassis-packet' %}
   neighbor INTERNAL_PEER_V6 update-source Loopback4096
@@ -30,6 +37,11 @@
     neighbor INTERNAL_PEER_V6 route-map FROM_BGP_INTERNAL_PEER_V6 in
     neighbor INTERNAL_PEER_V6 route-map TO_BGP_INTERNAL_PEER_V6 out
     neighbor INTERNAL_PEER_V6 send-community
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED allowas-in 1
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_INTERNAL_PEER_V6 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_INTERNAL_PEER_V6 out
+    neighbor PEER_UNNUMBERED send-community
   exit-address-family
 !
 ! end of template: bgpd/templates/internal/peer-group.conf.j2

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/voq_chassis/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/voq_chassis/instance.conf.j2
@@ -4,7 +4,18 @@
   bgp bestpath as-path multipath-relax
   bgp bestpath peer-type multipath-relax
 !
-{% if neighbor_addr | ipv4 %}
+{% if neighbor_addr | is_interface %}
+  neighbor {{ neighbor_addr }} interface peer-group PEER_UNNUMBERED
+  neighbor {{ neighbor_addr }} remote-as {{ bgp_session['asn'] }}
+{% if 'v6only' not in bgp_session or bgp_session['v6only'] != 'true' %}
+  address-family ipv4
+    neighbor {{ neighbor_addr }} activate
+  exit-address-family
+{% endif %}
+  address-family ipv6
+    neighbor {{ neighbor_addr }} activate
+  exit-address-family
+{% elif neighbor_addr | ipv4 %}
   neighbor {{ neighbor_addr }} peer-group VOQ_CHASSIS_V4_PEER
 {% elif neighbor_addr | ipv6 %}
   neighbor {{ neighbor_addr }} peer-group VOQ_CHASSIS_V6_PEER

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/voq_chassis/peer-group.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/voq_chassis/peer-group.conf.j2
@@ -3,9 +3,12 @@
 !
   neighbor VOQ_CHASSIS_V4_PEER peer-group
   neighbor VOQ_CHASSIS_V6_PEER peer-group
+  neighbor PEER_UNNUMBERED peer-group
+  neighbor PEER_UNNUMBERED capability extended-nexthop
   address-family ipv4
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
     neighbor VOQ_CHASSIS_V4_PEER allowas-in 1
+    neighbor PEER_UNNUMBERED allowas-in 1
 {% endif %}
     neighbor VOQ_CHASSIS_V4_PEER activate
     neighbor VOQ_CHASSIS_V4_PEER addpath-tx-all-paths
@@ -13,10 +16,16 @@
     neighbor VOQ_CHASSIS_V4_PEER route-map FROM_VOQ_CHASSIS_V4_PEER in
     neighbor VOQ_CHASSIS_V4_PEER route-map TO_VOQ_CHASSIS_V4_PEER out
     neighbor VOQ_CHASSIS_V4_PEER send-community
+    neighbor PEER_UNNUMBERED addpath-tx-all-paths
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_VOQ_CHASSIS_V4_PEER in
+    neighbor PEER_UNNUMBERED route-map TO_VOQ_CHASSIS_V4_PEER out
+    neighbor PEER_UNNUMBERED send-community
   exit-address-family
   address-family ipv6
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
     neighbor VOQ_CHASSIS_V6_PEER allowas-in 1
+    neighbor PEER_UNNUMBERED allowas-in 1
 {% endif %}
     neighbor VOQ_CHASSIS_V6_PEER activate
     neighbor VOQ_CHASSIS_V6_PEER addpath-tx-all-paths
@@ -24,6 +33,11 @@
     neighbor VOQ_CHASSIS_V6_PEER route-map FROM_VOQ_CHASSIS_V6_PEER in
     neighbor VOQ_CHASSIS_V6_PEER route-map TO_VOQ_CHASSIS_V6_PEER out
     neighbor VOQ_CHASSIS_V6_PEER send-community
+    neighbor PEER_UNNUMBERED addpath-tx-all-paths
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_VOQ_CHASSIS_V6_PEER in
+    neighbor PEER_UNNUMBERED route-map TO_VOQ_CHASSIS_V6_PEER out
+    neighbor PEER_UNNUMBERED send-community
   exit-address-family
 !
 ! end of template: bgpd/templates/voq_chassis/peer-group.conf.j2

--- a/files/image_config/constants/constants.yml
+++ b/files/image_config/constants/constants.yml
@@ -50,6 +50,9 @@ constants:
             - ipv4
           PEER_V6:
             - ipv6
+          PEER_UNNUMBERED:
+            - ipv4
+            - ipv6
       internal: # peer_type
         db_table: "BGP_INTERNAL_NEIGHBOR"
         template_dir: "internal"

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
@@ -1,4 +1,5 @@
 import json
+import re
 from swsscommon import swsscommon
 
 import jinja2
@@ -10,6 +11,15 @@ from .manager import Manager
 from .template import TemplateFabric
 from .utils import run_command
 from .managers_device_global import DeviceGlobalCfgMgr
+
+INTERFACE_PATTERN = re.compile(r'^(Ethernet|PortChannel|Vlan|Po)\d+(\.\d+)?$')
+
+
+def is_interface_neighbor(neighbor):
+    """Return True if neighbor key is an interface name, not an IP address."""
+    if not neighbor:
+        return False
+    return bool(INTERFACE_PATTERN.match(neighbor))
 
 
 class BGPPeerGroupMgr(object):
@@ -192,7 +202,10 @@ class BGPPeerMgrBase(Manager):
                 log_warn("Loopback4096 ipv4 address is not presented yet and bgp_router_id not configured")
                 return False
 
-        if "local_addr" not in data:
+        if is_interface_neighbor(nbr):
+            # Interface-based (unnumbered) neighbor: skip local_addr validation
+            pass
+        elif "local_addr" not in data:
             log_warn("Peer %s. Missing attribute 'local_addr'" % nbr)
         else:
             data["local_addr"] = str(netaddr.IPNetwork(str(data["local_addr"])).ip)

--- a/src/sonic-bgpcfgd/bgpcfgd/template.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/template.py
@@ -14,6 +14,7 @@ class TemplateFabric(object):
         j2_env = jinja2.Environment(loader=j2_loader, trim_blocks=False)
         j2_env.filters['ipv4'] = self.is_ipv4
         j2_env.filters['ipv6'] = self.is_ipv6
+        j2_env.filters['is_interface'] = self.is_interface
         j2_env.filters['pfx_filter'] = self.pfx_filter
         for attr in ['ip', 'network', 'prefixlen', 'netmask']:
             j2_env.filters[attr] = partial(self.prefix_attr, attr)
@@ -62,6 +63,14 @@ class TemplateFabric(object):
             except (netaddr.NotRegisteredError, netaddr.AddrFormatError, netaddr.AddrConversionError):
                 return False
         return addr.version == 6
+
+    @staticmethod
+    def is_interface(value):
+        """ Return True if the value is an interface name (Ethernet, PortChannel, Vlan) """
+        if not value:
+            return False
+        import re
+        return bool(re.match(r'^(Ethernet|PortChannel|Vlan|Po)\d+(\.\d+)?$', str(value)))
 
     @staticmethod
     def prefix_attr(attr, value):

--- a/src/sonic-bgpcfgd/tests/data/constants/constants_use_neig.yml
+++ b/src/sonic-bgpcfgd/tests/data/constants/constants_use_neig.yml
@@ -41,6 +41,9 @@ constants:
             - ipv4
           PEER_V6:
             - ipv6
+          PEER_UNNUMBERED:
+            - ipv4
+            - ipv6
       internal: # peer_type
         db_table: "BGP_INTERNAL_NEIGHBOR"
         template_dir: "internal"

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/param_unnumbered.json
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/param_unnumbered.json
@@ -1,0 +1,16 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {}
+    },
+    "neighbor_addr": "PortChannel101",
+    "bgp_session": {
+        "asn": "65200",
+        "name": "spine1"
+    },
+    "bgp_asn": "65100",
+    "constants": {
+        "deployment_id_asn_map": {
+            "5": "51111"
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/param_unnumbered_v6only.json
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/param_unnumbered_v6only.json
@@ -1,0 +1,17 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {}
+    },
+    "neighbor_addr": "Ethernet0",
+    "bgp_session": {
+        "asn": "65200",
+        "name": "spine2",
+        "v6only": "true"
+    },
+    "bgp_asn": "65100",
+    "constants": {
+        "deployment_id_asn_map": {
+            "5": "51111"
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_unnumbered.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_unnumbered.conf
@@ -1,0 +1,17 @@
+!
+! template: bgpd/templates/general/instance.conf.j2
+!
+  neighbor PortChannel101 remote-as 65200
+  neighbor PortChannel101 description spine1
+  neighbor PortChannel101 timers connect 10
+!
+  neighbor PortChannel101 interface peer-group PEER_UNNUMBERED
+  address-family ipv4
+    neighbor PortChannel101 activate
+  exit-address-family
+  address-family ipv6
+    neighbor PortChannel101 activate
+  exit-address-family
+!
+! end of template: bgpd/templates/general/instance.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_unnumbered_v6only.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_unnumbered_v6only.conf
@@ -1,0 +1,14 @@
+!
+! template: bgpd/templates/general/instance.conf.j2
+!
+  neighbor Ethernet0 remote-as 65200
+  neighbor Ethernet0 description spine2
+  neighbor Ethernet0 timers connect 10
+!
+  neighbor Ethernet0 interface peer-group PEER_UNNUMBERED
+  address-family ipv6
+    neighbor Ethernet0 activate
+  exit-address-family
+!
+! end of template: bgpd/templates/general/instance.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_UpperSpineRouter.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_UpperSpineRouter.conf
@@ -3,16 +3,24 @@
 !
   neighbor PEER_V4 peer-group
   neighbor PEER_V6 peer-group
+  neighbor PEER_UNNUMBERED peer-group
+  neighbor PEER_UNNUMBERED capability extended-nexthop
   address-family ipv4
     neighbor PEER_V4 soft-reconfiguration inbound
     neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
     neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V4 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V4 out
     table-map SELECTIVE_ROUTE_DOWNLOAD_V4
   exit-address-family
   address-family ipv6
     neighbor PEER_V6 soft-reconfiguration inbound
     neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
     neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V6 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V6 out
     table-map SELECTIVE_ROUTE_DOWNLOAD_V6
   exit-address-family
 !

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_all.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_all.conf
@@ -3,17 +3,27 @@
 !
   neighbor PEER_V4 peer-group
   neighbor PEER_V6 peer-group
+  neighbor PEER_UNNUMBERED peer-group
+  neighbor PEER_UNNUMBERED capability extended-nexthop
   address-family ipv4
     neighbor PEER_V4 allowas-in 1
+    neighbor PEER_UNNUMBERED allowas-in 1
     neighbor PEER_V4 soft-reconfiguration inbound
     neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
     neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V4 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V4 out
   exit-address-family
   address-family ipv6
     neighbor PEER_V6 allowas-in 1
+    neighbor PEER_UNNUMBERED allowas-in 1
     neighbor PEER_V6 soft-reconfiguration inbound
     neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
     neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V6 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V6 out
   exit-address-family
 !
 ! end of template: bgpd/templates/general/peer-group.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_all_idf_isolated_no_export.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_all_idf_isolated_no_export.conf
@@ -3,17 +3,27 @@
 !
   neighbor PEER_V4 peer-group
   neighbor PEER_V6 peer-group
+  neighbor PEER_UNNUMBERED peer-group
+  neighbor PEER_UNNUMBERED capability extended-nexthop
   address-family ipv4
     neighbor PEER_V4 allowas-in 1
+    neighbor PEER_UNNUMBERED allowas-in 1
     neighbor PEER_V4 soft-reconfiguration inbound
     neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
     neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V4 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V4 out
   exit-address-family
   address-family ipv6
     neighbor PEER_V6 allowas-in 1
+    neighbor PEER_UNNUMBERED allowas-in 1
     neighbor PEER_V6 soft-reconfiguration inbound
     neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
     neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V6 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V6 out
   exit-address-family
 !
 ! end of template: bgpd/templates/general/peer-group.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_all_idf_isolated_withdraw_all.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_all_idf_isolated_withdraw_all.conf
@@ -3,17 +3,27 @@
 !
   neighbor PEER_V4 peer-group
   neighbor PEER_V6 peer-group
+  neighbor PEER_UNNUMBERED peer-group
+  neighbor PEER_UNNUMBERED capability extended-nexthop
   address-family ipv4
     neighbor PEER_V4 allowas-in 1
+    neighbor PEER_UNNUMBERED allowas-in 1
     neighbor PEER_V4 soft-reconfiguration inbound
     neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
     neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V4 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V4 out
   exit-address-family
   address-family ipv6
     neighbor PEER_V6 allowas-in 1
+    neighbor PEER_UNNUMBERED allowas-in 1
     neighbor PEER_V6 soft-reconfiguration inbound
     neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
     neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V6 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V6 out
   exit-address-family
 !
 ! end of template: bgpd/templates/general/peer-group.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_all_idf_unisolated.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_all_idf_unisolated.conf
@@ -3,17 +3,27 @@
 !
   neighbor PEER_V4 peer-group
   neighbor PEER_V6 peer-group
+  neighbor PEER_UNNUMBERED peer-group
+  neighbor PEER_UNNUMBERED capability extended-nexthop
   address-family ipv4
     neighbor PEER_V4 allowas-in 1
+    neighbor PEER_UNNUMBERED allowas-in 1
     neighbor PEER_V4 soft-reconfiguration inbound
     neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
     neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V4 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V4 out
   exit-address-family
   address-family ipv6
     neighbor PEER_V6 allowas-in 1
+    neighbor PEER_UNNUMBERED allowas-in 1
     neighbor PEER_V6 soft-reconfiguration inbound
     neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
     neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V6 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V6 out
   exit-address-family
 !
 ! end of template: bgpd/templates/general/peer-group.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_all_isolate.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_all_isolate.conf
@@ -3,22 +3,31 @@
 !
   neighbor PEER_V4 peer-group
   neighbor PEER_V6 peer-group
+  neighbor PEER_UNNUMBERED peer-group
+  neighbor PEER_UNNUMBERED capability extended-nexthop
   address-family ipv4
     neighbor PEER_V4 allowas-in 1
+    neighbor PEER_UNNUMBERED allowas-in 1
     neighbor PEER_V4 soft-reconfiguration inbound
     neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
     neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V4 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V4 out
   exit-address-family
   address-family ipv6
     neighbor PEER_V6 allowas-in 1
+    neighbor PEER_UNNUMBERED allowas-in 1
     neighbor PEER_V6 soft-reconfiguration inbound
     neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
     neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V6 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V6 out
   exit-address-family
 !
 ! end of template: bgpd/templates/general/peer-group.conf.j2
 !
-
 
 route-map TO_BGP_PEER_V4 permit 20
   match ip address prefix-list PL_LoopbackV4

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_all_unisolate.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_all_unisolate.conf
@@ -3,22 +3,31 @@
 !
   neighbor PEER_V4 peer-group
   neighbor PEER_V6 peer-group
+  neighbor PEER_UNNUMBERED peer-group
+  neighbor PEER_UNNUMBERED capability extended-nexthop
   address-family ipv4
     neighbor PEER_V4 allowas-in 1
+    neighbor PEER_UNNUMBERED allowas-in 1
     neighbor PEER_V4 soft-reconfiguration inbound
     neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
     neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V4 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V4 out
   exit-address-family
   address-family ipv6
     neighbor PEER_V6 allowas-in 1
+    neighbor PEER_UNNUMBERED allowas-in 1
     neighbor PEER_V6 soft-reconfiguration inbound
     neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
     neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V6 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V6 out
   exit-address-family
 !
 ! end of template: bgpd/templates/general/peer-group.conf.j2
 !
-
 
 no route-map TO_BGP_PEER_V4 permit 20
 no route-map TO_BGP_PEER_V4 permit 30
@@ -28,4 +37,3 @@ no route-map TO_BGP_PEER_V6 permit 20
 no route-map TO_BGP_PEER_V6 permit 30
 no route-map TO_BGP_PEER_V6 deny 40
 !
-

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_base.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_base.conf
@@ -3,15 +3,23 @@
 !
   neighbor PEER_V4 peer-group
   neighbor PEER_V6 peer-group
+  neighbor PEER_UNNUMBERED peer-group
+  neighbor PEER_UNNUMBERED capability extended-nexthop
   address-family ipv4
     neighbor PEER_V4 soft-reconfiguration inbound
     neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
     neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V4 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V4 out
   exit-address-family
   address-family ipv6
     neighbor PEER_V6 soft-reconfiguration inbound
     neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
     neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V6 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V6 out
   exit-address-family
 !
 ! end of template: bgpd/templates/general/peer-group.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_downstream_lc.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_downstream_lc.conf
@@ -3,15 +3,23 @@
 !
   neighbor PEER_V4 peer-group
   neighbor PEER_V6 peer-group
+  neighbor PEER_UNNUMBERED peer-group
+  neighbor PEER_UNNUMBERED capability extended-nexthop
   address-family ipv4
     neighbor PEER_V4 soft-reconfiguration inbound
     neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
     neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V4 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V4 out
   exit-address-family
   address-family ipv6
     neighbor PEER_V6 soft-reconfiguration inbound
     neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
     neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V6 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V6 out
   exit-address-family
 !
 ! end of template: bgpd/templates/general/peer-group.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_spine_no_subtype.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_spine_no_subtype.conf
@@ -3,15 +3,23 @@
 !
   neighbor PEER_V4 peer-group
   neighbor PEER_V6 peer-group
+  neighbor PEER_UNNUMBERED peer-group
+  neighbor PEER_UNNUMBERED capability extended-nexthop
   address-family ipv4
     neighbor PEER_V4 soft-reconfiguration inbound
     neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
     neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V4 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V4 out
   exit-address-family
   address-family ipv6
     neighbor PEER_V6 soft-reconfiguration inbound
     neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
     neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V6 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V6 out
   exit-address-family
 !
 ! end of template: bgpd/templates/general/peer-group.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_upstream_lc.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_upstream_lc.conf
@@ -3,16 +3,24 @@
 !
   neighbor PEER_V4 peer-group
   neighbor PEER_V6 peer-group
+  neighbor PEER_UNNUMBERED peer-group
+  neighbor PEER_UNNUMBERED capability extended-nexthop
   address-family ipv4
     neighbor PEER_V4 soft-reconfiguration inbound
     neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
     neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V4 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V4 out
     table-map SELECTIVE_ROUTE_DOWNLOAD_V4
   exit-address-family
   address-family ipv6
     neighbor PEER_V6 soft-reconfiguration inbound
     neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
     neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_V6 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_V6 out
     table-map SELECTIVE_ROUTE_DOWNLOAD_V6
   exit-address-family
 !

--- a/src/sonic-bgpcfgd/tests/data/internal/instance.conf/param_unnumbered.json
+++ b/src/sonic-bgpcfgd/tests/data/internal/instance.conf/param_unnumbered.json
@@ -1,0 +1,13 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {
+            "switch_type": "switch"
+        }
+    },
+    "neighbor_addr": "PortChannel101",
+    "bgp_session": {
+        "asn": "65100",
+        "name": "peer_switch"
+    },
+    "bgp_asn": "65100"
+}

--- a/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_unnumbered.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_unnumbered.conf
@@ -1,0 +1,18 @@
+!
+! template: bgpd/templates/internal/instance.conf.j2
+!
+  neighbor PortChannel101 remote-as 65100
+  neighbor PortChannel101 description peer_switch
+  neighbor PortChannel101 timers 3 10
+  neighbor PortChannel101 timers connect 10
+!
+  neighbor PortChannel101 interface peer-group PEER_UNNUMBERED
+  address-family ipv4
+    neighbor PortChannel101 activate
+  exit-address-family
+  address-family ipv6
+    neighbor PortChannel101 activate
+  exit-address-family
+!
+! end of template: bgpd/templates/internal/instance.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_back.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_back.conf
@@ -3,6 +3,8 @@
 !
   neighbor INTERNAL_PEER_V4 peer-group
   neighbor INTERNAL_PEER_V6 peer-group
+  neighbor PEER_UNNUMBERED peer-group
+  neighbor PEER_UNNUMBERED capability extended-nexthop
   address-family ipv4
     neighbor INTERNAL_PEER_V4 route-reflector-client
     neighbor INTERNAL_PEER_V4 soft-reconfiguration inbound
@@ -10,6 +12,11 @@
     neighbor INTERNAL_PEER_V4 route-map FROM_BGP_INTERNAL_PEER_V4 in
     neighbor INTERNAL_PEER_V4 route-map TO_BGP_INTERNAL_PEER_V4 out
     neighbor INTERNAL_PEER_V4 send-community
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED allowas-in 1
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_INTERNAL_PEER_V4 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_INTERNAL_PEER_V4 out
+    neighbor PEER_UNNUMBERED send-community
   exit-address-family
   address-family ipv6
     neighbor INTERNAL_PEER_V6 route-reflector-client
@@ -18,6 +25,11 @@
     neighbor INTERNAL_PEER_V6 route-map FROM_BGP_INTERNAL_PEER_V6 in
     neighbor INTERNAL_PEER_V6 route-map TO_BGP_INTERNAL_PEER_V6 out
     neighbor INTERNAL_PEER_V6 send-community
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED allowas-in 1
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_INTERNAL_PEER_V6 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_INTERNAL_PEER_V6 out
+    neighbor PEER_UNNUMBERED send-community
   exit-address-family
 !
 ! end of template: bgpd/templates/internal/peer-group.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_chasiss_packet.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_chasiss_packet.conf
@@ -3,6 +3,8 @@
 !
   neighbor INTERNAL_PEER_V4 peer-group
   neighbor INTERNAL_PEER_V6 peer-group
+  neighbor PEER_UNNUMBERED peer-group
+  neighbor PEER_UNNUMBERED capability extended-nexthop
   neighbor INTERNAL_PEER_V4 update-source Loopback4096
   neighbor INTERNAL_PEER_V4 ttl-security hops 1
   address-family ipv4
@@ -11,6 +13,11 @@
     neighbor INTERNAL_PEER_V4 route-map FROM_BGP_INTERNAL_PEER_V4 in
     neighbor INTERNAL_PEER_V4 route-map TO_BGP_INTERNAL_PEER_V4 out
     neighbor INTERNAL_PEER_V4 send-community
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED allowas-in 1
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_INTERNAL_PEER_V4 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_INTERNAL_PEER_V4 out
+    neighbor PEER_UNNUMBERED send-community
   exit-address-family
   neighbor INTERNAL_PEER_V6 update-source Loopback4096
   neighbor INTERNAL_PEER_V6 ttl-security hops 1
@@ -20,6 +27,11 @@
     neighbor INTERNAL_PEER_V6 route-map FROM_BGP_INTERNAL_PEER_V6 in
     neighbor INTERNAL_PEER_V6 route-map TO_BGP_INTERNAL_PEER_V6 out
     neighbor INTERNAL_PEER_V6 send-community
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED allowas-in 1
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_INTERNAL_PEER_V6 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_INTERNAL_PEER_V6 out
+    neighbor PEER_UNNUMBERED send-community
   exit-address-family
 !
 ! end of template: bgpd/templates/internal/peer-group.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_chassis_packet_isolate.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_chassis_packet_isolate.conf
@@ -3,6 +3,8 @@
 !
   neighbor INTERNAL_PEER_V4 peer-group
   neighbor INTERNAL_PEER_V6 peer-group
+  neighbor PEER_UNNUMBERED peer-group
+  neighbor PEER_UNNUMBERED capability extended-nexthop
   neighbor INTERNAL_PEER_V4 update-source Loopback4096
   neighbor INTERNAL_PEER_V4 ttl-security hops 1
   address-family ipv4
@@ -11,6 +13,11 @@
     neighbor INTERNAL_PEER_V4 route-map FROM_BGP_INTERNAL_PEER_V4 in
     neighbor INTERNAL_PEER_V4 route-map TO_BGP_INTERNAL_PEER_V4 out
     neighbor INTERNAL_PEER_V4 send-community
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED allowas-in 1
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_INTERNAL_PEER_V4 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_INTERNAL_PEER_V4 out
+    neighbor PEER_UNNUMBERED send-community
   exit-address-family
   neighbor INTERNAL_PEER_V6 update-source Loopback4096
   neighbor INTERNAL_PEER_V6 ttl-security hops 1
@@ -20,6 +27,11 @@
     neighbor INTERNAL_PEER_V6 route-map FROM_BGP_INTERNAL_PEER_V6 in
     neighbor INTERNAL_PEER_V6 route-map TO_BGP_INTERNAL_PEER_V6 out
     neighbor INTERNAL_PEER_V6 send-community
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED allowas-in 1
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_INTERNAL_PEER_V6 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_INTERNAL_PEER_V6 out
+    neighbor PEER_UNNUMBERED send-community
   exit-address-family
 !
 ! end of template: bgpd/templates/internal/peer-group.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_chassis_packet_unisolate.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_chassis_packet_unisolate.conf
@@ -3,6 +3,8 @@
 !
   neighbor INTERNAL_PEER_V4 peer-group
   neighbor INTERNAL_PEER_V6 peer-group
+  neighbor PEER_UNNUMBERED peer-group
+  neighbor PEER_UNNUMBERED capability extended-nexthop
   neighbor INTERNAL_PEER_V4 update-source Loopback4096
   neighbor INTERNAL_PEER_V4 ttl-security hops 1
   address-family ipv4
@@ -11,6 +13,11 @@
     neighbor INTERNAL_PEER_V4 route-map FROM_BGP_INTERNAL_PEER_V4 in
     neighbor INTERNAL_PEER_V4 route-map TO_BGP_INTERNAL_PEER_V4 out
     neighbor INTERNAL_PEER_V4 send-community
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED allowas-in 1
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_INTERNAL_PEER_V4 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_INTERNAL_PEER_V4 out
+    neighbor PEER_UNNUMBERED send-community
   exit-address-family
   neighbor INTERNAL_PEER_V6 update-source Loopback4096
   neighbor INTERNAL_PEER_V6 ttl-security hops 1
@@ -20,6 +27,11 @@
     neighbor INTERNAL_PEER_V6 route-map FROM_BGP_INTERNAL_PEER_V6 in
     neighbor INTERNAL_PEER_V6 route-map TO_BGP_INTERNAL_PEER_V6 out
     neighbor INTERNAL_PEER_V6 send-community
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED allowas-in 1
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_INTERNAL_PEER_V6 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_INTERNAL_PEER_V6 out
+    neighbor PEER_UNNUMBERED send-community
   exit-address-family
 !
 ! end of template: bgpd/templates/internal/peer-group.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_front.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_front.conf
@@ -3,12 +3,19 @@
 !
   neighbor INTERNAL_PEER_V4 peer-group
   neighbor INTERNAL_PEER_V6 peer-group
+  neighbor PEER_UNNUMBERED peer-group
+  neighbor PEER_UNNUMBERED capability extended-nexthop
   address-family ipv4
     neighbor INTERNAL_PEER_V4 soft-reconfiguration inbound
     neighbor INTERNAL_PEER_V4 allowas-in 1
     neighbor INTERNAL_PEER_V4 route-map FROM_BGP_INTERNAL_PEER_V4 in
     neighbor INTERNAL_PEER_V4 route-map TO_BGP_INTERNAL_PEER_V4 out
     neighbor INTERNAL_PEER_V4 send-community
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED allowas-in 1
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_INTERNAL_PEER_V4 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_INTERNAL_PEER_V4 out
+    neighbor PEER_UNNUMBERED send-community
   exit-address-family
   address-family ipv6
     neighbor INTERNAL_PEER_V6 soft-reconfiguration inbound
@@ -16,6 +23,11 @@
     neighbor INTERNAL_PEER_V6 route-map FROM_BGP_INTERNAL_PEER_V6 in
     neighbor INTERNAL_PEER_V6 route-map TO_BGP_INTERNAL_PEER_V6 out
     neighbor INTERNAL_PEER_V6 send-community
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED allowas-in 1
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_INTERNAL_PEER_V6 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_INTERNAL_PEER_V6 out
+    neighbor PEER_UNNUMBERED send-community
   exit-address-family
 !
 ! end of template: bgpd/templates/internal/peer-group.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/param_unnumbered.json
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/param_unnumbered.json
@@ -1,0 +1,23 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {
+            "type": "SpineRouter",
+            "bgp_asn": "65100"
+        }
+    },
+    "neighbor_addr": "Ethernet0",
+    "bgp_session": {
+        "asn": "65100",
+        "name": "lc_peer"
+    },
+    "bgp_asn": "65100",
+    "constants": {
+        "bgp": {
+            "maximum_paths": {
+                "enabled": true,
+                "ipv4": 64,
+                "ipv6": 64
+            }
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_unnumbered.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_unnumbered.conf
@@ -1,0 +1,30 @@
+!
+! template: bgpd/templates/voq_chassis/instance.conf.j2
+!
+  bgp bestpath as-path multipath-relax
+  bgp bestpath peer-type multipath-relax
+!
+  neighbor Ethernet0 interface peer-group PEER_UNNUMBERED
+  neighbor Ethernet0 remote-as 65100
+  address-family ipv4
+    neighbor Ethernet0 activate
+  exit-address-family
+  address-family ipv6
+    neighbor Ethernet0 activate
+  exit-address-family
+  neighbor Ethernet0 description lc_peer
+  neighbor Ethernet0 timers 2 7
+  neighbor Ethernet0 timers connect 10
+!
+  address-family ipv4
+    maximum-paths ibgp 64
+!
+  exit-address-family
+!
+  address-family ipv6
+    maximum-paths ibgp 64
+!
+  exit-address-family
+!
+! end of template: bgpd/templates/voq_chassis/instance.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/peer-group.conf/result_all.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/peer-group.conf/result_all.conf
@@ -3,23 +3,37 @@
 !
   neighbor VOQ_CHASSIS_V4_PEER peer-group
   neighbor VOQ_CHASSIS_V6_PEER peer-group
+  neighbor PEER_UNNUMBERED peer-group
+  neighbor PEER_UNNUMBERED capability extended-nexthop
   address-family ipv4
     neighbor VOQ_CHASSIS_V4_PEER allowas-in 1
+    neighbor PEER_UNNUMBERED allowas-in 1
     neighbor VOQ_CHASSIS_V4_PEER activate
     neighbor VOQ_CHASSIS_V4_PEER addpath-tx-all-paths
     neighbor VOQ_CHASSIS_V4_PEER soft-reconfiguration inbound
     neighbor VOQ_CHASSIS_V4_PEER route-map FROM_VOQ_CHASSIS_V4_PEER in
     neighbor VOQ_CHASSIS_V4_PEER route-map TO_VOQ_CHASSIS_V4_PEER out
     neighbor VOQ_CHASSIS_V4_PEER send-community
+    neighbor PEER_UNNUMBERED addpath-tx-all-paths
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_VOQ_CHASSIS_V4_PEER in
+    neighbor PEER_UNNUMBERED route-map TO_VOQ_CHASSIS_V4_PEER out
+    neighbor PEER_UNNUMBERED send-community
   exit-address-family
   address-family ipv6
     neighbor VOQ_CHASSIS_V6_PEER allowas-in 1
+    neighbor PEER_UNNUMBERED allowas-in 1
     neighbor VOQ_CHASSIS_V6_PEER activate
     neighbor VOQ_CHASSIS_V6_PEER addpath-tx-all-paths
     neighbor VOQ_CHASSIS_V6_PEER soft-reconfiguration inbound
     neighbor VOQ_CHASSIS_V6_PEER route-map FROM_VOQ_CHASSIS_V6_PEER in
     neighbor VOQ_CHASSIS_V6_PEER route-map TO_VOQ_CHASSIS_V6_PEER out
     neighbor VOQ_CHASSIS_V6_PEER send-community
+    neighbor PEER_UNNUMBERED addpath-tx-all-paths
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_VOQ_CHASSIS_V6_PEER in
+    neighbor PEER_UNNUMBERED route-map TO_VOQ_CHASSIS_V6_PEER out
+    neighbor PEER_UNNUMBERED send-community
   exit-address-family
 !
 ! end of template: bgpd/templates/voq_chassis/peer-group.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/peer-group.conf/result_base.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/peer-group.conf/result_base.conf
@@ -3,6 +3,8 @@
 !
   neighbor VOQ_CHASSIS_V4_PEER peer-group
   neighbor VOQ_CHASSIS_V6_PEER peer-group
+  neighbor PEER_UNNUMBERED peer-group
+  neighbor PEER_UNNUMBERED capability extended-nexthop
   address-family ipv4
     neighbor VOQ_CHASSIS_V4_PEER activate
     neighbor VOQ_CHASSIS_V4_PEER addpath-tx-all-paths
@@ -10,6 +12,11 @@
     neighbor VOQ_CHASSIS_V4_PEER route-map FROM_VOQ_CHASSIS_V4_PEER in
     neighbor VOQ_CHASSIS_V4_PEER route-map TO_VOQ_CHASSIS_V4_PEER out
     neighbor VOQ_CHASSIS_V4_PEER send-community
+    neighbor PEER_UNNUMBERED addpath-tx-all-paths
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_VOQ_CHASSIS_V4_PEER in
+    neighbor PEER_UNNUMBERED route-map TO_VOQ_CHASSIS_V4_PEER out
+    neighbor PEER_UNNUMBERED send-community
   exit-address-family
   address-family ipv6
     neighbor VOQ_CHASSIS_V6_PEER activate
@@ -18,6 +25,11 @@
     neighbor VOQ_CHASSIS_V6_PEER route-map FROM_VOQ_CHASSIS_V6_PEER in
     neighbor VOQ_CHASSIS_V6_PEER route-map TO_VOQ_CHASSIS_V6_PEER out
     neighbor VOQ_CHASSIS_V6_PEER send-community
+    neighbor PEER_UNNUMBERED addpath-tx-all-paths
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_VOQ_CHASSIS_V6_PEER in
+    neighbor PEER_UNNUMBERED route-map TO_VOQ_CHASSIS_V6_PEER out
+    neighbor PEER_UNNUMBERED send-community
   exit-address-family
 !
 ! end of template: bgpd/templates/voq_chassis/peer-group.conf.j2

--- a/src/sonic-bgpcfgd/tests/test_bgp_unnumbered.py
+++ b/src/sonic-bgpcfgd/tests/test_bgp_unnumbered.py
@@ -1,0 +1,128 @@
+"""
+Unit tests for BGP unnumbered (interface-based) neighbor support.
+Tests template rendering and is_interface_neighbor detection logic.
+"""
+import os
+import sys
+import json
+from unittest.mock import MagicMock
+
+# Mock SONiC-specific modules for standalone testing
+sys.modules.setdefault('swsscommon', MagicMock())
+sys.modules.setdefault('sonic_py_common', MagicMock())
+sys.modules.setdefault('sonic_py_common.device_info', MagicMock())
+
+from bgpcfgd.template import TemplateFabric
+from bgpcfgd.config import ConfigMgr
+from bgpcfgd.managers_bgp import is_interface_neighbor
+
+TEMPLATE_PATH = os.path.abspath('../../dockers/docker-fpm-frr/frr')
+
+
+# --- is_interface_neighbor tests ---
+
+def test_is_interface_neighbor_portchannel():
+    assert is_interface_neighbor('PortChannel101') is True
+
+def test_is_interface_neighbor_ethernet():
+    assert is_interface_neighbor('Ethernet0') is True
+
+def test_is_interface_neighbor_vlan():
+    assert is_interface_neighbor('Vlan100') is True
+
+def test_is_interface_neighbor_ipv4():
+    assert is_interface_neighbor('10.10.10.1') is False
+
+def test_is_interface_neighbor_ipv6():
+    assert is_interface_neighbor('fc00::1') is False
+
+def test_is_interface_neighbor_dynamic_name():
+    assert is_interface_neighbor('BGPSLBPassive') is False
+
+def test_is_interface_neighbor_portchannel_high():
+    assert is_interface_neighbor('PortChannel4096') is True
+
+def test_is_interface_neighbor_ethernet_typical():
+    assert is_interface_neighbor('Ethernet48') is True
+
+def test_is_interface_neighbor_vlan_high():
+    assert is_interface_neighbor('Vlan1000') is True
+
+def test_is_interface_neighbor_empty_string():
+    assert is_interface_neighbor('') is False
+
+def test_is_interface_neighbor_none():
+    assert is_interface_neighbor(None) is False
+
+def test_is_interface_neighbor_trailing_junk():
+    assert is_interface_neighbor('Ethernet0foo') is False
+
+
+# --- Template rendering tests ---
+
+def render_general_instance(neighbor_addr, bgp_session, bgp_asn='65100'):
+    tf = TemplateFabric(TEMPLATE_PATH)
+    template = tf.from_file('bgpd/templates/general/instance.conf.j2')
+    return template.render(
+        CONFIG_DB__DEVICE_METADATA={'localhost': {}},
+        neighbor_addr=neighbor_addr,
+        bgp_session=bgp_session,
+        bgp_asn=bgp_asn,
+        constants={'deployment_id_asn_map': {'5': '51111'}}
+    )
+
+
+def test_unnumbered_dual_stack_rendering():
+    """Interface neighbor renders with PEER_UNNUMBERED and both address families."""
+    result = render_general_instance('PortChannel101', {'asn': '65200', 'name': 'spine1'})
+    assert 'neighbor PortChannel101 interface peer-group PEER_UNNUMBERED' in result
+    assert 'neighbor PortChannel101 activate' in result
+
+
+def test_unnumbered_v6only_rendering():
+    """Interface neighbor with v6only=true renders only IPv6 address family."""
+    result = render_general_instance('Ethernet0', {'asn': '65200', 'name': 'spine2', 'v6only': 'true'})
+    assert 'neighbor Ethernet0 interface peer-group PEER_UNNUMBERED' in result
+    # IPv6 should be present
+    assert 'address-family ipv6' in result
+    assert 'neighbor Ethernet0 activate' in result
+    # IPv4 should NOT be present
+    assert 'address-family ipv4' not in result
+
+
+def test_ipv4_neighbor_unchanged():
+    """IPv4 neighbor still renders with PEER_V4 (no regression)."""
+    result = render_general_instance('10.10.10.10', {'asn': '555', 'name': 'remote_peer'})
+    assert 'neighbor 10.10.10.10 peer-group PEER_V4' in result
+    assert 'PEER_UNNUMBERED' not in result
+
+
+def test_ipv6_neighbor_unchanged():
+    """IPv6 neighbor still renders with PEER_V6 (no regression)."""
+    result = render_general_instance('fc00::1', {'asn': '555', 'name': 'remote_peer'})
+    assert 'neighbor fc00::1 peer-group PEER_V6' in result
+    assert 'PEER_UNNUMBERED' not in result
+
+
+def test_peer_group_has_unnumbered():
+    """Peer-group template defines PEER_UNNUMBERED with extended-nexthop."""
+    tf = TemplateFabric(TEMPLATE_PATH)
+    template = tf.from_file('bgpd/templates/general/peer-group.conf.j2')
+    result = template.render(
+        CONFIG_DB__DEVICE_METADATA={'localhost': {'type': 'LeafRouter'}},
+        CONFIG_DB__BGP_BBR={'status': 'disabled'}
+    )
+    assert 'neighbor PEER_UNNUMBERED peer-group' in result
+    assert 'neighbor PEER_UNNUMBERED capability extended-nexthop' in result
+
+
+def test_unnumbered_remote_as():
+    """Interface neighbor renders remote-as correctly."""
+    result = render_general_instance('PortChannel101', {'asn': '65200', 'name': 'spine1'})
+    assert 'neighbor PortChannel101 remote-as 65200' in result
+
+
+def test_unnumbered_shutdown():
+    """Interface neighbor renders shutdown when admin_status is down."""
+    result = render_general_instance('PortChannel101', {'asn': '65200', 'name': 'spine1', 'admin_status': 'down'})
+    assert 'neighbor PortChannel101 shutdown' in result

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -3181,11 +3181,38 @@ An example is as follows:
 ### Prefix List
 Prefix list table stores a list of prefixes with type and prefix separated by `|`. The specific configuration for the prefix type are then rendered by the PrefixListMgr. Currently ANCHOR_PREFIX is supported to add RADIAN configuration.
 
-An example is as follows:
+The following optional fields are supported for dynamic prefix list configuration:
+
+| Field   | Type   | Description                                                                 |
+|---------|--------|-----------------------------------------------------------------------------|
+| action  | string | Permit or deny action for this prefix entry (`permit` or `deny`)            |
+| seq     | uint32 | Sequence number (1–4294967295) for ordering prefix list entries             |
+| ge      | uint8  | Minimum prefix length to match, greater-than-or-equal (0–128)              |
+| le      | uint8  | Maximum prefix length to match, less-than-or-equal (0–128)                 |
+
+Note: `seq`, `ge`, and `le` are modeled as numeric YANG types, but in CONFIG_DB JSON they are stored as strings, as shown in the examples below.
+
+Examples:
 ```json
 {
     "PREFIX_LIST": {
-        "ANCHOR_PREFIX|fc00::/48": {}
+        "ANCHOR_PREFIX|fc00::/48": {},
+        "BGP_ALLOWED_IPV4|172.16.0.0/12": {
+            "action": "permit",
+            "seq": "200",
+            "ge": "16",
+            "le": "24"
+        },
+        "BGP_ALLOWED_IPV6|2001:db8::/32": {
+            "action": "permit",
+            "seq": "30",
+            "ge": "48",
+            "le": "64"
+        },
+        "BGP_DENIED_IPV4|10.255.0.0/16": {
+            "action": "deny",
+            "seq": "30"
+        }
     }
 }
 ```

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -3018,7 +3018,23 @@
         },
         "PREFIX_LIST": {
             "ANCHOR_PREFIX|10.0.0.0/8" : {},
-            "ANCHOR_PREFIX|FC00::/48" : {}
+            "ANCHOR_PREFIX|FC00::/48" : {},
+            "BGP_ALLOWED_IPV4|172.16.0.0/12": {
+                "action": "permit",
+                "seq": "200",
+                "ge": "16",
+                "le": "24"
+            },
+            "BGP_ALLOWED_IPV6|2001:db8::/32": {
+                "action": "permit",
+                "seq": "30",
+                "ge": "48",
+                "le": "64"
+            },
+            "BGP_DENIED_IPV4|10.255.0.0/16": {
+                "action": "deny",
+                "seq": "30"
+            }
         },
         "DEBUG_COUNTER": {
             "DEBUG_4": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_prefix_list.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_prefix_list.json
@@ -9,5 +9,73 @@
         "desc": "Load BGP prefix list table with an invalid prefix",
         "eStrKey": "InvalidValue",
         "eStr": ["prefix"]
+    },
+    "BGP_PREFIX_LIST_WITH_ALL_OPTIONAL_FIELDS": {
+        "desc": "Load BGP prefix list with action, seq, ge and le fields"
+    },
+    "BGP_PREFIX_LIST_WITH_PERMIT_ACTION": {
+        "desc": "Load BGP prefix list with permit action only"
+    },
+    "BGP_PREFIX_LIST_WITH_DENY_ACTION": {
+        "desc": "Load BGP prefix list with deny action only"
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_ACTION": {
+        "desc": "Load BGP prefix list with invalid action value",
+        "eStrKey": "InvalidValue",
+        "eStr": ["action"]
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_SEQ_ZERO": {
+        "desc": "Load BGP prefix list with seq value 0 (out of range)",
+        "eStrKey": "Range"
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_GE": {
+        "desc": "Load BGP prefix list with ge value 129 (out of range)",
+        "eStrKey": "Range"
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_LE": {
+        "desc": "Load BGP prefix list with le value 129 (out of range)",
+        "eStrKey": "Range"
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_IPV4_GE_LENGTH": {
+        "desc": "Load BGP prefix list with IPv4 prefix and ge=33 (must fail)",
+        "eStr": ["ge value must be <= 32 for IPv4 or <= 128 for IPv6"]
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_IPV4_LE_LENGTH": {
+        "desc": "Load BGP prefix list with IPv4 prefix and le=33 (must fail)",
+        "eStr": ["le value must be <= 32 for IPv4 or <= 128 for IPv6"]
+    },
+    "BGP_PREFIX_LIST_WITH_IPV6_VALID_GE_LE": {
+        "desc": "Load BGP prefix list with IPv6 prefix and ge=64 le=128 (valid)"
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_GE_GREATER_THAN_LE": {
+        "desc": "Load BGP prefix list with ge=24 and le=16 (ge > le must fail)",
+        "eStr": ["le value must be >= ge value"]
+    },
+    "BGP_PREFIX_LIST_WITH_GE_LESS_THAN_PREFIX_LENGTH": {
+        "desc": "Load BGP prefix list with 10.0.0.0/24 and ge=16 (ge < prefix length must fail)",
+        "eStr": ["ge value must be >= prefix length"]
+    },
+    "BGP_PREFIX_LIST_WITH_LE_LESS_THAN_PREFIX_LENGTH": {
+        "desc": "Load BGP prefix list with 10.0.0.0/24 and le=8 (le < prefix length must fail)",
+        "eStr": ["le value must be >= prefix length"]
+    },
+    "BGP_PREFIX_LIST_WITH_EMBEDDED_IPV4_IN_IPV6_VALID_GE_LE": {
+        "desc": "Load BGP prefix list with IPv6 embedded IPv4 prefix 2001:db8::192.0.2.0/120 and ge=120 le=128 (valid, proves not misclassified as IPv4)"
+    },
+    "BGP_PREFIX_LIST_WITH_EMBEDDED_IPV4_IN_IPV6_GE_LESS_THAN_PREFIX": {
+        "desc": "Load BGP prefix list with IPv6 embedded IPv4 prefix 2001:db8::192.0.2.0/120 and ge=64 (ge < prefix length must fail)",
+        "eStr": ["ge value must be >= prefix length"]
+    },
+    "BGP_PREFIX_LIST_WITH_SEQ_WITHOUT_ACTION": {
+        "desc": "Load BGP prefix list with seq but no action (must fail, seq requires action)",
+        "eStrKey": "When"
+    },
+    "BGP_PREFIX_LIST_WITH_GE_WITHOUT_ACTION": {
+        "desc": "Load BGP prefix list with ge but no action (must fail, ge requires action)",
+        "eStrKey": "When"
+    },
+    "BGP_PREFIX_LIST_WITH_LE_WITHOUT_ACTION": {
+        "desc": "Load BGP prefix list with le but no action (must fail, le requires action)",
+        "eStrKey": "When"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_prefix_list.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_prefix_list.json
@@ -36,5 +36,256 @@
         },
         "eStrKey": "InvalidValue",
         "eStr": ["prefix"]
+    },
+    "BGP_PREFIX_LIST_WITH_ALL_OPTIONAL_FIELDS": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/8",
+                        "action": "permit",
+                        "seq": "100",
+                        "ge": "16",
+                        "le": "24"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_PERMIT_ACTION": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.1.0.0/16",
+                        "action": "permit"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_DENY_ACTION": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "192.168.0.0/16",
+                        "action": "deny"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_ACTION": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/8",
+                        "action": "reject"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_SEQ_ZERO": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/8",
+                        "action": "permit",
+                        "seq": "0"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_GE": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/8",
+                        "action": "permit",
+                        "ge": "129"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_LE": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/8",
+                        "action": "permit",
+                        "le": "129"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_IPV4_GE_LENGTH": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/8",
+                        "action": "permit",
+                        "ge": "33"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_IPV4_LE_LENGTH": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/8",
+                        "action": "permit",
+                        "le": "33"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_IPV6_VALID_GE_LE": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "fc00::/48",
+                        "action": "permit",
+                        "ge": "64",
+                        "le": "128"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_GE_GREATER_THAN_LE": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/8",
+                        "action": "permit",
+                        "ge": "24",
+                        "le": "16"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_GE_LESS_THAN_PREFIX_LENGTH": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/24",
+                        "action": "permit",
+                        "ge": "16"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_LE_LESS_THAN_PREFIX_LENGTH": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/24",
+                        "action": "permit",
+                        "le": "8"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_EMBEDDED_IPV4_IN_IPV6_VALID_GE_LE": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "2001:db8::192.0.2.0/120",
+                        "action": "permit",
+                        "ge": "120",
+                        "le": "128"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_EMBEDDED_IPV4_IN_IPV6_GE_LESS_THAN_PREFIX": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "2001:db8::192.0.2.0/120",
+                        "action": "permit",
+                        "ge": "64"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_SEQ_WITHOUT_ACTION": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/8",
+                        "seq": "100"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_GE_WITHOUT_ACTION": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/8",
+                        "ge": "16"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_LE_WITHOUT_ACTION": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/8",
+                        "le": "16"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
@@ -577,5 +577,13 @@ module sonic-bgp-common {
             type stypes:admin_status;
             description "Admin status of BGP peer";
         }
+
+        leaf v6only {
+            type string {
+                pattern "true|false";
+            }
+            default "false";
+            description "When set to true, only IPv6 address family is activated for this unnumbered BGP peer.";
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
@@ -23,6 +23,10 @@ module sonic-bgp-neighbor {
         prefix lag;
     }
 
+    import sonic-vlan-sub-interface {
+        prefix subintf;
+    }
+
     // Comment sonic-vlan import here until libyang back-links issue is resolved for VLAN leaf reference.
     //import sonic-vlan {
     //    prefix vlan;
@@ -57,8 +61,22 @@ module sonic-bgp-neighbor {
                 key "neighbor";
 
                 leaf neighbor {
-                    type inet:ip-address;
-                    description "BGP Neighbor address";
+                    type union {
+                        type inet:ip-address;
+                        type leafref {
+                            path "/port:sonic-port/port:PORT/port:PORT_LIST/port:name";
+                        }
+                        type leafref {
+                            path "/lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:name";
+                        }
+                        type leafref {
+                            path "/subintf:sonic-vlan-sub-interface/subintf:VLAN_SUB_INTERFACE/subintf:VLAN_SUB_INTERFACE_LIST/subintf:name";
+                        }
+                        type string {
+                            pattern 'Vlan([0-9]{1,3}|[1-3][0-9]{3}|[4][0][0-8][0-9]|[4][0][9][0-4])';
+                        }
+                    }
+                    description "BGP Neighbor address or interface name";
                 }
 
                 uses bgpcmn:sonic-bgp-cmn-neigh {

--- a/src/sonic-yang-models/yang-models/sonic-bgp-prefix-list.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-prefix-list.yang
@@ -12,12 +12,19 @@ module sonic-bgp-prefix-list {
 
     import sonic-extension {
         prefix ext;
+
+    import sonic-routing-policy-sets {
+        prefix rpolsets;
     }
 
     description "SONIC Device-specfifc BGP prefix lists data";
 
+    revision 2026-05-18 {
+        description "Add optional action, seq, ge and le leaves; require action for seq, ge, and le";
+    }
+
     revision 2025-02-17 {
-        description "Updated description and leafs for PREFIX_LIST_LIST";
+        description "Updated description and leaves for PREFIX_LIST_LIST";
     }
 
     revision 2025-02-05 {
@@ -59,6 +66,54 @@ module sonic-bgp-prefix-list {
                     must "(contains(../ip-prefix, ':') and current()='IPv6') or
                         (contains(../ip-prefix, '.') and current()='IPv4')";
                     type stypes:ip-family;
+                }
+
+                leaf action {
+                    type rpolsets:routing-policy-action-type;
+                    description "Permit or deny action for this prefix entry";
+                }
+
+                leaf seq {
+                    when "../action";
+                    type uint32 {
+                        range "1..4294967295";
+                    }
+                    description "Sequence number for ordering prefix list entries. Optional, but should be provided when a specific execution order is needed";
+                }
+
+                leaf ge {
+                    when "../action";
+                    must "(contains(../ip-prefix, '.') and . <= 32) or
+                        (contains(../ip-prefix, ':') and . <= 128)" {
+                        error-message "ge value must be <= 32 for IPv4 or <= 128 for IPv6";
+                    }
+                    must ". >= number(substring-after(../ip-prefix, '/'))" {
+                        error-message "ge value must be >= prefix length";
+                    }
+                    type uint8 {
+                        range "0..128";
+                    }
+                    description "Minimum prefix length to match (greater-than-or-equal)";
+                }
+
+                leaf le {
+                    when "../action";
+                    must "(contains(../ip-prefix, '.') and . <= 32) or
+                        (contains(../ip-prefix, ':') and . <= 128)" {
+                        error-message "le value must be <= 32 for IPv4 or <= 128 for IPv6";
+                    }
+                    must ". >= number(substring-after(../ip-prefix, '/'))" {
+                        error-message "le value must be >= prefix length";
+                    }
+                    /* If ge is not set, skip this check.
+                       If ge is set, enforce le >= ge. */
+                    must "not(../ge) or current() >= ../ge" {
+                        error-message "le value must be >= ge value";
+                    }
+                    type uint8 {
+                        range "0..128";
+                    }
+                    description "Maximum prefix length to match (less-than-or-equal)";
                 }
             }
         }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Cherry-pick of following prs for azd use cases:

Unnumbered bgp: https://github.com/Azure/sonic-buildimage-msft/pull/2413/
Prefix list yang: https://github.com/sonic-net/sonic-buildimage/pull/27449/

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

