### PR TITLE
[Broadcom] Upgrade Broadcom xgs SAI version to 14.3.0.0.0.0.30.0 (#28474)

### DIFF
--- a/platform/broadcom/sai-xgs.mk
+++ b/platform/broadcom/sai-xgs.mk
@@ -1,5 +1,5 @@
 # Broadcom XGS SAI definitions
-LIBSAIBCM_XGS_VERSION = 14.3.0.0.0.0.16.0
+LIBSAIBCM_XGS_VERSION = 14.3.0.0.0.0.30.0
 LIBSAIBCM_XGS_BRANCH_NAME = SAI_14.3.0_GA
 
 LIBSAIBCM_XGS_URL_PREFIX = "https://packages.trafficmanager.net/public/sai/sai-broadcom/$(LIBSAIBCM_XGS_BRANCH_NAME)/$(LIBSAIBCM_XGS_VERSION)/xgs"


### PR DESCRIPTION
### Description of PR
Summary:
Cherry-pick sonic-net/sonic-buildimage#28474 to the 202512 branch.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Cherry-pick of upstream sonic-net/sonic-buildimage#28474 ("[202511][Broadcom] Upgrade Broadcom xgs SAI version to 14.3.0.0.0.0.30.0") onto the `202512` branch of this repo.

Bump `LIBSAIBCM_XGS_VERSION` from `14.3.0.0.0.0.16.0` (current value on this branch) to `14.3.0.0.0.0.30.0`. Per the upstream PR, changes since the last bump include:
- 14.3.0.0.0.0.28.0: Add 128x800G config files for TH6P.
- 14.3.0.0.0.0.29.0: Uplift SONIC-124273 - fix `_brcm_sai_inif_discard_wa` counter underflow and clear-order race.
- 14.3.0.0.0.0.30.0: Uplift SONIC-123559 - duplicate mirror session support.

#### How did you do it?
Cherry-picked commit 5cc9b4ce93f1dd298c7a49e5af85ea0acd2d41d8 from sonic-net/sonic-buildimage. Since this branch's `sai-xgs.mk` was already at a different version (`14.3.0.0.0.0.16.0` vs upstream's pre-PR `14.3.0.0.0.0.27.0`), the cherry-pick conflicted; resolved by setting `LIBSAIBCM_XGS_VERSION` to the upstream PR's target version `14.3.0.0.0.0.30.0`.

#### How did you verify/test it?
Not build/tested locally; this is a straightforward version bump matching upstream's verified change.

#### Any platform specific information?
Broadcom XGS platforms.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A