### PR TITLE
[202506][sonic-yang-models]: Fix incorrect expected error key in BGP neighbor YANG model tests

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
@@ -30,7 +30,7 @@
     },
     "BGP_NEIGHBOR_NEG_VNET_NOT_EXIST": {
         "desc": "BGP neighbor vrf_name references a non-existing VNet.",
-        "eStrKey": "LeafRef"
+        "eStrKey": "InvalidValue"
     },
     "BGP_PEERGROUP_ALL_VALID": {
         "desc": "Configure BGP peer group table."
@@ -45,7 +45,7 @@
     },
     "BGP_NEIGHBOR_NEG_GLOBAL_NOT_EXIST": {
         "desc": "Referring non-existing BGP global table.",
-        "eStrKey" : "LeafRef"
+        "eStrKey" : "InvalidValue"
     },
     "BGP_NEIGHBOR_AF_NEG_NEIGHBOR_NOT_EXIST": {
         "desc": "Referring non-existing BGP neighbor table.",


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixing build error by https://github.com/Azure/sonic-buildimage-msft/pull/2736
<img width="1320" height="113" alt="image" src="https://github.com/user-attachments/assets/eec23fb6-710e-487a-9677-80072896030f" />
<img width="1315" height="103" alt="image" src="https://github.com/user-attachments/assets/8fbaa76a-f283-4818-8362-2123a8888215" />
PR #2736 ([Add VNet name support to BGP_NEIGHBOR YANG model](https://github.com/Azure/sonic-buildimage-msft/pull/2736)) introduced two new negative test cases (`BGP_NEIGHBOR_NEG_VNET_NOT_EXIST` and `BGP_NEIGHBOR_NEG_GLOBAL_NOT_EXIST`) that expected a `LeafRef` validation error. However, the YANG model raises an `InvalidValue` error for these cases, causing
the YANG model tests to fail. This PR fixes the expected error key in the test data.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Updated `src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json`:
- `BGP_NEIGHBOR_NEG_VNET_NOT_EXIST`: changed `eStrKey` from `"LeafRef"` → `"InvalidValue"`
- `BGP_NEIGHBOR_NEG_GLOBAL_NOT_EXIST`: changed `eStrKey` from `"LeafRef"` → `"InvalidValue"`


#### How to verify it
```
cd ~/sonic-buildimage/src/sonic-yang-models
python3 -m pytest tests/yang_model_tests/test_yang_model.py -v -s
```
Successful Pipeline Run:
https://github.com/sonic-net/sonic-buildimage/pull/28566/checks?check_run_id=90109513519
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202506

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

