### PR TITLE
Open Enhance PrefixListMgr to support dynamic prefix list types

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
@@ -33,19 +33,39 @@ class PrefixListMgr(Manager):
         :param data: data from the PREFIX_LIST table
         :return: rendered configuration
         """
+
+        if data["prefix_list_name"] != "ANCHOR_PREFIX":
+            cmd_parts = ["no"] if not add else []
+            cmd_parts.extend([data["ipv"], "prefix-list", data["prefix_list_name"]])
+            if "seq" in data:
+                cmd_parts.extend(["seq", str(data["seq"])])
+            if "action" not in data or not data["action"]:
+                log_warn("PrefixListMgr:: Mandatory field 'action' is not defined for prefix list '%s'" % prefix_type)
+                return False
+            cmd_parts.extend([data["action"], data["prefix"]])
+            if "ge" in data:
+                cmd_parts.extend(["ge", str(data["ge"])])
+            if "le" in data:
+                cmd_parts.extend(["le", str(data["le"])])
+            cmd = "\n" + " ".join(cmd_parts)
+            self.cfg_mgr.push(cmd)
+            action = "added to" if add else "removed from"
+            log_debug("PrefixListMgr:: Dynamic prefix list %s %s configuration" % (data["prefix"], action))
+            return True
+
         cmd = "\n"
-        metadata = self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)["localhost"]
+        if not self.directory.path_exist("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost"):
+            log_info("PrefixListMgr:: Device metadata is not ready yet")
+            return False
+        metadata = self.directory.get_path("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost")
         try:
             bgp_asn = metadata["bgp_asn"]
             localhost_type = metadata["type"]
-            subtype = metadata["subtype"]
+            subtype = metadata.get("subtype", "")
         except KeyError as e:
             log_warn(f"PrefixListMgr:: Missing metadata key: {e}")
             return False
 
-        if data["prefix_list_name"] != "ANCHOR_PREFIX":
-            log_warn("PrefixListMgr:: Prefix list %s is not supported" % data["prefix_list_name"])
-            return False
         if localhost_type not in ["UpperSpineRouter", "SpineRouter"] or (localhost_type == "SpineRouter" and subtype != "UpstreamLC"):
             log_warn("PrefixListMgr:: Prefix list %s is only supported on Upstream SpineRouter" % data["prefix_list_name"])
             return False
@@ -94,7 +114,11 @@ class PrefixListMgr(Manager):
             except (netaddr.NotRegisteredError, netaddr.AddrFormatError, netaddr.AddrConversionError):
                 log_warn("PrefixListMgr:: Prefix '%s' format is wrong for prefix list '%s'" % (prefix_str, prefix_list_name))
                 return True
-            data = {}
+            if prefix_list_name != "ANCHOR_PREFIX":
+                table_data = self.directory.get_slot(self.db_name, self.table_name)
+                data = dict(table_data.get(key, {}))
+            else:
+                data = {}
             data["prefix_list_name"] = prefix_list_name
             data["prefix"] = str(prefix.cidr)
             data["prefixlen"] = prefix.prefixlen


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Prefix List:

This PR is to enhance the existing PrefixListMgr to support dynamic prefix list configuration.
original PR: https://github.com/sonic-net/sonic-buildimage/pull/27495 
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Enhanced PrefixListMgr to support dynamic prefix-list types not in PREFIX_TYPE_CONFIG. In generate_prefix_list_config(), unknown types now build FRR commands directly from entry fields (action, optional seq/ge/le) instead of returning an error. In del_handler(), stored entry data is read back from directory to preserve optional fields for symmetric deletion. Existing template-based paths are unchanged.
#### How to verify it
Related unit tests added and tested on testbed.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

