### PR TITLE
[swss] Cherry-pick: restart xcvrd instead of pmon on media_settings.json SKUs (sonic-net#22240)

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -403,20 +403,15 @@ start() {
         $SONIC_DB_CLI APPL_STATE_DB FLUSHDB
         clean_up_chassis_db_tables
         rm -rf /tmp/cache
-        if [[ x"$sonic_asic_platform" == x"broadcom" ]]; then
-            . /host/machine.conf
-            if [ -n "$aboot_platform" ]; then
-                platform=$aboot_platform
-            elif [ -n "$onie_platform" ]; then
-                platform=$onie_platform
+        MEDIA_SETTINGS="/usr/share/sonic/device/$PLATFORM/media_settings.json"
+        if [ -f $MEDIA_SETTINGS ]; then
+            if [ "$( docker inspect -f '{{.State.Running}}' pmon )" != "true" ]; then
+                debug "pmon not running so skip restarting xcvrd"
             else
-                platform="unknown"
-            fi
-            # Need to restart PMON on media_settings.json skus due to
-            # https://github.com/sonic-net/sonic-buildimage/issues/21902
-            if [[ x"$platform" == x"x86_64-arista_7800r3a"* ]]; then
-                debug "Restarting pmon service..."
-                /bin/systemctl restart pmon
+                # Need to restart XCVRD on media_settings.json skus due to
+                # https://github.com/sonic-net/sonic-buildimage/issues/21902
+                debug "Restarting xcvrd service..."
+                /usr/bin/docker exec pmon supervisorctl restart xcvrd
             fi
         fi
 


### PR DESCRIPTION
## Description

Cherry-pick of [sonic-net/sonic-buildimage#22240](https://github.com/sonic-net/sonic-buildimage/pull/22240) into `202405`.

## Problem

The existing code in this branch restarts the entire `pmon` service (via `systemctl restart pmon`) but only for Arista `x86_64-arista_7800r3a` broadcom SKUs. This is fragile and heavier than needed.

## Fix

Replace the old broadcom/Arista-specific block with a generic check:
- For **any** platform that has a `media_settings.json` file, restart only `xcvrd` (not the full pmon) after SWSS flushes APPL_DB.
- Skip the restart if `pmon` is not already running.

This is more efficient (no full pmon restart) and covers all SKUs that use `media_settings.json`.

## Changes
- `files/scripts/swss.sh`: Replace Arista/broadcom-specific pmon restart with generic xcvrd-only restart for any `media_settings.json` SKU.

Fixes: https://github.com/sonic-net/sonic-buildimage/issues/21902