### PR TITLE
[Unnumbered bgp] Fix unnumbered bgpcfgd tests

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/voq_chassis/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/voq_chassis/instance.conf.j2
@@ -6,7 +6,6 @@
 !
 {% if neighbor_addr | is_interface %}
   neighbor {{ neighbor_addr }} interface peer-group PEER_UNNUMBERED
-  neighbor {{ neighbor_addr }} remote-as {{ bgp_session['asn'] }}
 {% if 'v6only' not in bgp_session or bgp_session['v6only'] != 'true' %}
   address-family ipv4
     neighbor {{ neighbor_addr }} activate

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_all_isolate.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_all_isolate.conf
@@ -29,6 +29,7 @@
 ! end of template: bgpd/templates/general/peer-group.conf.j2
 !
 
+
 route-map TO_BGP_PEER_V4 permit 20
   match ip address prefix-list PL_LoopbackV4
   set community 12345:12345

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_all_unisolate.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_all_unisolate.conf
@@ -29,6 +29,7 @@
 ! end of template: bgpd/templates/general/peer-group.conf.j2
 !
 
+
 no route-map TO_BGP_PEER_V4 permit 20
 no route-map TO_BGP_PEER_V4 permit 30
 no route-map TO_BGP_PEER_V4 deny 40
@@ -37,3 +38,4 @@ no route-map TO_BGP_PEER_V6 permit 20
 no route-map TO_BGP_PEER_V6 permit 30
 no route-map TO_BGP_PEER_V6 deny 40
 !
+

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_unnumbered.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_unnumbered.conf
@@ -5,13 +5,13 @@
   bgp bestpath peer-type multipath-relax
 !
   neighbor Ethernet0 interface peer-group PEER_UNNUMBERED
-  neighbor Ethernet0 remote-as 65100
   address-family ipv4
     neighbor Ethernet0 activate
   exit-address-family
   address-family ipv6
     neighbor Ethernet0 activate
   exit-address-family
+  neighbor Ethernet0 remote-as 65100
   neighbor Ethernet0 description lc_peer
   neighbor Ethernet0 timers 2 7
   neighbor Ethernet0 timers connect 10


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix broken template tests for unnumbered bgp

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

