### PR TITLE
Cherry pick PR #20968 into 202412

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -982,47 +982,6 @@ It currently allows user to administratively bring down a line-card or fabric-ca
 }
 ```
 
-### Data Plane L3 Interfaces
-
-IP configuration for data plane are defined in **INTERFACE**, **VLAN_SUB_INTERFACE**,
-**PORTCHANNEL_INTERFACE** and **VLAN_INTERFACE** table. The objects
-in all four tables have the interface (could be physical port, port
-channel, vlan or vlan sub interface) that IP address is attached to as first-level key, and
-IP prefix as second-level key. IP interface address objects don't have any attributes.
-IP interface attributes, resides in those tables as well, key is the interface name
-and value is a list of field-values representing the interface attributes, e.g. loopback action.
-
-```
-{
-"INTERFACE": {
-        "Ethernet0|10.0.0.0/31": {},
-        "Ethernet4|10.0.0.2/31": {},
-        "Ethernet8|10.0.0.4/31": {}
-        "Ethernet8": {
-            "loopback_action": "drop"
-        }
-    },
-
-"PORTCHANNEL_INTERFACE": {
-        "PortChannel01|10.0.0.56/31": {},
-        "PortChannel01|FC00::71/126": {},
-        "PortChannel02|10.0.0.58/31": {},
-        "PortChannel02|FC00::75/126": {}
-    },
-
-"VLAN_INTERFACE": {
-        "Vlan1000|192.168.0.1/27": {}
-    },
-
-"VLAN_SUB_INTERFACE": {
-        "Ethernet4.1|10.0.0.2/31": {},
-        "Ethernet4.1": {
-            "loopback_action": "drop"
-        }
-    }
-}
-```
-
 
 ### DEFAULT_LOSSLESS_BUFFER_PARAMETER
 
@@ -1397,30 +1356,6 @@ The configuration is applied globally for each ECMP and LAG on a switch.
 }
 ```
 
-### IPv6 Link-local
-```
-{
-    "INTERFACE": {
-        "Ethernet8": {
-            "ipv6_use_link_local_only": "disable"
-        }
-    },
-
-    "PORTCHANNEL_INTERFACE": {
-        "PortChannel01": {
-            "ipv6_use_link_local_only": "enable"
-        }
-    },
-
-    "VLAN_INTERFACE": {
-        "Vlan1000": {
-            "ipv6_use_link_local_only": "enable"
-        }
-    }
-}
-
-```
-
 ### KDUMP
 
 ```
@@ -1501,6 +1436,96 @@ loopback address can also be defined.
                 "type": "LeafRouter",
                 "port": "Ethernet1"
         }
+    }
+}
+```
+
+### L3 Interfaces
+
+Configuration for L3 data plane interfaces are defined in the `INTERFACE`,
+`VLAN_INTERFACE`, `VLAN_SUB_INTERFACE` and `PORTCHANNEL_INTERFACE` tables,
+respectively.
+
+The objects in all four tables have the interface as the key with the following
+required patterns:
+- `INTERFACE`: Any valid port name from the `PORT` table.  Typically `Ethernet{0-999}`.
+- `VLAN_INTERFACE`: `Vlan{1-4095}`
+- `PORTCHANNEL_INTERFACE`: `PortChannel{0-9999}`
+- `VLAN_SUB_INTERFACE`: Any valid `INTERFACE` or `PORTCHANNEL_INTERFACE` name followed by a `.` and a number between 1 and 4094.  E.g. `Ethernet1.4`
+
+
+These tables have a number of shared attributes as described below:
+ * `vrf_name`: Valid VRF name from the `VRF` table.  Default: `default`
+ * `nat_zone`: NAT Zone for this interface. `0..3`
+ * `mpls`: Enable/disable MPLS routing for the interface. `enable` or `disable`. Default `disable`.
+ * `ipv6_use_link_local_only`: Enable/Disable IPv6 link local address on interface. `enable` or `disable`. Default `disable`.
+ * `mac_addr`: Assign administrator-provided MAC address to Interface.  If not specified will use the system MAC (same for all interfaces). Not applicable to `VLAN_SUB_INTERFACE` as it will use the parent interface's mac address.
+ * `loopback_action`: Packet action when a packet ingress and gets routed on the same IP interface. `drop` or `forward`.
+
+
+```json
+
+{
+    "INTERFACE": {
+        "Ethernet0": {
+            "ipv6_use_link_local_only": "enable",
+            "mac_addr": "12:34:56:78:90:ab"
+        },
+        "Ethernet1": {
+            "loopback_action": "drop"
+        }
+    },
+    "VLAN_INTERFACE": {
+        "Vlan201": {
+            "vrf_name": "red",
+            "mac_addr": "AB:CD:EF:12:34:56"
+        }
+    },
+    "PORTCHANNEL_INTERFACE": {
+        "PortChannel101": {
+            "mac_addr": "1c:23:a8:56:de:2f"
+        }
+    },
+    "VLAN_SUB_INTERFACE": {
+        "Ethernet0.555": {
+            "vrf_name": "Blue",
+            "vlan": "555"
+        }
+    }
+}
+```
+
+#### Assigning IP addresses to L3 Interfaces
+
+The interface name and IP prefix act as multi-level key for the interface
+objects.  The IP prefixes are stored in the same tables as the interface
+attributes: `INTERFACE`, `VLAN_INTERFACE`, `VLAN_SUB_INTERFACE` and `PORTCHANNEL_INTERFACE`.
+
+In the example below we will show one interface with attributes for clarity,
+but otherwise this is simply an example of how IP addresses may be configured.
+
+```json
+{
+    "INTERFACE": {
+        "Ethernet0": {
+            "ipv6_use_link_local_only": "enable",
+            "mac_addr": "12:34:56:78:90:ab"
+        },
+        "Ethernet0|10.0.0.0/31": {},
+        "Ethernet4|10.0.0.2/31": {},
+        "Ethernet8|10.0.0.4/31": {},
+    },
+    "PORTCHANNEL_INTERFACE": {
+        "PortChannel01|10.0.0.56/31": {},
+        "PortChannel01|FC00::71/126": {},
+        "PortChannel02|10.0.0.58/31": {},
+        "PortChannel02|FC00::75/126": {}
+    },
+    "VLAN_INTERFACE": {
+        "Vlan1000|192.168.0.1/27": {}
+    },
+    "VLAN_SUB_INTERFACE": {
+        "Ethernet4.1|10.0.0.2/31": {}
     }
 }
 ```

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -134,7 +134,8 @@
                 "PortChannel0003": {
                     "nat_zone": "1",
                     "loopback_action": "drop",
-                    "ipv6_use_link_local_only": "enable"
+                    "ipv6_use_link_local_only": "enable",
+                    "mac_addr": "02:26:9b:73:c1:1a"
                 },
                 "PortChannel0004": {"vrf_name": "Vrf_blue"},
                 "PortChannel42|10.1.0.1/31": {},
@@ -151,7 +152,8 @@
             "Vlan111": {
                 "nat_zone": "0",
                 "loopback_action": "forward",
-                "ipv6_use_link_local_only": "disable"
+                "ipv6_use_link_local_only": "disable",
+                "mac_addr": "02:ab:cd:ef:12:34"
             },
             "Vlan777": {},
             "Vlan111|2a04:5555:45:6709::1/64": {
@@ -1209,7 +1211,8 @@
             "Ethernet18": {
                 "nat_zone": "1",
                 "loopback_action": "forward",
-                "ipv6_use_link_local_only": "enable"
+                "ipv6_use_link_local_only": "enable",
+                "mac_addr": "12:34:56:78:90:ab"
             },
             "Ethernet112|2a04:5555:40:a709::2/126": {
                 "scope": "global",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/interface.json
@@ -38,6 +38,6 @@
     },
     "INTERFACE_INVALID_MAC_ADDR": {
         "desc": "Set invalid interface mac address.",
-        "eStr": "Value \"badaddr\" does not satisfy the constraint \"[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}\" (range, length, or pattern)."
+        "eStrKey": "Pattern"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/interface.json
@@ -29,5 +29,15 @@
     "INTERFACE_INVALID_ENABLE_IPV6_LINK_LOCAL": {
         "desc": "Enable the ipv6 link-local as true.",
         "eStr": "Invalid value \"true\" in \"ipv6_use_link_local_only\" element."
+    },
+    "INTERFACE_MAC_ADDR": {
+        "desc": "Set administrator-provided interface mac address."
+    },
+    "INTERFACE_UPPER_MAC_ADDR": {
+        "desc": "Set UPPERCASE administrator-provided interface mac address."
+    },
+    "INTERFACE_INVALID_MAC_ADDR": {
+        "desc": "Set invalid interface mac address.",
+        "eStr": "Value \"badaddr\" does not satisfy the constraint \"[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}\" (range, length, or pattern)."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
@@ -94,6 +94,6 @@
     },
     "PORTCHANNEL_INTERFACE_INVALID_MAC_ADDR": {
         "desc": "Set invalid interface mac address.",
-        "eStr": "Value \"badaddr\" does not satisfy the constraint \"[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}\" (range, length, or pattern)."
+        "eStrKey": "Pattern"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
@@ -85,5 +85,15 @@
     "PORTCHANNEL_INTERFACE_INVALID_ENABLE_IPV6_LINK_LOCAL": {
         "desc": "Enable the ipv6 link-local as true.",
         "eStr": "Invalid value \"true\" in \"ipv6_use_link_local_only\" element."
+    },
+    "PORTCHANNEL_INTERFACE_MAC_ADDR": {
+        "desc": "Set administrator-provided interface mac address."
+    },
+    "PORTCHANNEL_INTERFACE_UPPER_MAC_ADDR": {
+        "desc": "Set UPPERCASE administrator-provided interface mac address."
+    },
+    "PORTCHANNEL_INTERFACE_INVALID_MAC_ADDR": {
+        "desc": "Set invalid interface mac address.",
+        "eStr": "Value \"badaddr\" does not satisfy the constraint \"[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}\" (range, length, or pattern)."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
@@ -91,6 +91,16 @@
         "desc": "Enable the ipv6 link-local as true.",
         "eStr": "Invalid value \"true\" in \"ipv6_use_link_local_only\" element."
     },
+    "VLAN_INTERFACE_MAC_ADDR": {
+        "desc": "Set administrator-provided interface mac address."
+    },
+    "VLAN_INTERFACE_UPPER_MAC_ADDR": {
+        "desc": "Set UPPERCASE administrator-provided interface mac address."
+    },
+    "VLAN_INTERFACE_INVALID_MAC_ADDR": {
+        "desc": "Set invalid interface mac address.",
+        "eStr": "Value \"badaddr\" does not satisfy the constraint \"[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}\" (range, length, or pattern)."
+    },
     "VLAN_MEMBERS_WITHOUT_CREATING_VLAN":{
         "desc": "Vlan members without Creating Vlan",
         "eStrKey": "LeafRef"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
@@ -99,7 +99,7 @@
     },
     "VLAN_INTERFACE_INVALID_MAC_ADDR": {
         "desc": "Set invalid interface mac address.",
-        "eStr": "Value \"badaddr\" does not satisfy the constraint \"[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}\" (range, length, or pattern)."
+        "eStrKey": "Pattern"
     },
     "VLAN_MEMBERS_WITHOUT_CREATING_VLAN":{
         "desc": "Vlan members without Creating Vlan",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/interface.json
@@ -274,5 +274,92 @@
                 ]
             }
         }
+    },
+    "INTERFACE_MAC_ADDR": {
+        "sonic-interface:sonic-interface": {
+            "sonic-interface:INTERFACE": {
+                "INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "mac_addr": "02:26:9b:73:c1:1a"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth8",
+                        "description": "Ethernet8",
+                        "fec": "rs",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet8",
+                        "speed": 25000,
+                        "mode":"trunk"
+                    }
+                ]
+            }
+        }
+    },
+    "INTERFACE_UPPER_MAC_ADDR": {
+        "sonic-interface:sonic-interface": {
+            "sonic-interface:INTERFACE": {
+                "INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "mac_addr": "02:AB:CD:EF:12:34"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth8",
+                        "description": "Ethernet8",
+                        "fec": "rs",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet8",
+                        "speed": 25000,
+                        "mode":"trunk"
+                    }
+                ]
+            }
+        }
+    },
+    "INTERFACE_INVALID_MAC_ADDR": {
+        "sonic-interface:sonic-interface": {
+            "sonic-interface:INTERFACE": {
+                "INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "mac_addr": "badaddr"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth8",
+                        "description": "Ethernet8",
+                        "fec": "rs",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet8",
+                        "speed": 25000,
+                        "mode":"trunk"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
@@ -535,5 +535,122 @@
                 ]
             }
         }
+    },
+    "PORTCHANNEL_INTERFACE_MAC_ADDR": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "speed": 25000,
+                        "mode": "routed"
+                    }
+                ]
+            }
+        },
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "min_links": "1",
+                        "mtu": "9100",
+                        "name": "PortChannel0001",
+                        "mode": "routed"
+                    }
+                ]
+            },
+            "sonic-portchannel:PORTCHANNEL_INTERFACE": {
+                "PORTCHANNEL_INTERFACE_LIST": [
+                    {
+                        "name": "PortChannel0001",
+                        "mac_addr": "02:26:9b:73:c1:1a"
+                    }
+                ]
+            }
+        }
+    },
+    "PORTCHANNEL_INTERFACE_UPPER_MAC_ADDR": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "speed": 25000,
+                        "mode": "routed"
+                    }
+                ]
+            }
+        },
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "min_links": "1",
+                        "mtu": "9100",
+                        "name": "PortChannel0001",
+                        "mode": "routed"
+                    }
+                ]
+            },
+            "sonic-portchannel:PORTCHANNEL_INTERFACE": {
+                "PORTCHANNEL_INTERFACE_LIST": [
+                    {
+                        "name": "PortChannel0001",
+                        "mac_addr": "02:AB:CD:EF:12:34"
+                    }
+                ]
+            }
+        }
+    },
+    "PORTCHANNEL_INTERFACE_INVALID_MAC_ADDR": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "speed": 25000,
+                        "mode": "routed"
+                    }
+                ]
+            }
+        },
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "min_links": "1",
+                        "mtu": "9100",
+                        "name": "PortChannel0001",
+                        "mode": "routed"
+                    }
+                ]
+            },
+            "sonic-portchannel:PORTCHANNEL_INTERFACE": {
+                "PORTCHANNEL_INTERFACE_LIST": [
+                    {
+                        "name": "PortChannel0001",
+                        "mac_addr": "badaddr"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
@@ -737,7 +737,141 @@
             }
         }
     },
-
+    "VLAN_INTERFACE_MAC_ADDR": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "1",
+                        "name": "Ethernet0",
+                        "speed": 25000,
+                        "mode":"trunk"
+                    }
+                ]
+            }
+        },
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "description": "vlan_nat",
+                        "name": "Vlan100"
+                    }
+                ]
+            },
+            "sonic-vlan:VLAN_MEMBER": {
+                "VLAN_MEMBER_LIST": [
+                    {
+                        "port": "Ethernet0",
+                        "tagging_mode": "tagged",
+                        "name": "Vlan100"
+                    }
+                ]
+            },
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_LIST": [
+                    {
+                        "name": "Vlan100",
+                        "mac_addr": "02:26:9b:73:c1:1a"
+                    }
+                ]
+            }
+        }
+    },
+    "VLAN_INTERFACE_UPPER_MAC_ADDR": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "1",
+                        "name": "Ethernet0",
+                        "speed": 25000,
+                        "mode":"trunk"
+                    }
+                ]
+            }
+        },
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "description": "vlan_nat",
+                        "name": "Vlan100"
+                    }
+                ]
+            },
+            "sonic-vlan:VLAN_MEMBER": {
+                "VLAN_MEMBER_LIST": [
+                    {
+                        "port": "Ethernet0",
+                        "tagging_mode": "tagged",
+                        "name": "Vlan100"
+                    }
+                ]
+            },
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_LIST": [
+                    {
+                        "name": "Vlan100",
+                        "mac_addr": "02:AB:CD:EF:12:34"
+                    }
+                ]
+            }
+        }
+    },
+    "VLAN_INTERFACE_INVALID_MAC_ADDR": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "1",
+                        "name": "Ethernet0",
+                        "speed": 25000,
+                        "mode":"trunk"
+                    }
+                ]
+            }
+        },
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "description": "vlan_nat",
+                        "name": "Vlan100"
+                    }
+                ]
+            },
+            "sonic-vlan:VLAN_MEMBER": {
+                "VLAN_MEMBER_LIST": [
+                    {
+                        "port": "Ethernet0",
+                        "tagging_mode": "tagged",
+                        "name": "Vlan100"
+                    }
+                ]
+            },
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_LIST": [
+                    {
+                        "name": "Vlan100",
+                        "mac_addr": "badaddr"
+                    }
+                ]
+            }
+        }
+    },
     "VLAN_MEMBERS_WITHOUT_CREATING_VLAN": {
         "sonic-port:sonic-port": {
             "sonic-port:PORT": {

--- a/src/sonic-yang-models/yang-models/sonic-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-interface.yang
@@ -5,6 +5,10 @@ module sonic-interface {
 	namespace "http://github.com/sonic-net/sonic-interface";
 	prefix intf;
 
+	import ietf-yang-types {
+		prefix yang;
+	}
+
 	import sonic-types {
 		prefix stypes;
 	}
@@ -79,6 +83,11 @@ module sonic-interface {
 					description "Enable/Disable IPv6 link local address on interface";
 					type stypes:mode-status;
 					default disable;
+				}
+
+				leaf mac_addr {
+					description "Assign administrator-provided MAC address to Interface";
+					type yang:mac-address;
 				}
 
                 leaf loopback_action {

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -9,6 +9,10 @@ module sonic-portchannel {
         prefix stypes;
     }
 
+    import ietf-yang-types {
+        prefix yang;
+    }
+
     import sonic-extension {
         prefix ext;
     }
@@ -192,6 +196,11 @@ module sonic-portchannel {
 			type stypes:mode-status;
 			default disable;
 		}
+
+                leaf mac_addr {
+                    description "Assign administrator-provided MAC address to Interface";
+                    type yang:mac-address;
+                }
 
             } /* end of list PORTCHANNEL_INTERFACE_LIST */
 

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -123,6 +123,10 @@ module sonic-vlan {
 					default disable;
 				}
 
+				leaf mac_addr {
+					description "Assign administrator-provided MAC address to Interface";
+					type yang:mac-address;
+				}
 
 				leaf loopback_action {
 					description "Packet action when a packet ingress and gets routed on the same IP interface";


### PR DESCRIPTION
## Why I did it

Backport PR sonic-net/sonic-buildimage#20968 to the 202412 branch.

The original PR updates the SONiC YANG models to include the missing `mac_addr` leaf for interface-related tables. `mac_addr` support already exists in the SONiC interface configuration path, but the YANG models and related test data did not reflect it.

## How I did it

Cherry-picked the following commits from sonic-net/sonic-buildimage#20968 onto `origin/202412`:

- `73f165c526bf594138a56ef4e3c04bf357b7b0a1` - `YANG sonic-interface: add missing mac_addr leaf`
- `7a2a4e0ba0be707fe9c5679d33d483816a977c6d` - `fix test compatibility with PR #21679`

The backport updates:

- `src/sonic-yang-models/yang-models/sonic-interface.yang`
- `src/sonic-yang-models/yang-models/sonic-portchannel.yang`
- `src/sonic-yang-models/yang-models/sonic-vlan.yang`
- related YANG model test cases and sample config data
- generated YANG configuration documentation

## Cherry-pick conflicts

One conflict was encountered while applying commit `73f165c526bf594138a56ef4e3c04bf357b7b0a1`:

- `src/sonic-yang-models/doc/Configuration.md`

The conflict was in the generated table-of-contents section. I resolved it by keeping the 202412 table of contents and applying the PR's generated documentation changes without retaining the duplicate TOC block from the source commit.

## How I verified it

- Confirmed the cherry-pick completed successfully.
- Confirmed the branch is clean and ahead of `origin/202412` by the two backported commits.
- Confirmed there are no unmerged files.
- Confirmed there are no remaining Git conflict start/end markers.
