### PR TITLE
 [202506] Cherry-pick BGP Unnumbered Neighbors Support

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
@@ -12,7 +12,10 @@ from .template import TemplateFabric
 from .utils import run_command
 from .managers_device_global import DeviceGlobalCfgMgr
 
-INTERFACE_PATTERN = re.compile(r'^(Ethernet|PortChannel|Vlan|Po)\d+(\.\d+)?$')
+INTERFACE_PATTERN = re.compile(
+    r'^(Ethernet\d+|PortChannel\d+|Vlan\d+)(\.\d+)?$'  # long-form (bare or subinterface)
+    r'|^(Eth\d+|Po\d+)\.\d+$'                          # short-form (subinterface only, per HLD)
+)
 
 
 def is_interface_neighbor(neighbor):

--- a/src/sonic-bgpcfgd/bgpcfgd/template.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/template.py
@@ -66,11 +66,15 @@ class TemplateFabric(object):
 
     @staticmethod
     def is_interface(value):
-        """ Return True if the value is an interface name (Ethernet, PortChannel, Vlan) """
+        """ Return True if the value is an interface name (Ethernet/Eth, PortChannel/Po, Vlan) """
         if not value:
             return False
         import re
-        return bool(re.match(r'^(Ethernet|PortChannel|Vlan|Po)\d+(\.\d+)?$', str(value)))
+        return bool(re.match(
+            r'^(Ethernet\d+|PortChannel\d+|Vlan\d+)(\.\d+)?$'  # long-form (bare or subinterface)
+            r'|^(Eth\d+|Po\d+)\.\d+$',                          # short-form (subinterface only, per HLD)
+            str(value)
+        ))
 
     @staticmethod
     def prefix_attr(attr, value):

--- a/src/sonic-bgpcfgd/tests/test_bgp_unnumbered.py
+++ b/src/sonic-bgpcfgd/tests/test_bgp_unnumbered.py
@@ -57,6 +57,45 @@ def test_is_interface_neighbor_none():
 def test_is_interface_neighbor_trailing_junk():
     assert is_interface_neighbor('Ethernet0foo') is False
 
+def test_is_interface_neighbor_ethernet_subinterface():
+    assert is_interface_neighbor('Ethernet0.100') is True
+
+def test_is_interface_neighbor_portchannel_subinterface():
+    assert is_interface_neighbor('PortChannel101.200') is True
+
+def test_is_interface_neighbor_eth_subinterface_short_form():
+    assert is_interface_neighbor('Eth24.15') is True
+
+def test_is_interface_neighbor_po_subinterface_short_form():
+    assert is_interface_neighbor('Po101.15') is True
+
+# --- Short-form negative test cases ---
+
+def test_is_interface_neighbor_eth_short_form():
+    # Bare short-form without subinterface dot is not valid (no kernel interface "Eth24" exists)
+    assert is_interface_neighbor('Eth24') is False
+
+def test_is_interface_neighbor_po_short_form():
+    # Bare short-form without subinterface dot is not valid (no kernel interface "Po101" exists)
+    assert is_interface_neighbor('Po101') is False
+
+def test_is_interface_neighbor_eth_no_number():
+    assert is_interface_neighbor('Eth') is False
+
+def test_is_interface_neighbor_po_no_number():
+    assert is_interface_neighbor('Po') is False
+
+def test_is_interface_neighbor_eth_lowercase():
+    assert is_interface_neighbor('eth24') is False
+
+def test_is_interface_neighbor_po_lowercase():
+    assert is_interface_neighbor('po101') is False
+
+def test_is_interface_neighbor_eth_uppercase():
+    assert is_interface_neighbor('ETH24') is False
+
+def test_is_interface_neighbor_po_uppercase():
+    assert is_interface_neighbor('PO24') is False
 
 # --- Template rendering tests ---
 

--- a/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
@@ -73,7 +73,7 @@ module sonic-bgp-neighbor {
                             path "/subintf:sonic-vlan-sub-interface/subintf:VLAN_SUB_INTERFACE/subintf:VLAN_SUB_INTERFACE_LIST/subintf:name";
                         }
                         type string {
-                            pattern 'Vlan([0-9]{1,3}|[1-3][0-9]{3}|[4][0][0-8][0-9]|[4][0][9][0-4])';
+                            pattern '(Ethernet|Eth|PortChannel|Po)[0-9]+\.[0-9]+';
                         }
                     }
                     description "BGP Neighbor address or interface name";
@@ -115,6 +115,9 @@ module sonic-bgp-neighbor {
                        // }
                         type string {
                             pattern 'Vlan([0-9]{1,3}|[1-3][0-9]{3}|[4][0][0-8][0-9]|[4][0][9][0-4])';
+                        }
+                        type string {
+                            pattern '(Ethernet|Eth|PortChannel|Po)[0-9]+\.[0-9]+';
                         }
                     }
                     description "BGP Neighbor, it will be neighbor address or interface name";


### PR DESCRIPTION
Cherry-pick follow-up commits from https://github.com/sonic-net/sonic-buildimage/pull/27370

Related PR: https://github.com/Azure/sonic-buildimage-msft/pull/2413
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

