### PR TITLE
[submodule] update submodule refs for 202607

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/sonic-net/sonic-sairedis
 [submodule "sonic-swss"]
 	path = src/sonic-swss
-	url = https://github.com/sonic-net/sonic-swss
+	url = https://github.com/Azure/sonic-swss.msft
 [submodule "src/p4c-bm/p4c-bm"]
 	path = platform/p4/p4c-bm/p4c-bm
 	url = https://github.com/krambn/p4c-bm
@@ -30,16 +30,16 @@
 	url = https://github.com/p4lang/ptf.git
 [submodule "src/sonic-utilities"]
 	path = src/sonic-utilities
-	url = https://github.com/sonic-net/sonic-utilities
+	url = https://github.com/Azure/sonic-utilities.msft
 [submodule "platform/broadcom/sonic-platform-modules-arista"]
 	path = platform/broadcom/sonic-platform-modules-arista
 	url = https://github.com/aristanetworks/sonic
 [submodule "src/sonic-platform-common"]
 	path = src/sonic-platform-common
-	url = https://github.com/sonic-net/sonic-platform-common
+	url = https://github.com/Azure/sonic-platform-common.msft
 [submodule "src/sonic-platform-daemons"]
 	path = src/sonic-platform-daemons
-	url = https://github.com/sonic-net/sonic-platform-daemons
+	url = https://github.com/Azure/sonic-platform-daemons.msft
 [submodule "src/sonic-platform-pde"]
 	path = src/sonic-platform-pde
 	url = https://github.com/sonic-net/sonic-platform-pdk-pde


### PR DESCRIPTION
#### Why I did it

Repoint submodule references to the internal Microsoft (`*.msft`) forks for the `202607` branch, so the build consumes the internal versions of these components instead of the upstream public repos.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Updated `.gitmodules` to change the `url` for the following submodules from `sonic-net/*` to the corresponding `Azure/*.msft` fork:

- `src/sonic-swss`: `sonic-net/sonic-swss` -> `Azure/sonic-swss.msft`
- `src/sonic-utilities`: `sonic-net/sonic-utilities` -> `Azure/sonic-utilities.msft`
- `src/sonic-platform-common`: `sonic-net/sonic-platform-common` -> `Azure/sonic-platform-common.msft`
- `src/sonic-platform-daemons`: `sonic-net/sonic-platform-daemons` -> `Azure/sonic-platform-daemons.msft`

#### How to verify it

- Confirm `.gitmodules` points the above submodules to the `Azure/*.msft` forks.
- Run `git submodule sync` and `git submodule update --init` and verify the submodules resolve to the internal forks.
- Verify the `202607` build completes successfully with the updated submodule sources.

#### Description for the changelog

Update submodule refs to internal `*.msft` forks for 202607.
