### PR TITLE
Update sonic-linux-kernel submodule to Azure/sonic-linux-kernel.msft:202512

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,8 @@
 	branch = 202511
 [submodule "sonic-linux-kernel"]
 	path = src/sonic-linux-kernel
-	url = https://github.com/sonic-net/sonic-linux-kernel
-	branch = 202511
+	url = https://github.com/Azure/sonic-linux-kernel.msft
+	branch = 202512
 [submodule "sonic-sairedis"]
 	path = src/sonic-sairedis
 	url = https://github.com/sonic-net/sonic-sairedis


### PR DESCRIPTION
### Description of PR
Update the `sonic-linux-kernel` submodule to point to `Azure/sonic-linux-kernel.msft` (instead of the public `sonic-net/sonic-linux-kernel`), tracking branch `202512`, pinned to the latest commit `5aeab09` (merge of PR #64).

This brings in the 11 apparmor security patches (QSA-2026) that were merged from `sonic-net/sonic-linux-kernel:202511` into `Azure/sonic-linux-kernel.msft:202512` via https://github.com/Azure/sonic-linux-kernel.msft/pull/64.

### Type of change
- [x] Testbed and Framework(new/improvement)

### Approach
#### What is the motivation for this PR?
Keep the sonic-linux-kernel submodule in sonic-buildimage-msft:202512 in sync with the latest security fixes on the Azure fork's 202512 branch.

#### How did you do it?
- Updated `.gitmodules` url from `https://github.com/sonic-net/sonic-linux-kernel` to `https://github.com/Azure/sonic-linux-kernel.msft`, and branch from `202511` to `202512`.
- Updated the `src/sonic-linux-kernel` submodule gitlink from `c5625d7` to `5aeab09` (latest 202512 HEAD).

#### How did you verify/test it?
Verified the submodule gitlink resolves to a valid commit on `Azure/sonic-linux-kernel.msft:202512`, and confirmed the diff is limited to the `.gitmodules` url/branch fields and the submodule pointer.
