### PR TITLE
[snmpd] Add trixie BLDENV version block to snmpd.mk

### DIFF
--- a/rules/snmpd.mk
+++ b/rules/snmpd.mk
@@ -1,6 +1,10 @@
 # snmpd package
 
-ifeq ($(BLDENV),bookworm)
+# TODO(trixie): Update version to version in Trixie
+ifeq ($(BLDENV),trixie)
+SNMPD_VERSION = 5.9.4+dfsg
+SNMPD_VERSION_FULL = $(SNMPD_VERSION)-2+deb13u1
+else ifeq ($(BLDENV),bookworm)
 SNMPD_VERSION = 5.9.3+dfsg
 SNMPD_VERSION_FULL = $(SNMPD_VERSION)-2+deb12u1
 else ifeq ($(BLDENV),bullseye)


### PR DESCRIPTION
#### Why I did it
Port the `rules/snmpd.mk` change from sonic-net/sonic-buildimage PR #25060 to the `202501` branch by adding a `trixie` `BLDENV` version block.

Upstream PR: https://github.com/sonic-net/sonic-buildimage/pull/25060

#### How I did it
Added a `trixie` `ifeq ($(BLDENV),trixie)` block at the top of the version selection in `rules/snmpd.mk`:
- `SNMPD_VERSION = 5.9.4+dfsg`
- `SNMPD_VERSION_FULL = $(SNMPD_VERSION)-2+deb13u1`

The existing `bookworm` (`-2+deb12u1`), `bullseye`, and default blocks are unchanged.

#### How to verify it
Building with `BLDENV=trixie` resolves `SNMPD_VERSION_FULL` to `5.9.4+dfsg-2+deb13u1`.