### PR TITLE
[202511_azd] [sonic-yang-models]: Add ipv6_use_link_local_only to VLAN_SUB_INTERFACE YANG model

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -1611,7 +1611,8 @@ These tables have a number of shared attributes as described below:
     "VLAN_SUB_INTERFACE": {
         "Ethernet0.555": {
             "vrf_name": "Blue",
-            "vlan": "555"
+            "vlan": "555",
+            "ipv6_use_link_local_only": "enable"
         }
     }
 }

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1280,7 +1280,8 @@
         "VLAN_SUB_INTERFACE": {
             "Ethernet12.10": {
                 "admin_status": "up",
-                "loopback_action": "drop"
+                "loopback_action": "drop",
+                "ipv6_use_link_local_only": "enable"
             },
             "Ethernet12.10|10.0.1.56/31": {},
             "Ethernet12.10|fc00::1:71/126": {},

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan_sub_interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan_sub_interface.json
@@ -71,7 +71,14 @@
         "desc": "Configure PortChannel VLAN sub interface with VNET reference."
     },
     "VLAN_SUB_INTERFACE_WITH_MISSING_VNET": {
-        "desc": "Configure VLAN sub interface with VNET reference but no VNET exsiting.",
+        "desc": "Configure VLAN sub interface with VNET reference but no VNET existing.",
         "eStrKey": "LeafRef"
+    },
+    "VLAN_SUB_INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
+        "desc": "Configure VLAN sub interface with ipv6_use_link_local_only enabled."
+    },
+    "VLAN_SUB_INTERFACE_INVALID_IPV6_LINK_LOCAL": {
+        "desc": "Configure VLAN sub interface with an invalid ipv6_use_link_local_only value.",
+        "eStr": "Invalid value \"true\" in \"ipv6_use_link_local_only\" element."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan_sub_interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan_sub_interface.json
@@ -779,5 +779,59 @@
                 ]
             }
         }
+    },
+    "VLAN_SUB_INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
+        "sonic-vlan-sub-interface:sonic-vlan-sub-interface": {
+            "sonic-vlan-sub-interface:VLAN_SUB_INTERFACE": {
+                "VLAN_SUB_INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8.10",
+                        "ipv6_use_link_local_only": "enable"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "admin_status": "up",
+                        "alias": "Ethernet8/1",
+                        "description": "Ethernet8",
+                        "lanes": "45,46,47,48",
+                        "mtu": 9000,
+                        "speed": 100000
+                    }
+                ]
+            }
+        }
+    },
+    "VLAN_SUB_INTERFACE_INVALID_IPV6_LINK_LOCAL": {
+        "sonic-vlan-sub-interface:sonic-vlan-sub-interface": {
+            "sonic-vlan-sub-interface:VLAN_SUB_INTERFACE": {
+                "VLAN_SUB_INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8.10",
+                        "ipv6_use_link_local_only": "true"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "admin_status": "up",
+                        "alias": "Ethernet8/1",
+                        "description": "Ethernet8",
+                        "lanes": "45,46,47,48",
+                        "mtu": 9000,
+                        "speed": 100000
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
@@ -28,9 +28,13 @@ module sonic-vlan-sub-interface {
 
     description "VLAN sub interface for SONiC OS";
 
-	revision 2025-03-06 {
-		description "Add leaf vnet_name";
-	}
+    revision 2026-07-20 {
+        description "Add leaf ipv6_use_link_local_only";
+    }
+
+    revision 2025-03-06 {
+        description "Add leaf vnet_name";
+    }
     
     revision 2021-11-11 {
         description "Initial version";
@@ -87,6 +91,12 @@ module sonic-vlan-sub-interface {
                     type leafref {
                         path "/svnet:sonic-vnet/svnet:VNET/svnet:VNET_LIST/svnet:name";
                     }   
+                }
+
+                leaf ipv6_use_link_local_only {
+                    description "Enable/Disable IPv6 link local address on vlan sub-interface";
+                    type stypes:mode-status;
+                    default disable;
                 }
 
                 leaf loopback_action {


### PR DESCRIPTION
This is to cherry-pick sonic-buildimage PR: https://github.com/sonic-net/sonic-buildimage/pull/28519

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

