### PR TITLE
[Nokia] [BCM] Set sai_fec_stats_cumulative to accumulate fabric port …

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250_x3b-r0/Nokia-IXR7250-X3B/0/jr2cp-nokia-18x400g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250_x3b-r0/Nokia-IXR7250-X3B/0/jr2cp-nokia-18x400g-config.bcm
@@ -2154,3 +2154,4 @@ sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
 sai_instru_stat_accum_enable=1
 sai_dnx_ecmp_udp_weight_support=0
+sai_fec_stats_cumulative=1

--- a/device/nokia/x86_64-nokia_ixr7250_x3b-r0/Nokia-IXR7250-X3B/1/jr2cp-nokia-18x400g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250_x3b-r0/Nokia-IXR7250-X3B/1/jr2cp-nokia-18x400g-config.bcm
@@ -2158,3 +2158,4 @@ sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
 sai_instru_stat_accum_enable=1
 sai_dnx_ecmp_udp_weight_support=0
+sai_fec_stats_cumulative=1

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/jr2cp-nokia-18x100g-4x25g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/jr2cp-nokia-18x100g-4x25g-config.bcm
@@ -2104,3 +2104,4 @@ sai_instru_stat_accum_enable=1
 sai_dnx_ecmp_udp_weight_support=0
 appl_param_active_links_thr_low=1
 appl_param_active_links_thr_high=112
+sai_fec_stats_cumulative=1

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/jr2cp-nokia-18x100g-4x25g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/jr2cp-nokia-18x100g-4x25g-config.bcm
@@ -2105,3 +2105,4 @@ sai_instru_stat_accum_enable=1
 sai_dnx_ecmp_udp_weight_support=0
 appl_param_active_links_thr_low=1
 appl_param_active_links_thr_high=112
+sai_fec_stats_cumulative=1

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/jr2cp-nokia-18x400g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/jr2cp-nokia-18x400g-config.bcm
@@ -2105,3 +2105,4 @@ sai_instru_stat_accum_enable=1
 sai_dnx_ecmp_udp_weight_support=0
 appl_param_active_links_thr_low=1
 appl_param_active_links_thr_high=112
+sai_fec_stats_cumulative=1

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/jr2cp-nokia-18x400g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/jr2cp-nokia-18x400g-config.bcm
@@ -2107,3 +2107,4 @@ sai_instru_stat_accum_enable=1
 sai_dnx_ecmp_udp_weight_support=0
 appl_param_active_links_thr_low=1
 appl_param_active_links_thr_high=112
+sai_fec_stats_cumulative=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/0/config-ramon-1-0.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/0/config-ramon-1-0.bcm
@@ -1400,3 +1400,4 @@ serdes_qrtt_active_47.0=1
 
 dpp_db_path=/usr/share/bcm/db
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/1/config-ramon-1-1.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/1/config-ramon-1-1.bcm
@@ -1397,3 +1397,4 @@ serdes_qrtt_active_47.0=1
 
 dpp_db_path=/usr/share/bcm/db
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/10/config-ramon-6-0.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/10/config-ramon-6-0.bcm
@@ -1396,3 +1396,4 @@ serdes_qrtt_active_47.0=1
 
 dpp_db_path=/usr/share/bcm/db
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/11/config-ramon-6-1.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/11/config-ramon-6-1.bcm
@@ -1398,3 +1398,4 @@ serdes_qrtt_active_47.0=1
 
 dpp_db_path=/usr/share/bcm/db
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/12/config-ramon-7-0.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/12/config-ramon-7-0.bcm
@@ -1397,3 +1397,4 @@ serdes_qrtt_active_47.0=1
 
 dpp_db_path=/usr/share/bcm/db
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/13/config-ramon-7-1.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/13/config-ramon-7-1.bcm
@@ -1398,3 +1398,4 @@ serdes_qrtt_active_47.0=1
 
 dpp_db_path=/usr/share/bcm/db
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/14/config-ramon-8-0.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/14/config-ramon-8-0.bcm
@@ -1399,3 +1399,4 @@ serdes_qrtt_active_47.0=1
 
 dpp_db_path=/usr/share/bcm/db
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/15/config-ramon-8-1.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/15/config-ramon-8-1.bcm
@@ -1398,3 +1398,4 @@ serdes_qrtt_active_47.0=1
 
 dpp_db_path=/usr/share/bcm/db
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/2/config-ramon-2-0.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/2/config-ramon-2-0.bcm
@@ -1396,3 +1396,4 @@ serdes_qrtt_active_47.0=1
 
 dpp_db_path=/usr/share/bcm/db
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/3/config-ramon-2-1.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/3/config-ramon-2-1.bcm
@@ -1397,3 +1397,4 @@ serdes_qrtt_active_47.0=1
 
 dpp_db_path=/usr/share/bcm/db
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/4/config-ramon-3-0.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/4/config-ramon-3-0.bcm
@@ -1396,3 +1396,4 @@ serdes_qrtt_active_47.0=1
 
 dpp_db_path=/usr/share/bcm/db
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/5/config-ramon-3-1.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/5/config-ramon-3-1.bcm
@@ -1397,3 +1397,4 @@ serdes_qrtt_active_47.0=1
 
 dpp_db_path=/usr/share/bcm/db
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/6/config-ramon-4-0.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/6/config-ramon-4-0.bcm
@@ -1396,3 +1396,4 @@ serdes_qrtt_active_47.0=1
 
 dpp_db_path=/usr/share/bcm/db
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/7/config-ramon-4-1.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/7/config-ramon-4-1.bcm
@@ -1397,3 +1397,4 @@ serdes_qrtt_active_47.0=1
 
 dpp_db_path=/usr/share/bcm/db
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/8/config-ramon-5-0.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/8/config-ramon-5-0.bcm
@@ -1396,3 +1396,4 @@ serdes_qrtt_active_47.0=1
 
 dpp_db_path=/usr/share/bcm/db
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/9/config-ramon-5-1.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/9/config-ramon-5-1.bcm
@@ -1397,3 +1397,4 @@ serdes_qrtt_active_47.0=1
 
 dpp_db_path=/usr/share/bcm/db
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The fabric counters are accumulated as reported in issue https://github.com/sonic-net/sonic-buildimage/issues/23806
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
BCM committed the fix for https://github.com/sonic-net/sonic-buildimage/issues/23806 to SAI 14.1 and SAI 15.2 and also need to enable sai_fec_stats_cumulative=1 soc variable
#### How to verify it
Verified in Nokia DNX platforms that the fabric counters are accumulated with BCM fix and sai_fec_stats_cumulative=1
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

