### PR TITLE
[minigraph/device_info] Parse device type from device_desc.xml; fix is_voq/packet_chassis to read Config DB directly

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -518,7 +518,9 @@ def parse_device(device):
             slice_type = "AZNG_Production"
 
     if d_type is None and str(QName(ns3, "type")) in device.attrib:
-        d_type = device.attrib[str(QName(ns3, "type"))]
+        # Strip namespace prefix (e.g. "a:BackEndLeafRouter" -> "BackEndLeafRouter")
+        raw_type = device.attrib[str(QName(ns3, "type"))]
+        d_type = raw_type.split(':')[-1] if ':' in raw_type else raw_type
 
     return (lo_prefix, lo_prefix_v6, mgmt_prefix, mgmt_prefix_v6, name, hwsku, d_type, deployment_id, cluster, d_subtype, slice_type)
 
@@ -2856,6 +2858,8 @@ def parse_device_desc_xml(filename):
         'hostname': hostname,
         'hwsku': hwsku,
         }}
+    if d_type:
+        results['DEVICE_METADATA']['localhost']['type'] = d_type
 
     results['LOOPBACK_INTERFACE'] = {'lo': {}, ('lo', lo_prefix): {}}
     if lo_prefix_v6:

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -518,9 +518,7 @@ def parse_device(device):
             slice_type = "AZNG_Production"
 
     if d_type is None and str(QName(ns3, "type")) in device.attrib:
-        # Strip namespace prefix (e.g. "a:BackEndLeafRouter" -> "BackEndLeafRouter")
-        raw_type = device.attrib[str(QName(ns3, "type"))]
-        d_type = raw_type.split(':')[-1] if ':' in raw_type else raw_type
+        d_type = device.attrib[str(QName(ns3, "type"))]
 
     return (lo_prefix, lo_prefix_v6, mgmt_prefix, mgmt_prefix_v6, name, hwsku, d_type, deployment_id, cluster, d_subtype, slice_type)
 

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -2859,7 +2859,10 @@ def parse_device_desc_xml(filename):
         'hwsku': hwsku,
         }}
     if d_type:
-        results['DEVICE_METADATA']['localhost']['type'] = d_type
+        if d_type in ('Linecard', 'Supervisor'):
+            results['DEVICE_METADATA']['localhost']['type'] = 'SpineRouter'
+        else:
+            results['DEVICE_METADATA']['localhost']['type'] = d_type
 
     results['LOOPBACK_INTERFACE'] = {'lo': {}, ('lo', lo_prefix): {}}
     if lo_prefix_v6:

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -2859,12 +2859,7 @@ def parse_device_desc_xml(filename):
         'hwsku': hwsku,
         }}
     if d_type:
-        # Linecard and Supervisor are chassis card types; map them to SpineRouter
-        # so that the rest of the config logic treats them correctly.
-        if d_type in ('Linecard', 'Supervisor'):
-            results['DEVICE_METADATA']['localhost']['type'] = 'SpineRouter'
-        else:
-            results['DEVICE_METADATA']['localhost']['type'] = d_type
+        results['DEVICE_METADATA']['localhost']['type'] = d_type
 
     results['LOOPBACK_INTERFACE'] = {'lo': {}, ('lo', lo_prefix): {}}
     if lo_prefix_v6:

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -2859,7 +2859,12 @@ def parse_device_desc_xml(filename):
         'hwsku': hwsku,
         }}
     if d_type:
-        results['DEVICE_METADATA']['localhost']['type'] = d_type
+        # Linecard and Supervisor are chassis card types; map them to SpineRouter
+        # so that the rest of the config logic treats them correctly.
+        if d_type in ('Linecard', 'Supervisor'):
+            results['DEVICE_METADATA']['localhost']['type'] = 'SpineRouter'
+        else:
+            results['DEVICE_METADATA']['localhost']['type'] = d_type
 
     results['LOOPBACK_INTERFACE'] = {'lo': {}, ('lo', lo_prefix): {}}
     if lo_prefix_v6:

--- a/src/sonic-config-engine/tests/simple-sample-device-desc-linecard.xml
+++ b/src/sonic-config-engine/tests/simple-sample-device-desc-linecard.xml
@@ -1,0 +1,12 @@
+<Device i:type="Linecard" xmlns="Microsoft.Search.Autopilot.Evolution" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <ElementType>Linecard</ElementType>
+  <Hostname>switch-linecard</Hostname>
+  <HwSku>8800-LC</HwSku>
+  <ClusterName>SEL20</ClusterName>
+  <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+    <a:IPPrefix>10.0.0.101/24</a:IPPrefix>
+  </ManagementAddress>
+  <ManagementAddressV6 xmlns:a="Microsoft.Search.Autopilot.NetMux">
+    <a:IPPrefix>FC00:1::33/64</a:IPPrefix>
+  </ManagementAddressV6>
+</Device>

--- a/src/sonic-config-engine/tests/simple-sample-device-desc-supervisor.xml
+++ b/src/sonic-config-engine/tests/simple-sample-device-desc-supervisor.xml
@@ -1,0 +1,12 @@
+<Device i:type="Supervisor" xmlns="Microsoft.Search.Autopilot.Evolution" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <ElementType>Supervisor</ElementType>
+  <Hostname>switch-supervisor</Hostname>
+  <HwSku>8800-RP</HwSku>
+  <ClusterName>SEL20</ClusterName>
+  <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+    <a:IPPrefix>10.0.0.100/24</a:IPPrefix>
+  </ManagementAddress>
+  <ManagementAddressV6 xmlns:a="Microsoft.Search.Autopilot.NetMux">
+    <a:IPPrefix>FC00:1::32/64</a:IPPrefix>
+  </ManagementAddressV6>
+</Device>

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -23,6 +23,8 @@ class TestCfgGenCaseInsensitive(TestCase):
         self.sample_subintf_graph = os.path.join(self.test_dir, 'sample-graph-subintf.xml')
         self.sample_simple_device_desc = os.path.join(self.test_dir, 'simple-sample-device-desc.xml')
         self.sample_simple_device_desc_ipv6_only = os.path.join(self.test_dir, 'simple-sample-device-desc-ipv6-only.xml')
+        self.sample_supervisor_device_desc = os.path.join(self.test_dir, 'simple-sample-device-desc-supervisor.xml')
+        self.sample_linecard_device_desc = os.path.join(self.test_dir, 'simple-sample-device-desc-linecard.xml')
         self.port_config = os.path.join(self.test_dir, 't0-sample-port-config.ini')
 
     def run_script(self, argument, check_stderr=False):
@@ -556,6 +558,19 @@ class TestCfgGenCaseInsensitive(TestCase):
         self.assertEqual(len(mgmt_intf.keys()), 1)
         self.assertTrue(('eth0', 'FC00:1::32/64') in mgmt_intf.keys())
         self.assertTrue(ipaddress.ip_address(u'fc00:1::1') == mgmt_intf[('eth0', 'FC00:1::32/64')]['gwaddr'])
+
+    def test_parse_device_desc_xml_device_type(self):
+        # Regular device type is passed through as-is
+        result = minigraph.parse_device_desc_xml(self.sample_simple_device_desc)
+        self.assertEqual(result['DEVICE_METADATA']['localhost']['type'], 'ToRRouter')
+
+        # Supervisor ElementType is mapped to SpineRouter
+        result = minigraph.parse_device_desc_xml(self.sample_supervisor_device_desc)
+        self.assertEqual(result['DEVICE_METADATA']['localhost']['type'], 'SpineRouter')
+
+        # Linecard ElementType is mapped to SpineRouter
+        result = minigraph.parse_device_desc_xml(self.sample_linecard_device_desc)
+        self.assertEqual(result['DEVICE_METADATA']['localhost']['type'], 'SpineRouter')
 
     def test_mgmt_device_disable_counters(self):
         expected_mgmt_disabled_counters = ["BUFFER_POOL_WATERMARK", "PFCWD", "PG_DROP", "PG_WATERMARK", "PORT_BUFFER_DROP", "QUEUE", "QUEUE_WATERMARK"]

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -573,6 +573,8 @@ def is_packet_chassis():
 
 
 def is_chassis():
+    if get_localhost_info('type') == 'SpineRouter':
+        return True
     return is_voq_chassis() or is_packet_chassis()
 
 

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -562,18 +562,18 @@ def is_multi_npu():
     return (num_npus > 1)
 
 
-def is_voq_chassis(config_db=None):
-    switch_type = get_localhost_info('switch_type', config_db)
+def is_voq_chassis():
+    switch_type = get_localhost_info('switch_type')
     return switch_type in ('voq', 'fabric') if switch_type else False
 
 
-def is_packet_chassis(config_db=None):
-    switch_type = get_localhost_info('switch_type', config_db)
+def is_packet_chassis():
+    switch_type = get_localhost_info('switch_type')
     return switch_type == 'chassis-packet' if switch_type else False
 
 
-def is_chassis(config_db=None):
-    return is_voq_chassis(config_db) or is_packet_chassis(config_db)
+def is_chassis():
+    return is_voq_chassis() or is_packet_chassis()
 
 
 def is_supervisor():

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -562,18 +562,18 @@ def is_multi_npu():
     return (num_npus > 1)
 
 
-def is_voq_chassis():
-    switch_type = get_platform_info().get('switch_type')
-    return True if switch_type and (switch_type == 'voq' or switch_type == 'fabric') else False
+def is_voq_chassis(config_db=None):
+    switch_type = get_localhost_info('switch_type', config_db)
+    return switch_type in ('voq', 'fabric') if switch_type else False
 
 
-def is_packet_chassis():
-    switch_type = get_platform_info().get('switch_type')
-    return True if switch_type and switch_type == 'chassis-packet' else False
+def is_packet_chassis(config_db=None):
+    switch_type = get_localhost_info('switch_type', config_db)
+    return switch_type == 'chassis-packet' if switch_type else False
 
 
-def is_chassis():
-    return is_voq_chassis() or is_packet_chassis()
+def is_chassis(config_db=None):
+    return is_voq_chassis(config_db) or is_packet_chassis(config_db)
 
 
 def is_supervisor():

--- a/src/sonic-py-common/tests/device_info_test.py
+++ b/src/sonic-py-common/tests/device_info_test.py
@@ -119,24 +119,24 @@ class TestDeviceInfo(object):
             # Assert the file was read only once
             open_mocked.assert_called_once_with(device_info.SONIC_VERSION_YAML_PATH)
 
-    @mock.patch("sonic_py_common.device_info.get_platform_info")
-    def test_is_chassis(self, mock_platform_info):
-        mock_platform_info.return_value = {"switch_type": "npu"}
+    @mock.patch("sonic_py_common.device_info.get_localhost_info")
+    def test_is_chassis(self, mock_localhost_info):
+        mock_localhost_info.return_value = "npu"
         assert device_info.is_chassis() == False
         assert device_info.is_voq_chassis() == False
         assert device_info.is_packet_chassis() == False
 
-        mock_platform_info.return_value = {"switch_type": "voq"}
+        mock_localhost_info.return_value = "voq"
         assert device_info.is_voq_chassis() == True
         assert device_info.is_packet_chassis() == False
         assert device_info.is_chassis() == True
 
-        mock_platform_info.return_value = {"switch_type": "chassis-packet"}
+        mock_localhost_info.return_value = "chassis-packet"
         assert device_info.is_voq_chassis() == False
         assert device_info.is_packet_chassis() == True
         assert device_info.is_chassis() == True
 
-        mock_platform_info.return_value = {}
+        mock_localhost_info.return_value = None
         assert device_info.is_voq_chassis() == False
         assert device_info.is_packet_chassis() == False
         assert device_info.is_chassis() == False

--- a/src/sonic-py-common/tests/device_info_test.py
+++ b/src/sonic-py-common/tests/device_info_test.py
@@ -136,6 +136,9 @@ class TestDeviceInfo(object):
         assert device_info.is_packet_chassis() == True
         assert device_info.is_chassis() == True
 
+        mock_localhost_info.return_value = "SpineRouter"
+        assert device_info.is_chassis() == True
+
         mock_localhost_info.return_value = None
         assert device_info.is_voq_chassis() == False
         assert device_info.is_packet_chassis() == False


### PR DESCRIPTION
## Problem

After running `config load_mgmt` + `config save`, two failures occur on Supervisor/Linecard devices:

### 1. `bgp_neighbor` script fails on Supervisor
**Root cause:** `type` is not populated in `DEVICE_METADATA.localhost` after `config load_mgmt`, so the script fails when checking device type.

### 2. `load_minigraph` fails on Supervisor and Linecard
**Root cause:** DB connection to `CHASSIS*DB` fails because `calcmgrd` does not have the iptable rule to allow midplane traffic — this rule is only added when `is_chassis()` returns `True`.

### Why `is_chassis()` returns `False`
- **Supervisor:** The current implementation calls a platform API which internally tries to connect to `CHASSIS*DB` — and since that connection is not yet available, it fails.
- **Linecard:** `switch_type` is not defined in Config DB at this point, so `is_chassis()` returns `False`.

---

## Fix

### 1. `src/sonic-config-engine/minigraph.py` — `parse_device_desc_xml()`
Populate `DEVICE_METADATA.localhost.type` from `<ElementType>` when parsing `device_desc.xml`. Map `Linecard` and `Supervisor` to `SpineRouter`.
This fixes the `bgp_neighbor` failure on Supervisor.

```python
if d_type:
    if d_type in ('Linecard', 'Supervisor'):
        results['DEVICE_METADATA']['localhost']['type'] = 'SpineRouter'
    else:
        results['DEVICE_METADATA']['localhost']['type'] = d_type
```

### 2. `src/sonic-py-common/sonic_py_common/device_info.py` — `is_chassis()`
- Remove dependency on `CHASSIS*DB` connection by reading `switch_type` directly from Config DB via `get_localhost_info()` instead of `get_platform_info()` (which uses a cached global and internally may attempt a `CHASSIS*DB` connection).
- Add an early check: if `DEVICE_METADATA.localhost.type == 'SpineRouter'`, return `True` immediately — removing the dependency on `switch_type` being defined.

```python
def is_chassis():
    if get_localhost_info('type') == 'SpineRouter':
        return True
    return is_voq_chassis() or is_packet_chassis()
```

---

## Files Changed
| File | Change |
|---|---|
| `src/sonic-config-engine/minigraph.py` | Populate `type` in `DEVICE_METADATA` from `<ElementType>`; map Linecard/Supervisor → SpineRouter |
| `src/sonic-py-common/sonic_py_common/device_info.py` | `is_chassis()` checks `type == SpineRouter` first; `is_voq/packet_chassis()` read Config DB directly |
| `src/sonic-py-common/tests/device_info_test.py` | Update mocks and add SpineRouter test case |
| `src/sonic-config-engine/tests/test_minigraph_case.py` | Add UTs for device type parsing and Linecard/Supervisor mapping |
| `src/sonic-config-engine/tests/simple-sample-device-desc-supervisor.xml` | New test fixture |
| `src/sonic-config-engine/tests/simple-sample-device-desc-linecard.xml` | New test fixture |