### PR TITLE
[device_info] is_voq_chassis/is_packet_chassis: read switch_type directly from Config DB

### DIFF
--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -562,18 +562,18 @@ def is_multi_npu():
     return (num_npus > 1)
 
 
-def is_voq_chassis():
-    switch_type = get_platform_info().get('switch_type')
-    return True if switch_type and (switch_type == 'voq' or switch_type == 'fabric') else False
+def is_voq_chassis(config_db=None):
+    switch_type = get_localhost_info('switch_type', config_db)
+    return switch_type in ('voq', 'fabric') if switch_type else False
 
 
-def is_packet_chassis():
-    switch_type = get_platform_info().get('switch_type')
-    return True if switch_type and switch_type == 'chassis-packet' else False
+def is_packet_chassis(config_db=None):
+    switch_type = get_localhost_info('switch_type', config_db)
+    return switch_type == 'chassis-packet' if switch_type else False
 
 
-def is_chassis():
-    return is_voq_chassis() or is_packet_chassis()
+def is_chassis(config_db=None):
+    return is_voq_chassis(config_db) or is_packet_chassis(config_db)
 
 
 def is_supervisor():


### PR DESCRIPTION
## Problem

`is_voq_chassis()` and `is_packet_chassis()` currently call `get_platform_info()`, which caches results in the global `hw_info_dict`. If the cache was already populated before `switch_type` was available in Config DB, these functions would incorrectly return `False` for chassis devices.

## Fix

Replace the `get_platform_info()` call with a direct `get_localhost_info('switch_type', config_db)` read, bypassing the cache. Also add an optional `config_db` parameter to all three functions so callers can pass a connected `ConfigDBConnector` and avoid reconnecting on every call.

```python
# Before
def is_voq_chassis():
    switch_type = get_platform_info().get('switch_type')
    return True if switch_type and (switch_type == 'voq' or switch_type == 'fabric') else False

def is_packet_chassis():
    switch_type = get_platform_info().get('switch_type')
    return True if switch_type and switch_type == 'chassis-packet' else False

def is_chassis():
    return is_voq_chassis() or is_packet_chassis()

# After
def is_voq_chassis(config_db=None):
    switch_type = get_localhost_info('switch_type', config_db)
    return switch_type in ('voq', 'fabric') if switch_type else False

def is_packet_chassis(config_db=None):
    switch_type = get_localhost_info('switch_type', config_db)
    return switch_type == 'chassis-packet' if switch_type else False

def is_chassis(config_db=None):
    return is_voq_chassis(config_db) or is_packet_chassis(config_db)
```