### PR TITLE
Fix database config JSON publish race

### DIFF
--- a/dockers/docker-database/docker-database-init.sh
+++ b/dockers/docker-database/docker-database-init.sh
@@ -46,10 +46,11 @@ mkdir -p $REDIS_DIR/sonic-db
 mkdir -p /etc/supervisor/conf.d/
 
 if [ -f /etc/sonic/database_config$NAMESPACE_ID.json ]; then
-    cp /etc/sonic/database_config$NAMESPACE_ID.json $REDIS_DIR/sonic-db/database_config.json
+    cp /etc/sonic/database_config$NAMESPACE_ID.json $REDIS_DIR/sonic-db/database_config.json.tmp
 else
-    HOST_IP=$host_ip REDIS_PORT=$redis_port DATABASE_TYPE=$DATABASE_TYPE j2 /usr/share/sonic/templates/database_config.json.j2 > $REDIS_DIR/sonic-db/database_config.json
+    HOST_IP=$host_ip REDIS_PORT=$redis_port DATABASE_TYPE=$DATABASE_TYPE j2 /usr/share/sonic/templates/database_config.json.j2 > $REDIS_DIR/sonic-db/database_config.json.tmp
 fi
+mv $REDIS_DIR/sonic-db/database_config.json.tmp $REDIS_DIR/sonic-db/database_config.json
 
 # on VoQ system, we only publish redis_chassis instance and CHASSIS_APP_DB when
 # either chassisdb.conf indicates starts chassis_db or connect to chassis_db,
@@ -68,7 +69,9 @@ chassisdb_config="/usr/share/sonic/platform/chassisdb.conf"
 
 db_cfg_file="/var/run/redis/sonic-db/database_config.json"
 db_cfg_file_tmp="/var/run/redis/sonic-db/database_config.json.tmp"
+db_cfg_file_publish="/var/run/redis/sonic-db/database_config.json.publish"
 cp $db_cfg_file $db_cfg_file_tmp
+cp $db_cfg_file $db_cfg_file_publish
 
 if [[ $DATABASE_TYPE == "chassisdb" ]]; then
     # Docker init for database-chassis
@@ -80,7 +83,7 @@ if [[ $DATABASE_TYPE == "chassisdb" ]]; then
     sonic-cfggen -j $db_cfg_file_tmp \
     -t /usr/share/sonic/templates/supervisord.conf.j2,/etc/supervisor/conf.d/supervisord.conf \
     -t /usr/share/sonic/templates/critical_processes.j2,/etc/supervisor/critical_processes
-    rm $db_cfg_file_tmp
+    rm $db_cfg_file_tmp $db_cfg_file_publish
     chown -R redis:redis $VAR_LIB_REDIS_CHASSIS_DIR
     chown -R redis:redis $REDIS_DIR
     exec /usr/local/bin/supervisord
@@ -91,10 +94,11 @@ fi
 if [[ $NAMESPACE_ID == "" && $DATABASE_TYPE == "" && ( $NAMESPACE_COUNT -gt 1 || $NUM_DPU -gt 1) ]]
 then
     if [ -f /etc/sonic/database_global.json ]; then
-        cp /etc/sonic/database_global.json $REDIS_DIR/sonic-db/database_global.json
+        cp /etc/sonic/database_global.json $REDIS_DIR/sonic-db/database_global.json.tmp
     else
-        j2 /usr/share/sonic/templates/database_global.json.j2 > $REDIS_DIR/sonic-db/database_global.json
+        j2 /usr/share/sonic/templates/database_global.json.j2 > $REDIS_DIR/sonic-db/database_global.json.tmp
     fi
+    mv $REDIS_DIR/sonic-db/database_global.json.tmp $REDIS_DIR/sonic-db/database_global.json
 fi
 # delete chassisdb config to generate supervisord config
 update_chassisdb_config -j $db_cfg_file_tmp -d
@@ -103,11 +107,13 @@ sonic-cfggen -j $db_cfg_file_tmp \
 -t /usr/share/sonic/templates/critical_processes.j2,/etc/supervisor/critical_processes
 
 if [[ "$start_chassis_db" != "1" ]] && [[ -z "$chassis_db_address" ]]; then
-     cp $db_cfg_file_tmp $db_cfg_file
+     mv $db_cfg_file_tmp $db_cfg_file
+     rm -f $db_cfg_file_publish
 else
-     update_chassisdb_config -j $db_cfg_file -p $chassis_db_port
+     update_chassisdb_config -j $db_cfg_file_publish -p $chassis_db_port
+     mv $db_cfg_file_publish $db_cfg_file
+     rm -f $db_cfg_file_tmp
 fi
-rm $db_cfg_file_tmp
 
 # copy dump.rdb file to each instance for restoration
 DUMPFILE=/var/lib/redis/dump.rdb

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -127,35 +127,55 @@ function setPlatformLagIdBoundaries()
         redis.call('rpush','SYSTEM_LAG_IDS_FREE_LIST', tostring(id))
     end" 0 $lag_id_start $lag_id_end
 }
+function waitForFileToBeValidJson()
+{
+    # Waits for $1 to exist AND contain valid, fully-rendered JSON, instead of blindly
+    # sleeping. The file is written by another process via a plain '>' redirect from a
+    # jinja2/j2 render, so a consumer can observe the file after it has been created
+    # (truncated to 0 bytes) but before rendering has finished writing to it. Polling for
+    # existence alone is therefore not sufficient and led to intermittent
+    # "unexpected end of input" json parse errors on slower devices.
+    file=$1
+    max_wait_seconds=30
+    poll_interval_seconds=0.2
+    cnt=0
+    max_cnt=$(python -c "print(int($max_wait_seconds / $poll_interval_seconds))")
+    while [ ! -f "$file" ] || ! python -c "import sys, json; json.load(open(sys.argv[1]))" "$file" >/dev/null 2>&1
+    do
+        sleep $poll_interval_seconds
+        cnt=$(( $cnt + 1))
+        if [ $cnt -ge $max_cnt ]; then
+            echo "Error: $file not found or not valid JSON after ${max_wait_seconds}s"
+            return 1
+        fi
+    done
+    return 0
+}
+
 function waitForAllInstanceDatabaseConfigJsonFilesReady()
 {
-    if [ ! -z "$DEV" ]; then
-	cnt=0
-	SONIC_DB_GLOBAL_JSON="/var/run/redis/sonic-db/database_global.json"
-	if [ -f "$SONIC_DB_GLOBAL_JSON" ]; then
-            # Create a separate python script to get a list of location of all instance database_config.json file
-            redis_database_cfg_list=`/usr/bin/python -c "import sys; import os; import json; f=open(sys.argv[1]); \
-            		    global_db_dir = os.path.dirname(sys.argv[1]); data=json.load(f); \
-                            print(\" \".join([os.path.normpath(global_db_dir+'/'+elem['include']) \
-                            for elem in data['INCLUDES'] if 'namespace' in elem])); f.close()" $SONIC_DB_GLOBAL_JSON`
-            for file  in $redis_database_cfg_list
-            do
-		while [ ! -f $file ]
-		do
-                    sleep 1
-                    cnt=$(( $cnt + 1))
-                    if [ $cnt -ge 60 ]; then
-			echo "Error: $file not found"
-			break
-                    fi
-		done
-            done
-        fi
-        # Delay 5 seconds to allow all instance database_config.json files to be completely generated and fully accessible.
-        # This delay is needed to make sure that the database_config.json files are correctly rendered from j2 template
-        # files ( rendering takes some time )
-        sleep 5
+    if [ -z "$DEV" ]; then
+        return 0
     fi
+
+    SONIC_DB_GLOBAL_JSON="/var/run/redis/sonic-db/database_global.json"
+    waitForFileToBeValidJson "$SONIC_DB_GLOBAL_JSON" || return 1
+
+    # Create a separate python script to get a list of location of all instance database_config.json file
+    redis_database_cfg_list=`/usr/bin/python -c "import sys; import os; import json; f=open(sys.argv[1]); \
+                    global_db_dir = os.path.dirname(sys.argv[1]); data=json.load(f); \
+                    print(\" \".join([os.path.normpath(global_db_dir+'/'+elem['include']) \
+                    for elem in data['INCLUDES'] if 'namespace' in elem])); f.close()" $SONIC_DB_GLOBAL_JSON`
+    if [ $? -ne 0 ]; then
+        echo "Error: failed to parse $SONIC_DB_GLOBAL_JSON"
+        return 1
+    fi
+
+    for file in $redis_database_cfg_list
+    do
+        waitForFileToBeValidJson "$file" || return 1
+    done
+    return 0
 }
 {%- endif %}
 
@@ -238,7 +258,7 @@ function postStartAction()
 	# sonic-db-cli try to initialize the global database. If in multiasic platform, inital global
         # database will try to access to all other instance database-config.json. If other instance
         # database-config.json files are not ready yet, it will generate the sonic-db-cli core files.
-	waitForAllInstanceDatabaseConfigJsonFilesReady
+	waitForAllInstanceDatabaseConfigJsonFilesReady || return 1
         until [[ ($(docker exec -i database$DEV pgrep -x -c supervisord) -gt 0) && ($($SONIC_DB_CLI PING | grep -c PONG) -gt 0) &&
                  ($(docker exec -i database$DEV sonic-db-cli PING | grep -c PONG) -gt 0) ]]; do
           sleep 1;


### PR DESCRIPTION
#### Why I did it

`database_config.json` and `database_global.json` are rendered by one process with a plain `>` redirect from a jinja2/j2 template. `>` truncates the file to 0 bytes and then streams the rendered content in, so another process can open the file after it exists but before rendering finishes, and read a truncated / partially written file. Consumers like `waitForAllInstanceDatabaseConfigJsonFilesReady` and `sonic-db-cli` then hit `unexpected end of input` JSON parse errors (and sonic-db-cli can core dump). The old code only waited on file existence and then slept a fixed 5 seconds, which is racy and unreliable on slower / multi-ASIC devices (seen on Cisco 8800 T2 chassis).

##### Work item tracking
- Microsoft ADO **(number only)**: 38753975

#### How I did it

`dockers/docker-database/docker-database-init.sh`:
- Render `database_config.json` and `database_global.json` into a `.tmp` file first, then `mv` it into place. `mv` is atomic on the same filesystem, so a reader never sees a half-written file.
- Add a `database_config.json.publish` temp for the chassisdb path and publish it with `mv` (the final `cp` becomes `mv`), so the published copy is atomic too.

`files/build_templates/docker_image_ctl.j2`:
- Add `waitForFileToBeValidJson()` that polls (0.2s interval, up to 30s) until the file exists AND parses as valid JSON, replacing the old existence-only `while [ ! -f ]` loop plus a blind `sleep 5`.
- Use it for `database_global.json` and each per-namespace `database_config.json`, propagate failures with `|| return 1`, and early-return when not in the multi-ASIC (`$DEV`) path.

#### How to verify it

- On a multi-ASIC / chassis device (Cisco 8800 T2), restart the database service / reboot repeatedly and confirm there are no `unexpected end of input` JSON parse errors and no `sonic-db-cli` core dumps, and that the database containers come up on all namespaces (`sonic-db-cli PING` returns `PONG`).

#### Which release branch to backport (provide reason below if selected)

Target branch of this PR is **202405**. Upstream equivalent: sonic-net/sonic-buildimage#28343 (against master). No older-branch backport requested here.

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

- [x] 20240532.78-dbrace (internal Cisco 8800 202405-chassis test image, built on top of 20240532.78)

#### Description for the changelog
Fix a race that could publish a truncated database_config.json / database_global.json by writing to a temp file and moving it into place, and wait for valid JSON instead of a fixed sleep.

#### Link to config_db schema for YANG module changes
N/A - no YANG / config_db schema change.

#### A picture of a cute animal (not mandatory but encouraged)
🐢
