### PR TITLE
[202405][GCU] Backport sonic-yang-mgmt + libyang perf-dep patches (co-req sonic-utilities.msft#417 — see merge order)

### DIFF
--- a/src/libyang/patch/libyang-leaf-must.patch
+++ b/src/libyang/patch/libyang-leaf-must.patch
@@ -1,0 +1,29 @@
+diff --git a/swig/cpp/src/Tree_Schema.cpp b/swig/cpp/src/Tree_Schema.cpp
+index 3587320..8da206a 100644
+--- a/swig/cpp/src/Tree_Schema.cpp
++++ b/swig/cpp/src/Tree_Schema.cpp
+@@ -344,6 +344,7 @@ S_Schema_Node Schema_Node_Choice::dflt() {
+ Schema_Node_Leaf::~Schema_Node_Leaf() {};
+ S_Set Schema_Node_Leaf::backlinks() LY_NEW_CASTED(lys_node_leaf, node, backlinks, Set);
+ S_When Schema_Node_Leaf::when() LY_NEW_CASTED(lys_node_leaf, node, when, When);
++std::vector<S_Restr> Schema_Node_Leaf::must() LY_NEW_LIST_CASTED(lys_node_leaf, node, must, must_size, Restr);
+ S_Type Schema_Node_Leaf::type() {return std::make_shared<Type>(&((struct lys_node_leaf *)node)->type, deleter);}
+ S_Schema_Node_List Schema_Node_Leaf::is_key() {
+     uint8_t pos;
+diff --git a/swig/cpp/src/Tree_Schema.hpp b/swig/cpp/src/Tree_Schema.hpp
+index d506891..f8ecc50 100644
+--- a/swig/cpp/src/Tree_Schema.hpp
++++ b/swig/cpp/src/Tree_Schema.hpp
+@@ -683,8 +683,12 @@ public:
+     ~Schema_Node_Leaf();
+     /** get backlinks variable from [lys_node_leaf](@ref lys_node_leaf)*/
+     S_Set backlinks();
++    /** get must_size variable from [lys_node_leaf](@ref lys_node_leaf)*/
++    uint8_t must_size() {return ((struct lys_node_leaf *)node)->must_size;};
+     /** get when variable from [lys_node_leaf](@ref lys_node_leaf)*/
+     S_When when();
++    /** get must variable from [lys_node_leaf](@ref lys_node_leaf)*/
++    std::vector<S_Restr> must();
+     /** get type variable from [lys_node_leaf](@ref lys_node_leaf)*/
+     S_Type type();
+     /** get units variable from [lys_node_leaf](@ref lys_node_leaf)*/

--- a/src/libyang/patch/series
+++ b/src/libyang/patch/series
@@ -3,3 +3,4 @@ libyang_mgmt_framework.patch
 swig.patch
 large_file_support_arm32.patch
 debian-packaging-files.patch
+libyang-leaf-must.patch

--- a/src/sonic-yang-mgmt/setup.py
+++ b/src/sonic-yang-mgmt/setup.py
@@ -30,6 +30,7 @@ setup(
     install_requires = [
         'xmltodict==0.12.0',
         'ijson==3.2.3',
+        'jsonpointer>=1.9',
         'jsondiff>=1.2.0',
         'tabulate==0.9.0'
     ],
@@ -46,7 +47,7 @@ setup(
     include_package_data=True,
     keywords='sonic-yang-mgmt',
     name='sonic-yang-mgmt',
-    py_modules=['sonic_yang', 'sonic_yang_ext'],
+    py_modules=['sonic_yang', 'sonic_yang_ext', 'sonic_yang_path'],
     packages=find_packages(),
     version='1.0',
     zip_safe=False,

--- a/src/sonic-yang-mgmt/sonic_yang_ext.py
+++ b/src/sonic-yang-mgmt/sonic_yang_ext.py
@@ -7,6 +7,8 @@ import syslog
 from json import dump, dumps, loads
 from xmltodict import parse
 from glob import glob
+import copy
+from sonic_yang_path import SonicYangPathMixin
 
 Type_1_list_maps_model = [
     'DSCP_TO_TC_MAP_LIST',
@@ -41,7 +43,7 @@ class SonicYangException(Exception):
     pass
 
 # class sonic_yang methods, use mixin to extend sonic_yang
-class SonicYangExtMixin:
+class SonicYangExtMixin(SonicYangPathMixin):
 
     """
     load all YANG models, create JSON of yang models. (Public function)
@@ -323,15 +325,21 @@ class SonicYangExtMixin:
     """
     Crop config as per yang models,
     This Function crops from config only those TABLEs, for which yang models is
-    provided. The Tables without YANG models are stored in
-    self.tablesWithOutYangModels.
+    provided. If there are tables to modify it will perform a deepcopy of the
+    original structure in case anyone is holding a reference.
+    The Tables without YANG models are stored in self.tablesWithOutYangModels.
     """
     def _cropConfigDB(self, croppedFile=None):
-
+        isCopy = False
         tables = list(self.jIn.keys())
         for table in tables:
             if table not in self.confDbYangMap:
-                # store in tablesWithOutYang
+                # Make sure we duplicate if we're modifying so if a caller
+                # has a reference we don't clobber it.
+                if not isCopy:
+                    isCopy = True
+                    self.jIn = copy.deepcopy(self.jIn)
+                # store in tablesWithOutYang and purge
                 self.tablesWithOutYang[table] = self.jIn[table]
                 del self.jIn[table]
 
@@ -1213,7 +1221,7 @@ class SonicYangExtMixin:
 
     """
     load_data: load Config DB, crop, xlate and create data tree from it. (Public)
-    input:    data
+    input:    configdbJson - will NOT be modified
               debug Flag
     returns:  True - success   False - failed
     """
@@ -1228,7 +1236,8 @@ class SonicYangExtMixin:
           # reset xlate and tablesWithOutYang
           self.xlateJson = dict()
           self.tablesWithOutYang = dict()
-          # self.jIn will be cropped
+          # self.jIn will be cropped if needed, however it will duplicate the object
+          # so the original is not modified
           self._cropConfigDB()
           # xlated result will be in self.xlateJson
           self._xlateConfigDB(xlateFile=xlateFile)

--- a/src/sonic-yang-mgmt/sonic_yang_ext.py
+++ b/src/sonic-yang-mgmt/sonic_yang_ext.py
@@ -1223,9 +1223,19 @@ class SonicYangExtMixin(SonicYangPathMixin):
     load_data: load Config DB, crop, xlate and create data tree from it. (Public)
     input:    configdbJson - will NOT be modified
               debug Flag
-    returns:  True - success   False - failed
+              quiet  - when True, suppress the informational "Try to load Data"
+                       syslog line and the "Data Loading Failed" syslog LOG_ERR
+                       line on failure. The SonicYangException is still raised
+                       so callers that want to recover silently (e.g. tools that
+                       speculatively validate many candidate configs, like the
+                       generic_config_updater patch sorter) can do so without
+                       polluting /var/log/syslog with transient errors they are
+                       already handling via the exception. Default False keeps
+                       existing behavior for all current callers.
+    returns:  True on success
+    raises:   SonicYangException on failure
     """
-    def loadData(self, configdbJson, debug=False):
+    def loadData(self, configdbJson, debug=False, quiet=False):
 
        try:
           # write Translated config in file if debug enabled
@@ -1242,14 +1252,16 @@ class SonicYangExtMixin(SonicYangPathMixin):
           # xlated result will be in self.xlateJson
           self._xlateConfigDB(xlateFile=xlateFile)
           #print(self.xlateJson)
-          self.sysLog(msg="Try to load Data in the tree")
+          if not quiet:
+              self.sysLog(msg="Try to load Data in the tree")
           self.root = self.ctx.parse_data_mem(dumps(self.xlateJson), \
                         ly.LYD_JSON, ly.LYD_OPT_CONFIG|ly.LYD_OPT_STRICT)
 
        except Exception as e:
            self.root = None
-           self.sysLog(msg="Data Loading Failed:{}".format(str(e)), \
-            debug=syslog.LOG_ERR, doPrint=True)
+           if not quiet:
+               self.sysLog(msg="Data Loading Failed:{}".format(str(e)), \
+                debug=syslog.LOG_ERR, doPrint=True)
            raise SonicYangException("Data Loading Failed\n{}".format(str(e)))
 
        return True

--- a/src/sonic-yang-mgmt/sonic_yang_ext.py
+++ b/src/sonic-yang-mgmt/sonic_yang_ext.py
@@ -69,6 +69,8 @@ class SonicYangExtMixin:
             self._loadJsonYangModel()
             # create a map from config DB table to yang container
             self._createDBTableToModuleMap()
+            # compile uses clause (embed into schema)
+            self._compileUsesClause()
         except Exception as e:
             self.sysLog(msg="Yang Models Load failed:{}".format(str(e)), \
                 debug=syslog.LOG_ERR, doPrint=True)
@@ -127,8 +129,10 @@ class SonicYangExtMixin:
 
             for grouping in groupings:
                 gName = grouping["@name"]
-                gLeaf = grouping["leaf"]
-                self.preProcessedYang['grouping'][moduleName][gName] = gLeaf
+                self.preProcessedYang['grouping'][moduleName][gName] = dict()
+                self.preProcessedYang['grouping'][moduleName][gName]["leaf"] = grouping.get('leaf')
+                self.preProcessedYang['grouping'][moduleName][gName]["leaf-list"] = grouping.get('leaf-list')
+                self.preProcessedYang['grouping'][moduleName][gName]["choice"] = grouping.get('choice')
 
         except Exception as e:
             self.sysLog(msg="_preProcessYangGrouping failed:{}".format(str(e)), \
@@ -159,14 +163,113 @@ class SonicYangExtMixin:
             raise e
         return
 
-    """
-    Create a map from config DB tables to container in yang model
-    This module name and topLevelContainer are fetched considering YANG models are
-    written using below Guidelines:
-    https://github.com/Azure/SONiC/blob/master/doc/mgmt/SONiC_YANG_Model_Guidelines.md.
-    """
-    def _createDBTableToModuleMap(self):
+    def _compileUsesClauseRefineApply(self, refine, model):
+        for item in model:
+            if item["@name"] == refine["@target-node"]:
+                # NOTE: We only handle 'description' and 'mandatory'
+                if refine.get('description') is not None:
+                    item["description"] = refine["description"]
+                if refine.get('mandatory') is not None:
+                    item["mandatory"] = refine["mandatory"]
+                return
 
+    def _compileUsesClauseRefine(self, refine, model):
+        # Nothing to refine
+        if refine is None:
+            return
+
+        # Convert to list if not already
+        if not isinstance(refine, list):
+            refine = [ refine ]
+
+        # Iterate across each refine
+        for r in refine:
+            self._compileUsesClauseRefineApply(r, model)
+
+
+    def _compileUsesClauseList(self, model, group, name, refine):
+        # If group doesn't have this entry, nothing to do.
+        groupobj = group.get(name)
+        if groupobj is None:
+            return
+
+        # model doesn't have this entry type, create it as a list
+        if model.get(name) is None:
+            model[name] = []
+
+        # model has this entry type, but its not a list, convert
+        if not isinstance(model[name], list):
+            model[name] = [ model[name] ]
+
+        if isinstance(groupobj, list):
+            model[name].extend(groupobj)
+        else:
+            model[name].append(groupobj)
+
+        self._compileUsesClauseRefine(refine, model[name])
+
+    def _compileUsesClauseModel(self, module, model):
+        """
+        Recursively process the yang schema looking for the "uses" clause under
+        "container", "list", and "choice"/"case" nodes.  Merge in the "uses"
+        dictionaries for leaf and leaf-list so callers don't need to try to do
+        their own "uses" processing.  Remove the "uses" member when processed so
+        anyone expecting it won't try to re-process.  It will just look like a
+        yang model that doesn't use "uses" so shouldn't cause compatibility issues.
+        """
+        if isinstance(model, list):
+            for item in model:
+                self._compileUsesClauseModel(module, item)
+            return
+
+        for model_name in [ "container", "list", "choice", "case" ]:
+            node = model.get(model_name)
+            if node:
+                self._compileUsesClauseModel(module, node)
+
+        uses_s = model.get("uses")
+        if not uses_s:
+            return
+
+        # Always make as a list
+        if isinstance(uses_s, dict):
+            uses_s = [uses_s]
+
+        # uses Example: "@name": "bgpcmn:sonic-bgp-cmn"
+        for uses in uses_s:
+            # Assume ':'  means reference to another module
+            if ':' in uses['@name']:
+                prefix = uses['@name'].split(':')[0].strip()
+                uses_module_name = self._findYangModuleFromPrefix(prefix, module)
+            else:
+                uses_module_name = module['@name']
+            grouping = uses['@name'].split(':')[-1].strip()
+            groupdata = self.preProcessedYang['grouping'][uses_module_name][grouping]
+
+            # Merge leaf from uses
+            refine = uses.get("refine")
+            self._compileUsesClauseList(model, groupdata, 'leaf', refine)
+            self._compileUsesClauseList(model, groupdata, 'leaf-list', refine)
+            self._compileUsesClauseList(model, groupdata, 'choice', refine)
+
+        # Delete the uses node so callers don't use it.
+        del model["uses"]
+
+    def _compileUsesClause(self):
+        try:
+            for module in self.yJson:
+                self._compileUsesClauseModel(module["module"], module["module"])
+        except Exception as e:
+            traceback.print_exc()
+            raise e
+
+    def _createDBTableToModuleMap(self):
+        """
+        Create a map from config DB tables to container in yang model
+        This module name and topLevelContainer are fetched considering YANG models are
+        written using below Guidelines:
+        https://github.com/Azure/SONiC/blob/master/doc/mgmt/SONiC_YANG_Model_Guidelines.md.
+        """
         for j in self.yJson:
             # get module name
             moduleName = j['module']['@name']
@@ -319,44 +422,6 @@ class SonicYangExtMixin:
             raise e
         return None
 
-    def _fillLeafDictUses(self, uses_s, table, leafDict):
-        '''
-            Find the leaf(s) in a grouping which maps to given uses statement,
-            then fill leafDict with leaf(s) information.
-
-            Parameters:
-                uses_s (str): uses statement in yang module.
-                table (str): config DB table, this table is being translated.
-                leafDict (dict): dict with leaf(s) information for List\Container
-                    corresponding to config DB table.
-
-            Returns:
-                 (void)
-        '''
-        try:
-            # make a list
-            if isinstance(uses_s, dict):
-                uses_s = [uses_s]
-            # find yang module for current table
-            table_module = self.confDbYangMap[table]['yangModule']
-            # uses Example: "@name": "bgpcmn:sonic-bgp-cmn"
-            for uses in uses_s:
-                # Assume ':'  means reference to another module
-                if ':' in uses['@name']:
-                    prefix = uses['@name'].split(':')[0].strip()
-                    uses_module_name = self._findYangModuleFromPrefix(prefix, table_module)
-                else:
-                    uses_module_name = table_module['@name']
-                grouping = uses['@name'].split(':')[-1].strip()
-                leafs = self.preProcessedYang['grouping'][uses_module_name][grouping]
-                self._fillLeafDict(leafs, leafDict)
-        except Exception as e:
-            self.sysLog(msg="_fillLeafDictUses failed:{}".format(str(e)), \
-                debug=syslog.LOG_ERR, doPrint=True)
-            raise e
-
-        return
-
     def _createLeafDict(self, model, table):
         '''
             create a dict to map each key under primary key with a leaf in yang model.
@@ -392,10 +457,6 @@ class SonicYangExtMixin:
 
         # leaf-lists
         self._fillLeafDict(model.get('leaf-list'), leafDict, True)
-
-        # uses should map to grouping,
-        if model.get('uses') is not None:
-            self._fillLeafDictUses(model.get('uses'), table, leafDict)
 
         return leafDict
 

--- a/src/sonic-yang-mgmt/sonic_yang_path.py
+++ b/src/sonic-yang-mgmt/sonic_yang_path.py
@@ -1,0 +1,573 @@
+# This script is used as extension of sonic_yang class. It has methods of
+# class sonic_yang. A separate file is used to avoid a single large file.
+
+from __future__ import print_function
+from json import dump, dumps, loads
+import sonic_yang_ext
+import re
+from jsonpointer import JsonPointer
+from typing import List
+
+# class sonic_yang methods related to path handling, use mixin to extend sonic_yang
+class SonicYangPathMixin:
+    """
+    All xpath operations in this class are only relevent to ConfigDb and the conversion to YANG xpath.
+    It is not meant to support all the xpath functionalities, just the ones relevent to ConfigDb/YANG.
+    """
+    @staticmethod
+    def configdb_path_split(configdb_path: str):
+        if configdb_path is None or configdb_path == "" or configdb_path == "/":
+            return []
+        return JsonPointer(configdb_path).parts
+
+    @staticmethod
+    def configdb_path_join(configdb_tokens: List[str]):
+        return JsonPointer.from_parts(configdb_tokens).path
+
+    @staticmethod
+    def xpath_join(xpath_tokens: List[str], schema_xpath: bool) -> str:
+        if not schema_xpath:
+            return "/" + "/".join(xpath_tokens)
+
+        # Schema XPath in libyang v1 wants each token prefixed with the module name.
+        # The first token should have this, use that to prefix the rest.
+        module_name = xpath_tokens[0].split(":")[0]
+
+        return "/" + ("/" + module_name + ":").join(xpath_tokens)
+
+    @staticmethod
+    def xpath_split(xpath: str) -> List[str]:
+        """
+        Splits the given xpath into tokens by '/'.
+
+        Example:
+          xpath: /sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[name='Vlan1000'][port='Ethernet8']/tagging_mode
+          tokens: sonic-vlan:sonic-vlan, VLAN_MEMBER, VLAN_MEMBER_LIST[name='Vlan1000'][port='Ethernet8'], tagging_mode
+        """
+        if xpath == "":
+            raise ValueError("xpath cannot be empty")
+
+        if xpath == "/":
+            return []
+
+        idx = 0
+        tokens = []
+        while idx < len(xpath):
+            end = SonicYangPathMixin.__get_xpath_token_end(idx+1, xpath)
+            token = xpath[idx+1:end]
+            tokens.append(token)
+            idx = end
+
+        return tokens
+
+    def configdb_path_to_xpath(self, configdb_path: str, schema_xpath: bool=False, configdb: dict=None) -> str:
+        """
+        Converts the given ConfigDB path to a Yang data module xpath.
+        Parameters:
+          - configdb_path: The JSON path in the form taken by Config DB,
+            e.g. /VLAN_MEMBER/Vlan1000|Ethernet8/tagging_mode
+          - schema_xpath: Whether or not to output the xpath in schema form or data form.  Schema form will not use
+            the data in the path, only table/list names.  Defaults to false, so will emit data xpaths.
+          - configdb: If provided, and schema_xpath is false, will also emit the xpath token for a specific leaf-list
+            entry based on the value within the configdb itself.  This is provided in the parsed configdb format, such
+            as returned from json.loads().
+                           
+        Example:
+          1. configdb_path: /VLAN_MEMBER/Vlan1000|Ethernet8/tagging_mode
+             schema_xpath: False
+             returns: /sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[name='Vlan1000'][port='Ethernet8']/tagging_mode
+          2. configdb_path: /VLAN_MEMBER/Vlan1000|Ethernet8/tagging_mode
+             schema_xpath: True
+             returns: /sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST/tagging_mode
+        """
+
+        if configdb_path is None or len(configdb_path) == 0 or configdb_path == "/":
+            return "/"
+
+        # Fetch from cache if available
+        key = (configdb_path, schema_xpath)
+        result = self.configPathCache.get(key)
+        if result is not None:
+            return result
+
+        # Not available, go through conversion
+        tokens = self.configdb_path_split(configdb_path)
+        if len(tokens) == 0:
+            return None
+
+        xpath_tokens = []
+        table = tokens[0]
+
+        cmap = self.confDbYangMap[table]
+
+        # getting the top level element <module>:<topLevelContainer>
+        xpath_tokens.append(cmap['module']+":"+cmap['topLevelContainer'])
+
+        xpath_tokens.extend(self.__get_xpath_tokens_from_container(cmap['container'], tokens, 0, schema_xpath, configdb))
+
+        xpath = self.xpath_join(xpath_tokens, schema_xpath)
+
+        # Save to cache
+        self.configPathCache[key] = xpath
+
+        return xpath
+
+
+    def xpath_to_configdb_path(self, xpath: str, configdb: dict = None) -> str:
+        """
+        Converts the given XPATH to ConfigDB Path. 
+        If the xpath references a list value and the configdb is provided, the 
+        generated path will reference the index of the list value
+        Example:
+          xpath: /sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[name='Vlan1000'][port='Ethernet8']/tagging_mode
+          path: /VLAN_MEMBER/Vlan1000|Ethernet8/tagging_mode
+        """
+        tokens = self.xpath_split(xpath)
+        if len(tokens) == 0:
+            return ""
+
+        if len(tokens) == 1:
+            raise ValueError("xpath cannot be just the module-name, there is no mapping to path")
+
+        table = tokens[1]
+        cmap = self.confDbYangMap[table]
+
+        configdb_path_tokens = self.__get_configdb_path_tokens_from_container(cmap['container'], tokens, 1, configdb)
+        return self.configdb_path_join(configdb_path_tokens)
+
+
+    def __get_xpath_tokens_from_container(self, model: dict, configdb_path_tokens: List[str], token_index: int, schema_xpath: bool, configdb: dict) -> List[str]:
+        token = configdb_path_tokens[token_index]
+        xpath_tokens = [token]
+
+        if len(configdb_path_tokens)-1 == token_index:
+            return xpath_tokens
+
+        # check if the configdb token is referring to a list
+        list_model = self.__get_list_model(model, configdb_path_tokens, token_index)
+        if list_model:
+            new_xpath_tokens = self.__get_xpath_tokens_from_list(list_model, configdb_path_tokens, token_index+1, schema_xpath, configdb)
+            xpath_tokens.extend(new_xpath_tokens)
+            return xpath_tokens
+
+        # check if it is targetting a child container
+        child_container_model = self.__get_model(model.get('container'), configdb_path_tokens[token_index+1])
+        if child_container_model:
+            new_xpath_tokens = self.__get_xpath_tokens_from_container(child_container_model, configdb_path_tokens, token_index+1, schema_xpath, configdb)
+            xpath_tokens.extend(new_xpath_tokens)
+            return xpath_tokens
+
+        leaf_token = self.__get_xpath_token_from_leaf(model, configdb_path_tokens, token_index+1, schema_xpath, configdb)
+        xpath_tokens.append(leaf_token)
+
+        return xpath_tokens
+
+
+    # Locate a model matching the given name.  If the model provided is a dict,
+    # it simply ensures the name matches and returns self.  If the model
+    # provided is a list it scans the list for a matching name and returns that
+    # model.
+    def __get_model(self, model, name: str) -> dict:
+        if isinstance(model, dict) and model['@name'] == name:
+            return model
+        if isinstance(model, list):
+            for submodel in model:
+                if submodel['@name'] == name:
+                    return submodel
+
+        return None
+
+
+    # A configdb list specifies the container name, plus the keys separated by |.  We are 
+    # scanning the model for a list with a matching *number* of keys and returning the
+    # reference to the model with the definition.  It is not valid to have 2 lists in
+    # the same container with the same number of keys since we have no way to match.
+    def __get_list_model(self, model: dict, configdb_path_tokens: List[str], token_index: int) -> dict:
+        parent_container_name = configdb_path_tokens[token_index]
+        clist = model.get('list')
+        # Container contains a single list, just return it
+        # TODO: check if matching also by name is necessary
+        if isinstance(clist, dict):
+            return clist
+
+        if isinstance(clist, list):
+            configdb_values_str = configdb_path_tokens[token_index+1]
+            # Format: "value1|value2|value|..."
+            configdb_values = configdb_values_str.split("|")
+            for list_model in clist:
+                yang_keys_str = list_model['key']['@value']
+                # Format: "key1 key2 key3 ..."
+                yang_keys = yang_keys_str.split()
+                # if same number of values and keys, this is the intended list-model
+                # TODO: Match also on types and not only the length of the keys/values
+                if len(yang_keys) == len(configdb_values):
+                    return list_model
+            raise ValueError(f"Container {parent_container_name} has multiple lists, "
+                             f"but none of them match the config_db value {configdb_values_str}")
+
+
+    def __get_xpath_tokens_from_list(self, model: dict, configdb_path_tokens: List[str], token_index: int, schema_xpath: bool, configdb: dict):
+        item_token=""
+
+        if schema_xpath:
+            item_token = model['@name']
+        else:
+            keyDict = self.__parse_configdb_key_to_dict(model['key']['@value'], configdb_path_tokens[token_index])
+            keyTokens = [f"[{key}='{keyDict[key]}']" for key in keyDict]
+            item_token = f"{model['@name']}{''.join(keyTokens)}"
+
+        xpath_tokens = [item_token]
+
+        # If we're pointing to the top level list item, and not a child leaf
+        # then we can just return.
+        if len(configdb_path_tokens)-1 == token_index:
+            return xpath_tokens
+
+        type_1_list_model = self.__type1_get_model(model)
+        if type_1_list_model:
+            token = self.__type1_get_xpath_token(type_1_list_model, configdb_path_tokens, token_index+1, schema_xpath)
+            xpath_tokens.append(token)
+            return xpath_tokens
+
+        leaf_token = self.__get_xpath_token_from_leaf(model, configdb_path_tokens, token_index+1, schema_xpath, configdb)
+        xpath_tokens.append(leaf_token)
+        return xpath_tokens
+
+
+    # Parse configdb key like Vlan1000|Ethernet8 (such as a key might be under /VLAN_MEMBER/)
+    # into its key/value dictionary form: { "name": "VLAN1000", "port": "Ethernet8" }
+    def __parse_configdb_key_to_dict(self, listKeys: str, configDbKey: str) -> dict:
+        xpath_list_keys = listKeys.split()
+        configdb_values = configDbKey.split("|")
+        # match lens
+        if len(xpath_list_keys) != len(configdb_values):
+            raise ValueError("Value not found for {} in {}".format(listKeys, configDbKey))
+        # create the keyDict
+        rv = dict()
+        for i in range(len(xpath_list_keys)):
+            rv[xpath_list_keys[i]] = configdb_values[i].strip()
+        return rv
+
+
+    # Type1 lists are lists contained within another list.  They always have exactly 1 key, and due to
+    # this they are special cased with a static lookup table.  Check to see if the
+    # specified model is a type1 list and if so, return the model.
+    def __type1_get_model(self, model: dict) -> dict:
+        list_name = model['@name']
+        if list_name not in sonic_yang_ext.Type_1_list_maps_model:
+            return None
+
+        # Type 1 list is expected to have a single inner list model.
+        # No need to check if it is a dictionary of list models.
+        return model.get('list')
+
+
+    # Type1 lists are lists contained within another list.  They always have exactly 1 key, and due to
+    # this they are special cased with a static lookup table.  This is just a helper to do a quick
+    # transformation from configdb to the xpath key.
+    def __type1_get_xpath_token(self, model: dict, configdb_path_tokens: List[str], token_index: int, schema_xpath: bool) -> str:
+        if schema_xpath:
+            return model['@name']
+        return f"{model['@name']}[{model['key']['@value']}='{configdb_path_tokens[token_index]}']"
+
+
+    # This function outputs the xpath token for leaf, choice, and leaf-list entries.
+    def __get_xpath_token_from_leaf(self, model: dict, configdb_path_tokens: List[str], token_index: int, schema_xpath: bool, configdb: dict) -> str:
+        token = configdb_path_tokens[token_index]
+
+        # checking all leaves
+        leaf_model = self.__get_model(model.get('leaf'), token)
+        if leaf_model:
+            return token
+
+        # checking choice
+        choices = model.get('choice')
+        if choices:
+            for choice in choices:
+                cases = choice['case']
+                for case in cases:
+                    leaf_model = self.__get_model(case.get('leaf'), token)
+                    if leaf_model:
+                        return token
+
+        # checking leaf-list (i.e. arrays of string, number or bool)
+        leaf_list_model = self.__get_model(model.get('leaf-list'), token)
+        if leaf_list_model:
+            # If there are no more tokens, just return the current token.
+            if len(configdb_path_tokens)-1 == token_index:
+                return token
+
+            value = self.__get_configdb_value(configdb_path_tokens, configdb)
+            if value is None or schema_xpath:
+                return token
+
+            # Reference an explicit leaf list value
+            return f"{token}[.='{value}']"
+
+        raise ValueError(f"Path token not found.\n  model: {model}\n  token_index: {token_index}\n  " + \
+                         f"path_tokens: {configdb_path_tokens}\n  config: {configdb}")
+
+
+    def __get_configdb_value(self, configdb_path_tokens: List[str], configdb: dict) -> str:
+        if configdb is None:
+            return None
+
+        ptr = configdb
+        for i in range(len(configdb_path_tokens)):
+            if isinstance(ptr, dict):
+                ptr = ptr[configdb_path_tokens[i]]
+            elif isinstance(ptr, list):
+                ptr = ptr[int(configdb_path_tokens[i])]
+            else:
+                return None
+        return ptr
+
+    @staticmethod
+    def __get_xpath_token_end(start: int, xpath: str) -> int:
+        idx = start
+        while idx < len(xpath):
+            if xpath[idx] == "/":
+                break
+            elif xpath[idx] == "[":
+                idx = SonicYangPathMixin.__get_xpath_predicate_end(idx, xpath)
+            idx = idx+1
+
+        return idx
+
+    @staticmethod
+    def __get_xpath_predicate_end(start: int, xpath: str) -> int:
+        idx = start
+        while idx < len(xpath):
+            if xpath[idx] == "]":
+                break
+            elif xpath[idx] == "'" or xpath[idx] == '"':
+                idx = SonicYangPathMixin.__get_xpath_quote_str_end(xpath[idx], idx, xpath)
+
+            idx = idx+1
+
+        return idx
+
+    @staticmethod
+    def __get_xpath_quote_str_end(ch: str, start: int, xpath: str) -> int:
+        idx = start+1 # skip first single quote
+        while idx < len(xpath):
+            if xpath[idx] == ch:
+                break
+            # libyang implements XPATH 1.0 which does not escape single or double quotes
+            # libyang src: https://netopeer.liberouter.org/doc/libyang/master/html/howtoxpath.html
+            # XPATH 1.0 src: https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-Literal
+            idx = idx+1
+
+        return idx
+
+
+    def __get_configdb_path_tokens_from_container(self, model: dict, xpath_tokens: List[str], token_index: int, configdb: dict) -> List[str]:
+        token = xpath_tokens[token_index]
+        configdb_path_tokens = [token]
+
+        if len(xpath_tokens)-1 == token_index:
+            return configdb_path_tokens
+
+        if configdb is not None:
+            configdb = configdb[token]
+
+        # check child list
+        list_name = xpath_tokens[token_index+1].split("[")[0]
+        list_model = self.__get_model(model.get('list'), list_name)
+        if list_model:
+            new_path_tokens = self.__get_configdb_path_tokens_from_list(list_model, xpath_tokens, token_index+1, configdb)
+            configdb_path_tokens.extend(new_path_tokens)
+            return configdb_path_tokens
+
+        container_name = xpath_tokens[token_index+1]
+        container_model = self.__get_model(model.get('container'), container_name)
+        if container_model:
+            new_path_tokens = self.__get_configdb_path_tokens_from_container(container_model, xpath_tokens, token_index+1, configdb)
+            configdb_path_tokens.extend(new_path_tokens)
+            return configdb_path_tokens
+
+        new_path_tokens = self.__get_configdb_path_tokens_from_leaf(model, xpath_tokens, token_index+1, configdb)
+        configdb_path_tokens.extend(new_path_tokens)
+
+        return configdb_path_tokens
+
+
+    def __xpath_keys_to_dict(self, token: str) -> dict:
+        # Token passed in is something like:
+        #   VLAN_MEMBER_LIST[name='Vlan1000'][port='Ethernet8']
+        # Strip off the Table name, and return a dictionary of key/value pairs.
+
+        # See if we have keys
+        idx = token.find("[")
+        if idx == -1:
+            return dict()
+
+        # Strip off table name
+        token = token[idx:]
+
+        # Use regex to extract our keys and values
+        key_value_pattern = "\[([^=]+)='([^']*)'\]"
+        matches = re.findall(key_value_pattern, token)
+        kv = dict()
+        for item in matches:
+            kv[item[0]] = item[1]
+
+        return kv
+
+    def __get_configdb_path_tokens_from_list(self, model: dict, xpath_tokens: List[str], token_index: int, configdb: dict):
+        token = xpath_tokens[token_index]
+        key_dict = self.__xpath_keys_to_dict(token)
+
+        # If no keys specified return empty tokens, as we are already inside the correct table.
+        # Also note that the list name in SonicYang has no correspondence in ConfigDb and is ignored.
+        # Example where VLAN_MEMBER_LIST has no specific key/value:
+        #   xpath: /sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST
+        #   path: /VLAN_MEMBER
+        if not(key_dict):
+            return []
+
+        listKeys = model['key']['@value']
+        key_list = listKeys.split()
+
+        if len(key_list) != len(key_dict):
+            raise ValueError(f"Keys in configDb not matching keys in SonicYang. ConfigDb keys: {key_dict.keys()}. SonicYang keys: {key_list}")
+
+        values = [key_dict[k] for k in key_list]
+        configdb_path_token = '|'.join(values)
+        configdb_path_tokens = [ configdb_path_token ]
+
+        # Set pointer to pass for recursion
+        if configdb is not None:
+            # use .get() here as if configdb doesn't have the key it could return failure, but it can actually still
+            # generate a mostly relevant path.
+            configdb = configdb.get(configdb_path_token)
+
+        # At end, just return
+        if len(xpath_tokens)-1 == token_index:
+            return configdb_path_tokens
+
+        next_token = xpath_tokens[token_index+1]
+        # if the target node is a key, then it does not have a correspondene to path.
+        # Just return the current 'key1|key2|..' token as it already refers to the keys
+        # Example where the target node is 'name' which is a key in VLAN_MEMBER_LIST:
+        #   xpath: /sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[name='Vlan1000'][port='Ethernet8']/name
+        #   path: /VLAN_MEMBER/Vlan1000|Ethernet8
+        if next_token in key_dict:
+            return configdb_path_tokens
+
+        type_1_list_model = self.__type1_get_model(model)
+        if type_1_list_model:
+            new_path_tokens = self.__get_configdb_path_tokens_from_type_1_list(type_1_list_model, xpath_tokens, token_index+1, configdb)
+            configdb_path_tokens.extend(new_path_tokens)
+            return configdb_path_tokens
+
+        new_path_tokens = self.__get_configdb_path_tokens_from_leaf(model, xpath_tokens, token_index+1, configdb)
+        configdb_path_tokens.extend(new_path_tokens)
+        return configdb_path_tokens
+
+
+    def __get_configdb_path_tokens_from_leaf(self, model: dict, xpath_tokens: List[str], token_index: int, configdb: dict) -> List[str]:
+        token = xpath_tokens[token_index]
+
+        # checking all leaves
+        leaf_model = self.__get_model(model.get('leaf'), token)
+        if leaf_model:
+            return [token]
+
+        # checking choices
+        choices = model.get('choice')
+        if choices:
+            for choice in choices:
+                cases = choice['case']
+                for case in cases:
+                    leaf_model = self.__get_model(case.get('leaf'), token)
+                    if leaf_model:
+                        return [token]
+
+        # checking leaf-list
+        leaf_list_tokens = token.split("[", 1) # split once on the first '[', a regex is used later to fetch keys/values
+        leaf_list_name = leaf_list_tokens[0]
+        leaf_list_model = self.__get_model(model.get('leaf-list'), leaf_list_name)
+        if leaf_list_model:
+            # if whole-list is to be returned, such as if there is no key, or if configdb is not provided,
+            # Just return the list-name without checking the list items
+            # Example:
+            #   xpath: /sonic-vlan:sonic-vlan/VLAN/VLAN_LIST[name='Vlan1000']/dhcp_servers
+            #   path: /VLAN/Vlan1000/dhcp_servers
+            if configdb is None or len(leaf_list_tokens) == 1:
+                return [leaf_list_name]
+            leaf_list_pattern = "^[^\[]+(?:\[\.='([^']*)'\])?$"
+            leaf_list_regex = re.compile(leaf_list_pattern)
+            match = leaf_list_regex.match(token)
+            # leaf_list_name = match.group(1)
+            leaf_list_value = match.group(1)
+            list_config = configdb[leaf_list_name]
+            # Workaround for those fields who is defined as leaf-list in YANG model but have string value in config DB
+            # No need to lookup the item index in ConfigDb since the list is represented as a string, return path to string immediately
+            # Example:
+            #   xpath: /sonic-buffer-port-egress-profile-list:sonic-buffer-port-egress-profile-list/BUFFER_PORT_EGRESS_PROFILE_LIST/BUFFER_PORT_EGRESS_PROFILE_LIST_LIST[port='Ethernet9']/profile_list[.='egress_lossy_profile']
+            #   path: /BUFFER_PORT_EGRESS_PROFILE_LIST/Ethernet9/profile_list
+            if isinstance(list_config, str):
+                return [leaf_list_name]
+
+            if not isinstance(list_config, list):
+                raise ValueError(f"list_config is expected to be of type list or string. Found {type(list_config)}.\n  " + \
+                                 f"model: {model}\n  token_index: {token_index}\n  " + \
+                                 f"xpath_tokens: {xpath_tokens}\n  config: {configdb}")
+
+            list_idx = list_config.index(leaf_list_value)
+            return [leaf_list_name, list_idx]
+
+        raise ValueError(f"Xpath token not found.\n  model: {model}\n  token_index: {token_index}\n  " + \
+                         f"xpath_tokens: {xpath_tokens}\n  config: {configdb}")
+
+
+    def __get_configdb_path_tokens_from_type_1_list(self, model: dict, xpath_tokens: List[str], token_index: int, configdb: dict):
+        type_1_inner_list_name = model['@name']
+
+        token = xpath_tokens[token_index]
+        list_tokens = token.split("[", 1) # split once on the first '[', first element will be the inner list name
+        inner_list_name = list_tokens[0]
+
+        if type_1_inner_list_name != inner_list_name:
+            raise ValueError(f"Type 1 inner list name '{type_1_inner_list_name}' does match xpath inner list name '{inner_list_name}'.")
+
+        key_dict = self.__xpath_keys_to_dict(token)
+
+        # If no keys specified return empty tokens, as we are already inside the correct table.
+        # Also note that the type 1 inner list name in SonicYang has no correspondence in ConfigDb and is ignored.
+        # Example where DOT1P_TO_TC_MAP_LIST has no specific key/value:
+        #   xpath: /sonic-dot1p-tc-map:sonic-dot1p-tc-map/DOT1P_TO_TC_MAP/DOT1P_TO_TC_MAP_LIST[name='Dot1p_to_tc_map1']/DOT1P_TO_TC_MAP
+        #   path: /DOT1P_TO_TC_MAP/Dot1p_to_tc_map1
+        if not(key_dict):
+            return []
+
+        if len(key_dict) > 1:
+            raise ValueError(f"Type 1 inner list should have only 1 key in xpath, {len(key_dict)} specified. Key dictionary: {key_dict}")
+
+        keyName = next(iter(key_dict.keys()))
+        value = key_dict[keyName]
+
+        path_tokens = [value]
+
+        # If this is the last xpath token, return the path tokens we have built so far, no need for futher checks
+        # Example:
+        #   xpath: /sonic-dot1p-tc-map:sonic-dot1p-tc-map/DOT1P_TO_TC_MAP/DOT1P_TO_TC_MAP_LIST[name='Dot1p_to_tc_map1']/DOT1P_TO_TC_MAP[dot1p='2']
+        #   path: /DOT1P_TO_TC_MAP/Dot1p_to_tc_map1/2
+        if token_index+1 >= len(xpath_tokens):
+            return path_tokens
+
+        # Checking if the next_token is actually a child leaf of the inner type 1 list, for which case
+        # just ignore the token, and return the already created ConfigDb path pointing to the whole object
+        # Example where the leaf specified is the key:
+        #   xpath: /sonic-dot1p-tc-map:sonic-dot1p-tc-map/DOT1P_TO_TC_MAP/DOT1P_TO_TC_MAP_LIST[name='Dot1p_to_tc_map1']/DOT1P_TO_TC_MAP[dot1p='2']/dot1p
+        #   path: /DOT1P_TO_TC_MAP/Dot1p_to_tc_map1/2
+        # Example where the leaf specified is not the key:
+        #   xpath: /sonic-dot1p-tc-map:sonic-dot1p-tc-map/DOT1P_TO_TC_MAP/DOT1P_TO_TC_MAP_LIST[name='Dot1p_to_tc_map1']/DOT1P_TO_TC_MAP[dot1p='2']/tc
+        #   path: /DOT1P_TO_TC_MAP/Dot1p_to_tc_map1/2
+        next_token = xpath_tokens[token_index+1]
+        leaf_model = self.__get_model(model.get('leaf'), next_token)
+        if leaf_model:
+            return path_tokens
+
+        raise ValueError(f"Type 1 inner list '{type_1_inner_list_name}' does not have a child leaf named '{next_token}'")

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/config_data.json
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/config_data.json
@@ -1,5 +1,5 @@
 {
-	"test-vlan:vlan": {
+	"test-vlan:test-vlan": {
 		"test-vlan:VLAN_INTERFACE": {
 			"VLAN_INTERFACE_LIST": [{
 					"vlanid": 111,
@@ -101,7 +101,7 @@
 			]
 		}
 	},
-	"test-port:port": {
+	"test-port:test-port": {
 		"test-port:PORT": {
 			"PORT_LIST": [{
 					"port_name": "Ethernet0",
@@ -187,7 +187,7 @@
 		}
 	},
 
-	"test-acl:acl": {
+	"test-acl:test-acl": {
 		"test-acl:ACL_RULE": {
 			"ACL_RULE_LIST": [{
 					"ACL_TABLE_NAME": "PACL-V4",
@@ -240,7 +240,7 @@
 		}
 	},
 
-	"test-interface:interface": {
+	"test-interface:test-interface": {
 		"test-interface:INTERFACE": {
 			"INTERFACE_LIST": [{
 					"interface": "Ethernet8",
@@ -258,7 +258,7 @@
 		}
 	},
 
-	"test-yang-structure:test-yang-container": {
+	"test-yang-structure:test-yang-structure": {
 		"test-yang-structure:YANG_STRUCT_TEST": {
 			"YANG_LIST_TEST_LIST": [{
 					"name" : "Vlan1001",

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/config_data_merge.json
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/config_data_merge.json
@@ -1,5 +1,5 @@
 {
-	"test-vlan:vlan": {
+	"test-vlan:test-vlan": {
 		"test-vlan:VLAN_INTERFACE": {
 			"VLAN_INTERFACE_LIST": [{
 					"vlanid": 111,
@@ -58,7 +58,7 @@
 			}]
 		}
 	},
-	"test-port:port": {
+	"test-port:test-port": {
 		"test-port:PORT": {
 			"PORT_LIST": [{
 					"port_name": "Ethernet0",

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/sample-yang-models/test-acl.yang
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/sample-yang-models/test-acl.yang
@@ -32,7 +32,7 @@ module test-acl {
 		description "First Revision";
 	}
 
-	container acl {
+	container test-acl {
 
 		container ACL_RULE {
 
@@ -44,7 +44,7 @@ module test-acl {
 
 				leaf ACL_TABLE_NAME {
 					type leafref {
-						path "/acl:acl/acl:ACL_TABLE/acl:ACL_TABLE_LIST/acl:ACL_TABLE_NAME";
+						path "/acl:test-acl/acl:ACL_TABLE/acl:ACL_TABLE_LIST/acl:ACL_TABLE_NAME";
 					}
 				}
 
@@ -251,10 +251,10 @@ module test-acl {
                     /* union of leafref is allowed in YANG 1.1 */
 					type union {
 						type leafref {
-							path /port:port/port:PORT/port:PORT_LIST/port:port_name;
+							path /port:test-port/port:PORT/port:PORT_LIST/port:port_name;
 						}
 						type leafref {
-							path /lag:portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:portchannel_name;
+							path /lag:test-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:portchannel_name;
 						}
 					}
 				}

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/sample-yang-models/test-interface.yang
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/sample-yang-models/test-interface.yang
@@ -25,7 +25,7 @@ module test-interface {
 		description "First Revision";
 	}
 
-	container interface {
+	container test-interface {
 		container INTERFACE {
 
 			description "INTERFACE part of config_db.json";
@@ -36,7 +36,7 @@ module test-interface {
 
 				leaf interface {
 					type leafref {
-						path /port:port/port:PORT/port:PORT_LIST/port:port_name;
+						path /port:test-port/port:PORT/port:PORT_LIST/port:port_name;
 					}
 				}
 

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/sample-yang-models/test-port.yang
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/sample-yang-models/test-port.yang
@@ -20,7 +20,7 @@ module test-port{
 		description "First Revision";
 	}
 
-	container port{
+	container test-port {
 		container PORT {
 
 			description "PORT part of config_db.json";

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/sample-yang-models/test-portchannel.yang
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/sample-yang-models/test-portchannel.yang
@@ -25,7 +25,7 @@ module test-portchannel {
 		description "First Revision";
 	}
 
-	container portchannel {
+	container test-portchannel {
 		container PORTCHANNEL {
 
 			description "PORTCHANNEL part of config_db.json";
@@ -44,7 +44,7 @@ module test-portchannel {
 				leaf-list members {
 					/* leaf-list members are unique by default */
 					type leafref {
-						path /port:port/port:PORT/port:PORT_LIST/port:port_name;
+						path /port:test-port/port:PORT/port:PORT_LIST/port:port_name;
 					}
 				}
 

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/sample-yang-models/test-vlan.yang
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/sample-yang-models/test-vlan.yang
@@ -25,7 +25,7 @@ module test-vlan {
 		description "First Revision";
 	}
 
-	container vlan {
+	container test-vlan {
 		container VLAN_INTERFACE {
 
 			description "VLAN_INTERFACE part of config_db.json";
@@ -126,7 +126,7 @@ module test-vlan {
 					/* key elements are mandatory by default */
 					mandatory true;
 					type leafref {
-						path /port:port/port:PORT/port:PORT_LIST/port:port_name;
+						path /port:test-port/port:PORT/port:PORT_LIST/port:port_name;
 					}
 				}
 

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/sample-yang-models/test-yang-structure.yang
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/sample-yang-models/test-yang-structure.yang
@@ -22,7 +22,7 @@ module test-yang-structure {
     description "First Revision";
   }
 
-  container test-yang-container {
+  container test-yang-structure {
 
     container YANG_STRUCT_TEST {
 

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/test_SonicYang.json
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/test_SonicYang.json
@@ -4,144 +4,144 @@
    "data_nodes" : [
       {
          "valid" : "True",
-         "xpath" : "/test-port:port/PORT/PORT_LIST[port_name='Ethernet9']/alias"
+         "xpath" : "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet9']/alias"
       },
       {
          "valid" : "False",
-         "xpath" : "/test-port:port/PORT/PORT_LIST[port_name='Ethernet20']/alias"
+         "xpath" : "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet20']/alias"
       },
       {
          "valid" : "True",
-         "xpath" : "/test-vlan:vlan/VLAN_INTERFACE"
+         "xpath" : "/test-vlan:test-vlan/VLAN_INTERFACE"
       },
       {
          "valid" : "False",
-         "xpath" : "/test-vlan:vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST"
+         "xpath" : "/test-vlan:test-vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST"
       },
       {
          "valid" : "True",
-         "xpath" : "/test-vlan:vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='2000:f500:45:6709::/64']"
+         "xpath" : "/test-vlan:test-vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='2000:f500:45:6709::/64']"
       }
    ],
    "data_type" : [
       {
          "data_type" : "LY_TYPE_STRING",
-         "xpath" : "/test-port:port/test-port:PORT/test-port:PORT_LIST/test-port:port_name"
+         "xpath" : "/test-port:test-port/test-port:PORT/test-port:PORT_LIST/test-port:port_name"
       },
       {
          "data_type" : "LY_TYPE_LEAFREF",
-         "xpath" : "/test-vlan:vlan/test-vlan:VLAN_INTERFACE/test-vlan:VLAN_INTERFACE_LIST/test-vlan:vlanid"
+         "xpath" : "/test-vlan:test-vlan/test-vlan:VLAN_INTERFACE/test-vlan:VLAN_INTERFACE_LIST/test-vlan:vlanid"
       }
    ],
    "delete_nodes" : [
       {
          "valid" : "False",
-         "xpath" : "/test-port:port/PORT/PORT_LIST[port_name='Ethernet10']/speed"
+         "xpath" : "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet10']/speed"
       },
       {
          "valid" : "True",
-         "xpath" : "/test-port:port/PORT/PORT_LIST[port_name='Ethernet9']/mtu"
+         "xpath" : "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet9']/mtu"
       },
       {
          "valid" : "False",
-         "xpath" : "/test-port:port/PORT/PORT_LIST[port_name='Ethernet20']/mtu"
+         "xpath" : "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet20']/mtu"
       }
    ],
    "dependencies" : [
       {
          "dependencies" : [
-            "/test-acl:acl/ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME='PACL-V6']/ports[.='Ethernet8']",
-            "/test-interface:interface/INTERFACE/INTERFACE_LIST[interface='Ethernet8'][ip-prefix='10.1.1.64/26']/interface",
-            "/test-interface:interface/INTERFACE/INTERFACE_LIST[interface='Ethernet8'][ip-prefix='2000:f500:40:a749::/126']/interface"
+            "/test-acl:test-acl/ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME='PACL-V6']/ports[.='Ethernet8']",
+            "/test-interface:test-interface/INTERFACE/INTERFACE_LIST[interface='Ethernet8'][ip-prefix='10.1.1.64/26']/interface",
+            "/test-interface:test-interface/INTERFACE/INTERFACE_LIST[interface='Ethernet8'][ip-prefix='2000:f500:40:a749::/126']/interface"
          ],
-         "xpath" : "/test-port:port/PORT/PORT_LIST[port_name='Ethernet8']/port_name"
+         "xpath" : "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet8']/port_name"
       },
       {
          "dependencies" : [],
-         "xpath" : "/test-port:port/PORT/PORT_LIST[port_name='Ethernet8']/alias"
+         "xpath" : "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet8']/alias"
       }
    ],
    "leafref_path" : [
       {
          "leafref_path" : "../../../VLAN/VLAN_LIST/vlanid",
-         "xpath" : "/test-vlan:vlan/test-vlan:VLAN_INTERFACE/test-vlan:VLAN_INTERFACE_LIST/test-vlan:vlanid"
+         "xpath" : "/test-vlan:test-vlan/test-vlan:VLAN_INTERFACE/test-vlan:VLAN_INTERFACE_LIST/test-vlan:vlanid"
       },
       {
-         "leafref_path" : "/test-port:port/test-port:PORT/test-port:PORT_LIST/test-port:port_name",
-         "xpath" : "/test-interface:interface/test-interface:INTERFACE/test-interface:INTERFACE_LIST/test-interface:interface"
+         "leafref_path" : "/test-port:test-port/test-port:PORT/test-port:PORT_LIST/test-port:port_name",
+         "xpath" : "/test-interface:test-interface/test-interface:INTERFACE/test-interface:INTERFACE_LIST/test-interface:interface"
       },
       {
-         "leafref_path" : "/test-port:port/test-port:PORT/test-port:PORT_LIST/test-port:port_name",
-         "xpath" : "/test-vlan:vlan/test-vlan:VLAN_MEMBER/test-vlan:VLAN_MEMBER_LIST/test-vlan:port"
+         "leafref_path" : "/test-port:test-port/test-port:PORT/test-port:PORT_LIST/test-port:port_name",
+         "xpath" : "/test-vlan:test-vlan/test-vlan:VLAN_MEMBER/test-vlan:VLAN_MEMBER_LIST/test-vlan:port"
       },
       {
          "leafref_path" : "../../../VLAN/VLAN_LIST/vlanid",
-         "xpath" : "/test-vlan:vlan/test-vlan:VLAN_MEMBER/test-vlan:VLAN_MEMBER_LIST/test-vlan:vlanid"
+         "xpath" : "/test-vlan:test-vlan/test-vlan:VLAN_MEMBER/test-vlan:VLAN_MEMBER_LIST/test-vlan:vlanid"
       }
    ],
    "leafref_type" : [
       {
          "data_type" : "LY_TYPE_UINT16",
-         "xpath" : "/test-vlan:vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='2000:f500:45:6709::/64']/vlanid"
+         "xpath" : "/test-vlan:test-vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='2000:f500:45:6709::/64']/vlanid"
       },
       {
          "data_type" : "LY_TYPE_STRING",
-         "xpath" : "/test-interface:interface/INTERFACE/INTERFACE_LIST[interface='Ethernet8'][ip-prefix='2000:f500:40:a749::/126']/interface"
+         "xpath" : "/test-interface:test-interface/INTERFACE/INTERFACE_LIST[interface='Ethernet8'][ip-prefix='2000:f500:40:a749::/126']/interface"
       },
       {
          "data_type" : "LY_TYPE_STRING",
-         "xpath" : "/test-vlan:vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlanid='111'][port='Ethernet0']/port"
+         "xpath" : "/test-vlan:test-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlanid='111'][port='Ethernet0']/port"
       },
       {
          "data_type" : "LY_TYPE_UINT16",
-         "xpath" : "/test-vlan:vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlanid='111'][port='Ethernet0']/vlanid"
+         "xpath" : "/test-vlan:test-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlanid='111'][port='Ethernet0']/vlanid"
       }
    ],
    "leafref_type_schema" : [
       {
          "data_type" : "LY_TYPE_UINT16",
-         "xpath" : "/test-vlan:vlan/test-vlan:VLAN_INTERFACE/test-vlan:VLAN_INTERFACE_LIST/test-vlan:vlanid"
+         "xpath" : "/test-vlan:test-vlan/test-vlan:VLAN_INTERFACE/test-vlan:VLAN_INTERFACE_LIST/test-vlan:vlanid"
       },
       {
          "data_type" : "LY_TYPE_STRING",
-         "xpath" : "/test-interface:interface/test-interface:INTERFACE/test-interface:INTERFACE_LIST/test-interface:interface"
+         "xpath" : "/test-interface:test-interface/test-interface:INTERFACE/test-interface:INTERFACE_LIST/test-interface:interface"
       },
       {
          "data_type" : "LY_TYPE_STRING",
-         "xpath" : "/test-vlan:vlan/test-vlan:VLAN_MEMBER/test-vlan:VLAN_MEMBER_LIST/test-vlan:port"
+         "xpath" : "/test-vlan:test-vlan/test-vlan:VLAN_MEMBER/test-vlan:VLAN_MEMBER_LIST/test-vlan:port"
       },
       {
          "data_type" : "LY_TYPE_UINT16",
-         "xpath" : "/test-vlan:vlan/test-vlan:VLAN_MEMBER/test-vlan:VLAN_MEMBER_LIST/test-vlan:vlanid"
+         "xpath" : "/test-vlan:test-vlan/test-vlan:VLAN_MEMBER/test-vlan:VLAN_MEMBER_LIST/test-vlan:vlanid"
       }
    ],
    "members" : [
       {
          "members" : [
-            "/test-port:port/PORT/PORT_LIST[port_name='Ethernet0']",
-            "/test-port:port/PORT/PORT_LIST[port_name='Ethernet1']",
-            "/test-port:port/PORT/PORT_LIST[port_name='Ethernet2']",
-            "/test-port:port/PORT/PORT_LIST[port_name='Ethernet3']",
-            "/test-port:port/PORT/PORT_LIST[port_name='Ethernet4']",
-            "/test-port:port/PORT/PORT_LIST[port_name='Ethernet5']",
-            "/test-port:port/PORT/PORT_LIST[port_name='Ethernet6']",
-            "/test-port:port/PORT/PORT_LIST[port_name='Ethernet7']",
-            "/test-port:port/PORT/PORT_LIST[port_name='Ethernet8']",
-            "/test-port:port/PORT/PORT_LIST[port_name='Ethernet9']",
-            "/test-port:port/PORT/PORT_LIST[port_name='Ethernet10']",
-            "/test-port:port/PORT/PORT_LIST[port_name='Ethernet12']"
+            "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet0']",
+            "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet1']",
+            "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet2']",
+            "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet3']",
+            "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet4']",
+            "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet5']",
+            "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet6']",
+            "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet7']",
+            "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet8']",
+            "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet9']",
+            "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet10']",
+            "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet12']"
          ],
-         "xpath" : "/test-port:port/PORT/PORT_LIST"
+         "xpath" : "/test-port:test-port/PORT/PORT_LIST"
       }
    ],
    "merged_nodes" : [
       {
          "value" : "25000",
-         "xpath" : "/test-port:port/PORT/PORT_LIST[port_name='Ethernet10']/speed"
+         "xpath" : "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet10']/speed"
       },
       {
          "value" : "IPv6",
-         "xpath" : "/test-vlan:vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='200'][ip-prefix='2000:f500:45:6708::/64']/family"
+         "xpath" : "/test-vlan:test-vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='200'][ip-prefix='2000:f500:45:6708::/64']/family"
       }
    ],
    "modules" : [
@@ -177,51 +177,51 @@
    "new_nodes" : [
       {
          "value" : "Ethernet10_alias",
-         "xpath" : "/test-port:port/PORT/PORT_LIST[port_name='Ethernet12']/alias"
+         "xpath" : "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet12']/alias"
       },
       {
          "value" : "5000",
-         "xpath" : "/test-port:port/PORT/PORT_LIST[port_name='Ethernet12']/speed"
+         "xpath" : "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet12']/speed"
       },
       {
          "value" : "rule_20",
-         "xpath" : "/test-acl:acl/ACL_RULE/ACL_RULE_LIST[ACL_TABLE_NAME='PACL-test'][RULE_NAME='rule_20']/RULE_NAME"
+         "xpath" : "/test-acl:test-acl/ACL_RULE/ACL_RULE_LIST[ACL_TABLE_NAME='PACL-test'][RULE_NAME='rule_20']/RULE_NAME"
       }
    ],
    "node_values" : [
       {
          "value" : "25000",
-         "xpath" : "/test-port:port/PORT/PORT_LIST[port_name='Ethernet9']/speed"
+         "xpath" : "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet9']/speed"
       },
       {
          "value" : "IPv6",
-         "xpath" : "/test-vlan:vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='2000:f500:45:6709::/64']/family"
+         "xpath" : "/test-vlan:test-vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='2000:f500:45:6709::/64']/family"
       }
    ],
    "parents" : [
       {
-         "parent" : "/test-vlan:vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='2000:f500:45:6709::/64']",
-         "xpath" : "/test-vlan:vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='2000:f500:45:6709::/64']/family"
+         "parent" : "/test-vlan:test-vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='2000:f500:45:6709::/64']",
+         "xpath" : "/test-vlan:test-vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='2000:f500:45:6709::/64']/family"
       },
       {
-         "parent" : "/test-vlan:vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='10.1.1.64/26']",
-         "xpath" : "/test-vlan:vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='10.1.1.64/26']/scope"
+         "parent" : "/test-vlan:test-vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='10.1.1.64/26']",
+         "xpath" : "/test-vlan:test-vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='10.1.1.64/26']/scope"
       },
       {
-         "parent" : "/test-vlan:vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='10.1.1.64/26']",
-         "xpath" : "/test-vlan:vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='10.1.1.64/26']/vlanid"
+         "parent" : "/test-vlan:test-vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='10.1.1.64/26']",
+         "xpath" : "/test-vlan:test-vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='10.1.1.64/26']/vlanid"
       },
       {
-         "parent" : "/test-vlan:vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='10.1.1.64/26']",
-         "xpath" : "/test-vlan:vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='10.1.1.64/26']/ip-prefix"
+         "parent" : "/test-vlan:test-vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='10.1.1.64/26']",
+         "xpath" : "/test-vlan:test-vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='10.1.1.64/26']/ip-prefix"
       },
       {
-         "parent" : "/test-vlan:vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='10.1.1.64/26']",
-         "xpath" : "/test-vlan:vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='10.1.1.64/26']/family"
+         "parent" : "/test-vlan:test-vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='10.1.1.64/26']",
+         "xpath" : "/test-vlan:test-vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='10.1.1.64/26']/family"
       },
       {
-         "parent" : "/test-port:port/PORT/PORT_LIST[port_name='Ethernet9']",
-         "xpath" : "/test-port:port/PORT/PORT_LIST[port_name='Ethernet9']/speed"
+         "parent" : "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet9']",
+         "xpath" : "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet9']/speed"
       }
    ],
    "prefix" : [
@@ -257,36 +257,54 @@
    "schema_dependencies" : [
       {
          "schema_dependencies" : [
-            "/test-acl:acl/test-acl:ACL_TABLE/test-acl:ACL_TABLE_LIST/test-acl:ports",
-            "/test-portchannel:portchannel/test-portchannel:PORTCHANNEL/test-portchannel:PORTCHANNEL_LIST/test-portchannel:members",
-            "/test-interface:interface/test-interface:INTERFACE/test-interface:INTERFACE_LIST/test-interface:interface",
-            "/test-vlan:vlan/test-vlan:VLAN_MEMBER/test-vlan:VLAN_MEMBER_LIST/test-vlan:port"
+            "/test-acl:test-acl/test-acl:ACL_TABLE/test-acl:ACL_TABLE_LIST/test-acl:ports",
+            "/test-portchannel:test-portchannel/test-portchannel:PORTCHANNEL/test-portchannel:PORTCHANNEL_LIST/test-portchannel:members",
+            "/test-interface:test-interface/test-interface:INTERFACE/test-interface:INTERFACE_LIST/test-interface:interface",
+            "/test-vlan:test-vlan/test-vlan:VLAN_MEMBER/test-vlan:VLAN_MEMBER_LIST/test-vlan:port"
          ],
-         "xpath" : "/test-port:port/test-port:PORT/test-port:PORT_LIST/test-port:port_name"
+         "xpath" : "/test-port:test-port/test-port:PORT/test-port:PORT_LIST/test-port:port_name"
       }
    ],
    "schema_nodes" : [
       {
-         "value" : "/test-vlan:vlan/test-vlan:VLAN_INTERFACE/test-vlan:VLAN_INTERFACE_LIST/test-vlan:family",
-         "xpath" : "/test-vlan:vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='10.1.1.64/26']/family"
+         "value" : "/test-vlan:test-vlan/test-vlan:VLAN_INTERFACE/test-vlan:VLAN_INTERFACE_LIST/test-vlan:family",
+         "xpath" : "/test-vlan:test-vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='10.1.1.64/26']/family"
       },
       {
-         "value" : "/test-port:port/test-port:PORT/test-port:PORT_LIST/test-port:speed",
-         "xpath" : "/test-port:port/PORT/PORT_LIST[port_name='Ethernet9']/speed"
+         "value" : "/test-port:test-port/test-port:PORT/test-port:PORT_LIST/test-port:speed",
+         "xpath" : "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet9']/speed"
       }
    ],
    "set_nodes" : [
       {
          "value" : "10000",
-         "xpath" : "/test-port:port/PORT/PORT_LIST[port_name='Ethernet10']/speed"
+         "xpath" : "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet10']/speed"
       },
       {
          "value" : "1500",
-         "xpath" : "/test-port:port/PORT/PORT_LIST[port_name='Ethernet9']/mtu"
+         "xpath" : "/test-port:test-port/PORT/PORT_LIST[port_name='Ethernet9']/mtu"
       },
       {
          "value" : "server_vlan111",
-         "xpath" : "/test-vlan:vlan/VLAN/VLAN_LIST[vlanid='111']/description"
+         "xpath" : "/test-vlan:test-vlan/VLAN/VLAN_LIST[vlanid='111']/description"
+      }
+   ],
+   "configdb_path_to_xpath": [
+      {
+         "configdb_path": "/VLAN_MEMBER/Vlan1000|Ethernet8/tagging_mode",
+         "schema_xpath": false,
+         "xpath": "/test-vlan:test-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlanid='Vlan1000'][port='Ethernet8']/tagging_mode"
+      },
+      {
+         "configdb_path": "/VLAN_MEMBER/Vlan1000|Ethernet8/tagging_mode",
+         "schema_xpath": true,
+         "xpath": "/test-vlan:test-vlan/test-vlan:VLAN_MEMBER/test-vlan:VLAN_MEMBER_LIST/test-vlan:tagging_mode"
+      }
+   ],
+   "xpath_to_configdb_path": [
+      {
+         "xpath": "/test-vlan:test-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlanid='Vlan1000'][port='Ethernet8']/tagging_mode",
+         "configdb_path": "/VLAN_MEMBER/Vlan1000|Ethernet8/tagging_mode"
       }
    ],
    "yang_dir" : "./tests/libyang-python-tests/sample-yang-models/"

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py
@@ -211,7 +211,7 @@ class Test_SonicYang(object):
         for node in data['schema_dependencies']:
             xpath = str(node['xpath'])
             list = node['schema_dependencies']
-            depend = yang_s._find_schema_dependencies(xpath)
+            depend = yang_s.find_schema_dependencies(xpath)
             assert set(depend) == set(list)
 
     #test merge data tree
@@ -260,6 +260,56 @@ class Test_SonicYang(object):
             expected_type = yang_s._str_to_type(expected)
             data_type = yang_s._get_leafref_type_schema(xpath)
             assert expected_type == data_type
+
+    def test_configdb_path_to_xpath(self, yang_s, data):
+        yang_s.loadYangModel()
+        for node in data['configdb_path_to_xpath']:
+            configdb_path = str(node['configdb_path'])
+            schema_xpath = bool(node['schema_xpath'])
+            expected = node['xpath']
+            received = yang_s.configdb_path_to_xpath(configdb_path, schema_xpath=schema_xpath)
+            assert received == expected
+
+    def test_xpath_to_configdb_path(self, yang_s, data):
+        yang_s.loadYangModel()
+        for node in data['xpath_to_configdb_path']:
+            xpath = str(node['xpath'])
+            expected = node['configdb_path']
+            received = yang_s.xpath_to_configdb_path(xpath)
+            assert received == expected
+
+    def test_configdb_path_split(self, yang_s, data):
+        def check(path, tokens):
+            expected=tokens
+            actual=yang_s.configdb_path_split(path)
+            assert expected == actual
+
+        check("", [])
+        check("/", [])
+        check("/token", ["token"])
+        check("/more/than/one/token", ["more", "than", "one", "token"])
+        check("/has/numbers/0/and/symbols/^", ["has", "numbers", "0", "and", "symbols", "^"])
+        check("/~0/this/is/telda", ["~", "this", "is", "telda"])
+        check("/~1/this/is/forward-slash", ["/", "this", "is", "forward-slash"])
+        check("/\\\\/no-escaping", ["\\\\", "no-escaping"])
+        check("////empty/tokens/are/ok", ["", "", "", "empty", "tokens", "are", "ok"])
+
+    def configdb_path_join(self, yang_s, data):
+        def check(tokens, path):
+            expected=path
+            actual=yang_s.configdb_path_join(tokens)
+            assert expected == actual
+
+        check([], "/",)
+        check([""], "/",)
+        check(["token"], "/token")
+        check(["more", "than", "one", "token"], "/more/than/one/token")
+        check(["has", "numbers", "0", "and", "symbols", "^"], "/has/numbers/0/and/symbols/^")
+        check(["~", "this", "is", "telda"], "/~0/this/is/telda")
+        check(["/", "this", "is", "forward-slash"], "/~1/this/is/forward-slash")
+        check(["\\\\", "no-escaping"], "/\\\\/no-escaping")
+        check(["", "", "", "empty", "tokens", "are", "ok"], "////empty/tokens/are/ok")
+        check(["~token", "telda-not-followed-by-0-or-1"], "/~0token/telda-not-followed-by-0-or-1")
 
     """
     This is helper function to load YANG models for tests cases, which works

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py
@@ -431,5 +431,85 @@ class Test_SonicYang(object):
 
         return
 
+    def test_loaddata_quiet_suppresses_syslog_on_success(self, sonic_yang_data, monkeypatch):
+        # With quiet=True, the informational "Try to load Data" sysLog
+        # call must not be emitted. Exception path is covered below.
+        # monkeypatch.setattr cleanly reverts the instance-level override
+        # on teardown so state does not leak across tests.
+        test_file = sonic_yang_data['test_file']
+        syc = sonic_yang_data['syc']
+        jIn = json.loads(self.readIjsonInput(test_file, 'SAMPLE_CONFIG_DB_JSON'))
+
+        calls = []
+        monkeypatch.setattr(syc, 'sysLog',
+                            lambda *a, **kw: calls.append((a, kw)))
+
+        syc.loadData(jIn, quiet=True)
+
+        msgs = [kw.get('msg', '') for (_a, kw) in calls] + [
+            a[0] for (a, _kw) in calls if a
+        ]
+        assert not any('Try to load Data' in str(m) for m in msgs), \
+            "quiet=True must suppress 'Try to load Data' sysLog: {}".format(msgs)
+        assert not any('Data Loading Failed' in str(m) for m in msgs), \
+            "quiet=True must suppress 'Data Loading Failed' sysLog: {}".format(msgs)
+
+        return
+
+    def test_loaddata_quiet_suppresses_syslog_on_failure(self, sonic_yang_data, monkeypatch):
+        # With quiet=True, the LOG_ERR "Data Loading Failed" sysLog call
+        # must not be emitted even when parse_data_mem raises. The
+        # SonicYangException must still be raised so the caller sees the
+        # failure. monkeypatch.setattr cleanly reverts on teardown.
+        test_file = sonic_yang_data['test_file']
+        syc = sonic_yang_data['syc']
+        jIn = json.loads(self.readIjsonInput(test_file, 'SAMPLE_CONFIG_DB_JSON'))
+
+        calls = []
+
+        def _boom(*a, **kw):
+            raise RuntimeError('forced parse failure')
+
+        monkeypatch.setattr(syc, 'sysLog',
+                            lambda *a, **kw: calls.append((a, kw)))
+        monkeypatch.setattr(syc.ctx, 'parse_data_mem', _boom)
+
+        raised = False
+        try:
+            syc.loadData(jIn, quiet=True)
+        except sy.SonicYangException:
+            raised = True
+        assert raised, "SonicYangException must still be raised even when quiet=True"
+
+        msgs = [kw.get('msg', '') for (_a, kw) in calls] + [
+            a[0] for (a, _kw) in calls if a
+        ]
+        assert not any('Data Loading Failed' in str(m) for m in msgs), \
+            "quiet=True must suppress 'Data Loading Failed' sysLog on failure: {}".format(msgs)
+
+        return
+
+    def test_loaddata_default_logs_syslog_on_success(self, sonic_yang_data, monkeypatch):
+        # Default (quiet=False) preserves existing behavior: the
+        # "Try to load Data" sysLog call must be emitted on success.
+        # monkeypatch.setattr cleanly reverts on teardown.
+        test_file = sonic_yang_data['test_file']
+        syc = sonic_yang_data['syc']
+        jIn = json.loads(self.readIjsonInput(test_file, 'SAMPLE_CONFIG_DB_JSON'))
+
+        calls = []
+        monkeypatch.setattr(syc, 'sysLog',
+                            lambda *a, **kw: calls.append((a, kw)))
+
+        syc.loadData(jIn)
+
+        msgs = [kw.get('msg', '') for (_a, kw) in calls] + [
+            a[0] for (a, _kw) in calls if a
+        ]
+        assert any('Try to load Data' in str(m) for m in msgs), \
+            "default quiet=False must log 'Try to load Data': {}".format(msgs)
+
+        return
+
     def teardown_class(self):
         pass

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1809,6 +1809,8 @@
         },
         "BGP_NEIGHBOR_AF": {
             "default|192.168.1.1|ipv4_unicast": {
+                "route_map_in": [ "map1" ],
+                "route_map_out": [ "map1" ]
             }
         },
         "BGP_PEER_GROUP": {
@@ -1817,6 +1819,8 @@
         },
         "BGP_PEER_GROUP_AF": {
             "default|PG1|ipv4_unicast": {
+                "route_map_in": [ "map1" ],
+                "route_map_out": [ "map1" ]
             }
         },
         "BGP_GLOBALS_LISTEN_PREFIX": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
@@ -70,6 +70,9 @@
         "eStrKey" : "InvalidValue",
         "eStr": ["send_community"]
     },
+    "BGP_NEIGHBOR_AF_ROUTE_MAP_VALID": {
+        "desc": "Reference valid route map"
+    },
     "BGP_NEIGHBOR_AF_NEG_ROUTE_MAP_NOT_EXIST": {
         "desc": "Reference to non-existent route-map.",
         "eStrKey" : "LeafRef"
@@ -113,6 +116,9 @@
         "desc": "Invalid value for send community type in peergroup AF.",
         "eStrKey" : "InvalidValue",
         "eStr": ["send_community"]
+    },
+    "BGP_PEERGROUP_AF_ROUTE_MAP_VALID": {
+        "desc": "Validate route-map reference in peergroup AF."
     },
     "BGP_PEERGROUP_AF_ROUTE_MAP_NOT_EXIST": {
         "desc": "Missing or non-existent route-map reference in peergroup AF.",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
@@ -823,6 +823,62 @@
         }
     },
 
+    "BGP_NEIGHBOR_AF_ROUTE_MAP_VALID": {
+        "sonic-route-map:sonic-route-map": {
+            "sonic-route-map:ROUTE_MAP_SET": {
+                "ROUTE_MAP_SET_LIST": [
+                    {
+                        "name": "ALLOW"
+                    }
+                ]
+            },
+            "sonic-route-map:ROUTE_MAP": {
+                "ROUTE_MAP_LIST": [
+                {
+                    "name": "ALLOW",
+                    "stmt_name": 1,
+                    "route_operation": "permit"
+                }
+                ]
+            }
+        },
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "local_asn": 65001
+                    }
+                ]
+            }
+        },
+        "sonic-bgp-neighbor:sonic-bgp-neighbor": {
+            "sonic-bgp-neighbor:BGP_NEIGHBOR": {
+                "BGP_NEIGHBOR_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "neighbor": "20.0.0.1",
+                        "local_asn": 1,
+                        "name": "BGP nbr 1",
+                        "asn": 65003
+                    }
+                ]
+            },
+            "sonic-bgp-neighbor:BGP_NEIGHBOR_AF": {
+                "BGP_NEIGHBOR_AF_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "neighbor": "20.0.0.1",
+                        "afi_safi": "ipv4_unicast",
+                        "admin_status": "up",
+                        "route_map_in": [ "ALLOW" ],
+                        "route_map_out": [ "ALLOW" ]
+                    }
+                ]
+            }
+        }
+    },
+
     "BGP_NEIGHBOR_AF_NEG_INVALID_MAP_IN": {
         "sonic-route-map:sonic-route-map": {
             "sonic-route-map:ROUTE_MAP_SET": {
@@ -1175,6 +1231,62 @@
                         "afi_safi": "ipv4_unicast",
                         "admin_status": "up",
                         "send_community": "foobar"
+                    }
+                ]
+            }
+        }
+    },
+
+    "BGP_PEERGROUP_AF_ROUTE_MAP_VALID": {
+         "sonic-route-map:sonic-route-map": {
+            "sonic-route-map:ROUTE_MAP_SET": {
+                "ROUTE_MAP_SET_LIST": [
+                    {
+                        "name": "ALLOW"
+                    }
+                ]
+            },
+            "sonic-route-map:ROUTE_MAP": {
+                "ROUTE_MAP_LIST": [
+                {
+                    "name": "ALLOW",
+                    "stmt_name": 1,
+                    "route_operation": "permit"
+                }
+                ]
+            }
+        },
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "local_asn": 65001
+                    }
+                ]
+            }
+        },
+        "sonic-bgp-peergroup:sonic-bgp-peergroup": {
+            "sonic-bgp-peergroup:BGP_PEER_GROUP": {
+                "BGP_PEER_GROUP_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "peer_group_name": "PG1",
+                        "local_asn": 1,
+                        "name": "BGP PeerGroup 01",
+                        "asn": 65003
+                    }
+                ]
+            },
+            "sonic-bgp-peergroup:BGP_PEER_GROUP_AF": {
+                "BGP_PEER_GROUP_AF_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "peer_group_name": "PG1",
+                        "afi_safi": "ipv4_unicast",
+                        "admin_status": "up",
+                        "route_map_in": [ "ALLOW" ],
+                        "route_map_out": [ "ALLOW" ]
                     }
                 ]
             }


### PR DESCRIPTION
## Backport GCU perf dependencies: sonic-yang-mgmt helpers + libyang `must_size()` patch to 202405

This is **Layers 2 + 3 of a 2-PR coordinated backport** of upstream GCU perf improvements. The Layer 1 code lives at Azure/sonic-utilities.msft#417 (now at parts **1-8**, includes the #4335 400G config-apply fix — see below).

### What's in this PR (3 upstream cherry-picks)

1. **sonic-net/sonic-buildimage#21907** — `sonic-yang-mgmt: uses clause with leaf-list, choice not honored` — required by the perf helpers to correctly walk grouped schema (leaf-list + choice under `uses`).
2. **sonic-net/sonic-buildimage#22254** — `sonic-yang-mgmt: Generic Config Updater - performance dependencies` — the primary perf-dependency payload:
   - New `sonic_yang_path.py` — YANG path-manipulation helpers
   - `find_schema_dependencies()` — schema dep index with caching
   - `find_schema_must_count()` — must-constraint counting (needs Layer 3)
   - Backlinks / must caches for O(1) lookups
3. **sonic-net/sonic-buildimage#26957** — `sonic-yang-mgmt: add quiet= kwarg to SonicYangExtMixin.loadData` — quiets the logs on the hot loadData path invoked repeatedly by the sorter.

**Layer 3** — `src/libyang/patch/libyang-leaf-must.patch`: exposes `Schema_Node_Leaf::must_size()` on the libyang 1.0.73 swig CPP binding. Without this, Layer 2's `find_schema_must_count()` raises `AttributeError` at runtime.

### Cherry-pick provenance

**These are clean cherry-picks — content-identical to upstream.** Unlike the companion [sonic-utilities.msft#417](https://github.com/Azure/sonic-utilities.msft/pull/417), where 202405's GCU had diverged far enough that each upstream change had to be re-expressed by hand, all three commits here applied unmodified.

| Commit | Upstream PR | Upstream commit |
|---|---|---|
| `7c9d704bb` | [#21907](https://github.com/sonic-net/sonic-buildimage/pull/21907) | `9cab5bd72` |
| `c0dbc41a2` | [#22254](https://github.com/sonic-net/sonic-buildimage/pull/22254) | `e016924f4` |
| `7042bbf2e` | [#26875](https://github.com/sonic-net/sonic-buildimage/pull/26875) (picked via its 202511 backport [#26957](https://github.com/sonic-net/sonic-buildimage/pull/26957)) | `dddd9baf8` |

Verified file-by-file against those upstream commits: **all 22 file diffs are content-identical**, and every file's +/− line counts match upstream exactly. 15 are byte-identical including `@@` hunk headers; the other 7 differ only in hunk line offsets, because the surrounding 202405 code sits at different line numbers. Each upstream PR was taken whole — no files or hunks dropped, and no 202405-specific code added.


### Why all three layers must land together

The three layers form a runtime dependency chain. Any partial combination breaks GCU on 202405:

| Layer 1 (#417) present | Layer 2 present | Layer 3 present | Runtime behavior |
|:---:|:---:|:---:|---|
| ✗ | * | * | stock 202405 GCU (slow, no perf win) |
| ✓ | ✗ | * | `AttributeError: 'SonicYang' object has no attribute 'find_schema_dependencies'` on GCU init |
| ✓ | ✓ | ✗ | `AttributeError: 'Schema_Node_Leaf' object has no attribute 'must_size'` during patch validation |
| ✓ | ✓ | ✓ | ✅ Full perf win — see #417 for benchmarks |

To guarantee the 202405 buildimage `HEAD` is never in a broken intermediate state, Layer 1 (#417) is merged first on `sonic-utilities.msft`, then this PR is rebased to bump `src/sonic-utilities` to that merge SHA so Layers 1+2+3 land in one atomic buildimage commit. See "Merge order" below.

### Validation (all 3 layers combined — refreshed on parts 1-8 of #417)

Full test matrix (562 total checks, 0 failures) lives in **Azure/sonic-utilities.msft#417**. Headline verified numbers on `str3-7800-lc3-1` (asic0, SONiC.20240532.59):

| Scenario | Ops | Baseline | Parts 1-7 | **Parts 1-8** | Speedup vs baseline |
|---|---:|---:|---:|---:|---:|
| `scale_50_add` (3-iter mean) | 50 | 11.44 s | 4.78 s | **3.89 s** | **2.94×** |
| `scale_100_add` (3-iter mean) | 100 | 21.13 s | 5.03 s | **4.08 s** | **5.18×** |
| `scale_200_add` (3-iter mean) | 200 | 42.46 s | 6.07 s | **4.67 s** | **9.09×** |
| `scale_500` | 500 | 171.57 s | 12.65 s | **5.48 s** | **31.3×** |
| `scale_1000` | 1000 | timeout (rc=2) | 32.40 s | **6.96 s** | **∞ (never completed)** |
| `variance_100` (5-iter mean) | 100 | 21.42 s | 4.92 s | **4.15 s** | **5.16×** |

Small-op isolated coverage (3 iters each): `op_add_20`, `op_replace_20`, `op_remove_20`, `op_mixed_30` — **12/12 pass** post part 8.

**Real (non-dry-run) end-to-end patches:** 8/8 pass on `str3-7800-lc3-1` — including `100g_config`, `400g_config`, `400g_add_v2`, `queue_add`, `multi_asic`, `multi_asic_revert`, `stress`, `stress_revert`.

**Unit tests:** 409 pytest + 81 subtests = **490 pass, 0 fail** across all 8 files in `tests/generic_config_updater/`.

**Malformed patches** (invalid JSON, invalid op, dangling leafref, schema-value violation): all produce graceful rc=2 errors with no python tracebacks.

### Real MOR add-cluster scaling (validates the combined 3-layer stack)

The full L1+L2+L3 stack was additionally measured against the real MOR add-cluster workflow using
`test_max_mors_under_budget` from sonic-mgmt [#26274](https://github.com/sonic-net/sonic-mgmt/pull/26274),
on `str3-7800-lc4-1` under a 1800 s budget. Six full test executions (stock `.59` vs this stack,
across two ASICs), **all PASSED** — full tables and analysis in **Azure/sonic-utilities.msft#417**.

| N MORs | Input ops | Stock `.59` apply | With #2733 L2+L3 + #417 | Speedup |
|---:|---:|---:|---:|:---:|
| 1 | 25 | 38.85 s | 31.88 s | 1.22× |
| 5 | 113 | 161.54 s | 33.25 s | 4.86× |
| 8 | 179 | 249.27 s | 32.41 s | 7.69× |
| 10 | 223 | 309.60 s | 32.95 s | 9.40× |
| 14 | 317 | 530.33 s | **43.40 s** | **12.22×** |

Marginal cost per MOR drops **37.8 s → 0.89 s** (42× slope reduction); GCU change count stays
flat at 20 from N=1 through N=10 while the input patch grows ~9×. The speedup widens with N and
is still climbing at N=14 — the advantage grows with cluster size rather than being a fixed
constant. An empty `[]` patch costs ~10.4–10.8 s in **both** states, confirming the fixed
overhead is untouched and the gain is attributable to the sorter.

Because Layer 3 (`must_size()`) is a hard prerequisite for the L1 sorter, these MOR numbers are
only obtainable with this PR merged — they are as much a validation of #2733 as of #417.

### 400G config-apply — **resolved by #4335 (cherry-picked into #417 as part 6)**

The earlier reported `KeyError('PORTCHANNEL_MEMBER')` on 400G port-add via `config apply-patch` is **fixed**. Root cause was upstream issue #24464 (leaf-list handling regression introduced by #3831); upstream fix #4335 was cherry-picked into #417 as part 6 and independently verified against the 400G real-config patches:

- `400g_config.patch`: 27 s / 25 moves, no regression
- `400g_add_v2.patch`: passes cleanly

No open perf/correctness caveats remain for this backport.

### Environment

Tested on **str3-7800-lc3-1** (Arista 7800R3A-36DM2-D36 chassis LC, SONiC.20240532.59, Python 3.11.2, libyang 1.0.73 with this PR's patch applied). Wheel rebuilt via `make -C src/sonic-yang-mgmt` and installed on DUT for perf runs.

### Files
19 files changed: `src/sonic-yang-mgmt/**` (Layer 2 python + tests) and `src/libyang/patch/libyang-leaf-must.patch` + `src/libyang/patch/series` (Layer 3). Two extra test-fixture JSON edits under `src/sonic-yang-models/tests/` needed for the new dependency semantics.

### Merge order (single atomic buildimage merge)

1. **Azure/sonic-utilities.msft#417 merges first** on `sonic-utilities.msft:202405` → produces a merge SHA
2. **This PR is rebased** to add a `src/sonic-utilities` submodule bump to that merge SHA on top of the existing Layer 2 + Layer 3 commits
3. **This PR merges** → buildimage `202405` picks up Layers 1 + 2 + 3 in one atomic commit; no image build off `202405` is ever in a broken intermediate state

