### PR TITLE
[202506] [sonic-yang-models] Update VNET_ROUTE_TUNNEL to support IPv6 route prefix

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -2751,10 +2751,35 @@ monitoring sessions for the vnet routes and is optional.
 }
 ```
 
+### VNET_ROUTE
+
+VNET_ROUTE table has vnet_name|prefix as the object key, where vnet_name is the name of the VNet and prefix is the IPv4 or IPv6 prefix associated with the vnet route. The table includes the following attributes:
+- NEXTHOP: Comma-separated nexthop IPs (mandatory). IPv4 and IPv6 addresses are supported. They are used to identify the nexthops of the vnet route.
+- IFNAME: The interface names (mandatory), such as "Ethernet1". It identifies the outgoing interfaces for the vnet route.
+
+```
+{
+  "VNET_ROUTE": {
+    "Vnet_2000|100.100.3.0/24": {
+        "nexthop": "100.100.3.1,100.100.3.2",
+        "ifname": "Ethernet1,Ethernet2"
+    },
+    "Vnet_3000|100.100.4.0/24": {
+        "nexthop": "100.100.4.1",
+        "ifname": "Ethernet2"
+    },
+    "Vnet_4000|fc00::/64": {
+        "nexthop": "2001:db8::1,2001:db8::2",
+        "ifname": "Ethernet3,Ethernet4"
+    }
+  }
+}
+```
+
 ### VNET_ROUTE_TUNNEL
 
-VNET_ROUTE_TUNNEL table has vnet_name|prefix as the object key, where vnet_name is the name of the VNet and prefix is the ip4 prefix associated with the route tunnel. The table includes the following attributes:
-- ENDPOINT: Comma-separated endpoint/nexthop tunnel IPs (mandatory). They are used to identify the endpoints of the tunnel.
+VNET_ROUTE_TUNNEL table has vnet_name|prefix as the object key, where vnet_name is the name of the VNet and prefix is the IPv4 or IPv6 prefix associated with the route tunnel. The table includes the following attributes:
+- ENDPOINT: Comma-separated endpoint/nexthop tunnel IPs (mandatory). IPv4 and IPv6 addresses are supported. They are used to identify the endpoints of the tunnel.
 - MAC_ADDRESS: Comma-separated inner destination MAC addresses in the encapsulated packet (optional).  They should be 12-hexadecimal digit values.
 - VNI: Comma-separated VNI values in the encapsulated packet (optional). They should be numeric values.
 - CONSISTENT_HASHING_BUCKETS: Number of consistent hashing buckets to use, if consistent hashing is desired (optional). It should be a numeric value.
@@ -2762,7 +2787,7 @@ VNET_ROUTE_TUNNEL table has vnet_name|prefix as the object key, where vnet_name 
 ```
 {
   "VNET_ROUTE_TUNNEL": {
-        "Vnet_1000|100.200.1.1/32": {
+    "Vnet_1000|100.200.1.1/32": {
         "endpoint": "192.174.1.1,192.174.1.2",
         "mac_address": "f8:25:84:98:22:a1,f8:25:84:98:22:a2",
         "vni": "10010,10011",
@@ -2776,6 +2801,11 @@ VNET_ROUTE_TUNNEL table has vnet_name|prefix as the object key, where vnet_name 
         "endpoint": "192.168.1.2",
         "mac_address": "f8:22:83:99:22:a2",
         "vni": "10012"
+    },
+    "Vnetv6_v6-0|fc00::/64": {
+        "endpoint": "2001:db8::1,2001:db8::2",
+        "mac_address": "f8:22:83:99:22:a3,f8:22:83:99:22:a4",
+        "vni": "10013,10014"
     }
   }
 }

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2414,6 +2414,16 @@
                 "overlay_dmac": "22:33:44:55:66:77"
             }
         },
+        "VNET_ROUTE": {
+            "vnet1|100.100.4.0/24": {
+                "nexthop": "100.100.4.1,100.100.4.2",
+                "ifname": "Ethernet1,Ethernet2"
+            },
+            "vnet1|fc00::/64": {
+                "nexthop": "2001:db8::1",
+                "ifname": "Ethernet3"
+            }
+        },
         "VNET_ROUTE_TUNNEL" : {
             "vnet1|10.0.0.0/24" : {
                 "endpoint": "192.168.1.1,192.168.1.2",
@@ -2421,6 +2431,11 @@
                 "vni": "10011,10012",
                 "consistent_hashing_buckets": "10",
                 "metric": "0"
+            },
+            "vnet1|fc00:1::/64" : {
+                "endpoint": "2001:db8::1",
+                "mac_address": "f9:22:83:99:22:a3",
+                "vni": "10013"
             }
         },
         "PORT_QOS_MAP": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vnet.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vnet.json
@@ -25,6 +25,51 @@
         "desc": "Missing Vxlan_TUNNEL configuration",
         "eStr" : [ "points to a non-existing leaf" ]
     },
+    "VNET_ROUTE_VALID_TEST": {
+        "desc": "Valid VNET Route Configuration."
+    },
+    "VNET_ROUTE_MULTI_TEST": {
+        "desc": "Multiple VNET route configurations for different VNETs in VNET_ROUTE_LIST table."
+    },
+    "VNET_ROUTE_TEST_DUPLICATE_NAME": {
+        "desc": "VNET route configuration with duplicate name keys in VNET_ROUTE_LIST table.",
+        "eStr": "Duplicated instance of \"VNET_ROUTE_LIST\" list."
+    },
+    "VNET_ROUTE_TEST_INVALID_NEXTHOP": {
+        "desc": "VNET route configuration with invalid nexthop IP value (256.256.256.256) in VNET_ROUTE_LIST table.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["nexthop"]
+    },
+    "VNET_ROUTE_TEST_INVALID_NAME_FORMAT": {
+        "desc": "VNET route configuration with invalid name format (missing prefix) in VNET_ROUTE_LIST table.",
+        "eStrKey": "ListKey"
+    },
+    "VNET_ROUTE_TEST_INVALID_PREFIX": {
+        "desc": "VNET route configuration with invalid prefix format (300.100.4.0/24) in name field.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["prefix"]
+    },
+    "VNET_ROUTE_TEST_MISSING_NEXTHOP": {
+        "desc": "VNET route configuration with missing mandatory attribute (nexthop) in VNET_ROUTE_LIST table.",
+        "eStrKey": "Mandatory"
+    },
+    "VNET_ROUTE_TEST_MISSING_INTERFACE": {
+        "desc": "VNET route configuration with missing mandatory attribute (interface) in VNET_ROUTE_LIST table.",
+        "eStrKey": "Mandatory"
+    },
+    "VNET_ROUTE_TEST_NONEXISTENT_VNET": {
+        "desc": "VNET route configuration referencing a non-existent VNET name, violating the must condition.",
+        "eStrKey" : "LeafRef"
+    },
+    "VNET_ROUTE_TEST_MULTI_NEXTHOP_INTERFACE": {
+        "desc": "VNET route configuration with multiple comma-separated nexthop IPs and interfaces in VNET_ROUTE_LIST table."
+    },
+    "VNET_ROUTE_TEST_INVALID_MULTI_NEXTHOP": {
+        "desc": "VNET route configuration with invalid IP in comma-separated nexthop list.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["nexthop"]
+    },
+
     "VNET_ROUTE_TUNNEL_MIN_TEST": {
         "desc": "Basic VNET route tunnel configuration with minimal required field - endpoint in VNET_ROUTE_TUNNEL_LIST table."
     },
@@ -44,7 +89,8 @@
 
     "VNET_ROUTE_TUNNEL_TEST_INVALID_ENDPOINT": {
         "desc": "VNET route tunnel configuration with invalid endpoint IP value (256.256.256.256) in VNET_ROUTE_TUNNEL_LIST table.",
-        "eStr": "Value \"256.256.256.256\" does not satisfy the constraint"
+        "eStrKey": "InvalidValue",
+        "eStr": ["endpoint"]
     },
 
     "VNET_ROUTE_TUNNEL_TEST_INVALID_MAC": {
@@ -112,7 +158,8 @@
 
     "VNET_ROUTE_TUNNEL_TEST_INVALID_MULTI_ENDPOINT": {
         "desc": "VNET route tunnel configuration with invalid IP in comma-separated endpoint list.",
-        "eStrKey": "Pattern"
+        "eStrKey": "InvalidValue",
+        "eStr": ["endpoint"]
     },
 
     "VNET_ROUTE_TUNNEL_TEST_INVALID_MULTI_MAC": {
@@ -143,6 +190,42 @@
 
     "VNET_ROUTE_TUNNEL_TEST_INVALID_CONSISTENT_HASHING": {
         "desc": "VNET route tunnel configuration with invalid consistent_hashing_buckets value (exceeds uint16 max).",
-        "eStrKey": "InvalidValue"
+        "eStr": "does not satisfy the constraint"
+    },
+
+    "VNET_ROUTE_V6_PREFIX_TEST": {
+        "desc": "Valid VNET route configuration with IPv6 prefix and IPv4 nexthop in VNET_ROUTE_LIST table."
+    },
+
+    "VNET_ROUTE_V6_NEXTHOP_TEST": {
+        "desc": "Valid VNET route configuration with IPv6 prefix and IPv6 nexthop in VNET_ROUTE_LIST table."
+    },
+
+    "VNET_ROUTE_V6_MULTI_NEXTHOP_TEST": {
+        "desc": "Valid VNET route configuration with IPv6 prefix and multiple comma-separated IPv6 nexthops in VNET_ROUTE_LIST table."
+    },
+
+    "VNET_ROUTE_V6_INVALID_NEXTHOP_TEST": {
+        "desc": "VNET route configuration with invalid IPv6 nexthop value in VNET_ROUTE_LIST table.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["nexthop"]
+    },
+
+    "VNET_ROUTE_TUNNEL_V6_PREFIX_TEST": {
+        "desc": "Valid VNET route tunnel configuration with IPv6 prefix and IPv4 endpoint in VNET_ROUTE_TUNNEL_LIST table."
+    },
+
+    "VNET_ROUTE_TUNNEL_V6_ENDPOINT_TEST": {
+        "desc": "Valid VNET route tunnel configuration with IPv6 prefix and IPv6 endpoint in VNET_ROUTE_TUNNEL_LIST table."
+    },
+
+    "VNET_ROUTE_TUNNEL_V6_MULTI_ENDPOINT_TEST": {
+        "desc": "Valid VNET route tunnel configuration with IPv6 prefix and multiple comma-separated IPv6 endpoints in VNET_ROUTE_TUNNEL_LIST table."
+    },
+
+    "VNET_ROUTE_TUNNEL_V6_INVALID_ENDPOINT_TEST": {
+        "desc": "VNET route tunnel configuration with invalid IPv6 endpoint value in VNET_ROUTE_TUNNEL_LIST table.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["endpoint"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vnet.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vnet.json
@@ -64,7 +64,24 @@
 
     "VNET_ROUTE_TUNNEL_TEST_INVALID_PREFIX": {
         "desc": "VNET route tunnel configuration with invalid prefix format (300.168.1.0/24) in name field.",
-        "eStr": "Value \"300.168.1.0/24\" does not satisfy the constraint \"((([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/(([0-9])|([1-2][0-9])|(3[0-2])))\" (range, length, or pattern)\""
+        "eStrKey": "InvalidValue",
+        "eStr": ["prefix"]
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_INVALID_PREFIX_LEN": {
+        "desc": "VNET route tunnel configuration with invalid IPv4 prefix length (10.0.0.0/33) in VNET_ROUTE_TUNNEL_LIST table.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["prefix"]
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_IPV6_PREFIX": {
+        "desc": "VNET route tunnel configuration with IPv6 prefix in VNET_ROUTE_TUNNEL_LIST table."
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_INVALID_IPV6_PREFIX": {
+        "desc": "VNET route tunnel configuration with invalid IPv6 prefix format in VNET_ROUTE_TUNNEL_LIST table.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["prefix"]
     },
 
     "VNET_ROUTE_TUNNEL_TEST_MISSING_ENDPOINT": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vnet.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vnet.json
@@ -990,6 +990,113 @@
         }
     },
 
+    "VNET_ROUTE_TUNNEL_TEST_INVALID_PREFIX_LEN": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix": "10.0.0.0/33",
+                        "endpoint": "192.168.1.1"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_IPV6_PREFIX": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1000",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1000",
+                        "prefix": "2001:db8:30::2/128",
+                        "endpoint": "100.0.1.12",
+                        "mac_address": "52:54:00:00:00:aa",
+                        "vni": "10002"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_INVALID_IPV6_PREFIX": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1000",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1000",
+                        "prefix": "2001:db8:gg::1/128",
+                        "endpoint": "100.0.1.12"
+                    }
+                ]
+            }
+        }
+    },
+
     "VNET_ROUTE_TUNNEL_TEST_INVALID_CONSISTENT_HASHING": {
         "sonic-vxlan:sonic-vxlan": {
             "sonic-vxlan:VXLAN_TUNNEL": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vnet.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vnet.json
@@ -1131,5 +1131,289 @@
                 ]
             }
         }
+    },
+
+    "VNET_ROUTE_V6_PREFIX_TEST": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE": {
+                "VNET_ROUTE_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix": "fc00::/64",
+                        "nexthop": "100.100.1.1",
+                        "ifname": "Ethernet0"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_V6_NEXTHOP_TEST": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE": {
+                "VNET_ROUTE_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix": "fc00::/64",
+                        "nexthop": "2001:db8::1",
+                        "ifname": "Ethernet0"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_V6_MULTI_NEXTHOP_TEST": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE": {
+                "VNET_ROUTE_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix": "fc00::/64",
+                        "nexthop": "2001:db8::1,2001:db8::2,2001:db8::3",
+                        "ifname": "Ethernet1,Ethernet2,Ethernet3"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_V6_INVALID_NEXTHOP_TEST": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE": {
+                "VNET_ROUTE_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix": "fc00::/64",
+                        "nexthop": "zzzz::invalid",
+                        "ifname": "Ethernet0"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_V6_PREFIX_TEST": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix": "fc00::/64",
+                        "endpoint": "192.168.1.1"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_V6_ENDPOINT_TEST": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix": "fc00::/64",
+                        "endpoint": "2001:db8::1"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_V6_MULTI_ENDPOINT_TEST": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix": "fc00::/64",
+                        "endpoint": "2001:db8::1,2001:db8::2,2001:db8::3"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_V6_INVALID_ENDPOINT_TEST": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix": "fc00::/64",
+                        "endpoint": "zzzz::invalid"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-vnet.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vnet.yang
@@ -119,8 +119,8 @@ module sonic-vnet {
                 }
                 
                 leaf prefix {
-                    description "IPv4 prefix in CIDR format";
-                    type stypes:sonic-ip4-prefix;
+                    description "IP prefix in CIDR format (IPv4 or IPv6)";
+                    type stypes:sonic-ip-prefix;
                 }
                 
                 leaf endpoint {

--- a/src/sonic-yang-models/yang-models/sonic-vnet.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vnet.yang
@@ -104,6 +104,46 @@ module sonic-vnet {
         }
         /* end of container VNET */
 
+        container VNET_ROUTE {
+
+            description "Static routes within a virtual network";
+
+            list VNET_ROUTE_LIST {
+                description "Static route entry within a virtual network";
+
+                key "vnet_name prefix";
+
+                leaf vnet_name {
+                    description "VNET name";
+                    type leafref {
+                        path "/svnet:sonic-vnet/svnet:VNET/svnet:VNET_LIST/svnet:name";
+                    }
+                }
+
+                leaf prefix {
+                    description "IP prefix in CIDR format (IPv4 or IPv6)";
+                    type stypes:sonic-ip-prefix;
+                }
+
+                leaf nexthop {
+                    description "Nexthop IP addresses (IPv4 or IPv6, comma-separated)";
+                    type union {
+                        type stypes:ipv4-address-list;
+                        type stypes:ipv6-address-list;
+                    }
+                    mandatory true;
+                }
+
+                leaf ifname {
+                    description "Interface names";
+                    type string;
+                    mandatory true;
+                }
+            }
+            /* end of list VNET_ROUTE_LIST */
+        }
+        /* end of container VNET_ROUTE */
+
         container VNET_ROUTE_TUNNEL {
 
             description "ConfigDB VNET_ROUTE_TUNNEL table";
@@ -124,8 +164,11 @@ module sonic-vnet {
                 }
                 
                 leaf endpoint {
-                    description "Endpoint/nexthop tunnel IPs";
-                    type stypes:ipv4-address-list;
+                    description "Endpoint/nexthop tunnel IPs (IPv4 or IPv6, comma-separated)";
+                    type union {
+                        type stypes:ipv4-address-list;
+                        type stypes:ipv6-address-list;
+                    }
                     mandatory true;
                 }
 

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -64,6 +64,23 @@ module sonic-types {
             "Comma-separated IPv4 addresses";
     }
 
+    typedef ipv6-address-list {
+        type string {
+            pattern '(((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
+                + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
+                + '(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}'
+                + '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))'
+                + '(%[\p{N}\p{L}]+)?)'
+                + '(,(((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
+                + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
+                + '(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}'
+                + '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))'
+                + '(%[\p{N}\p{L}]+)?))*';
+        }
+        description
+            "Comma-separated IPv6 addresses";
+    }
+
     typedef admin_status {
         type enumeration {
             enum up;


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The `VNET_ROUTE_TUNNEL` YANG model only accepted IPv4 route prefixes (`sonic-ip4-prefix`). This change updates the `prefix` leaf to use `sonic-ip-prefix` (a union of IPv4 and IPv6) so that IPv6 route prefixes like `2001:db8:30::2/128` are accepted.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
**Commit 1** — Update VNET_ROUTE_TUNNEL prefix to support IPv6
- `VNET_ROUTE_TUNNEL.prefix`: `sonic-ip4-prefix` → `sonic-ip-prefix` (union of IPv4/IPv6)
- Updated `VNET_ROUTE_TUNNEL_TEST_INVALID_PREFIX` to `InvalidValue` (union error format)
- Added tests: `VNET_ROUTE_TUNNEL_TEST_IPV6_PREFIX`, `VNET_ROUTE_TUNNEL_TEST_INVALID_PREFIX_LEN`, `VNET_ROUTE_TUNNEL_TEST_INVALID_IPV6_PREFIX`

**Commit 2** — Add IPv6 support for VNET_ROUTE and VNET_ROUTE_TUNNEL nexthop/endpoint
- Added `ipv6-address-list` typedef to `sonic-types.yang.j2`
- `VNET_ROUTE.prefix`: `sonic-ip4-prefix` → `sonic-ip-prefix`
- `VNET_ROUTE.nexthop`: `ipv4-address-list` → `union { ipv4-address-list | ipv6-address-list }`
- `VNET_ROUTE_TUNNEL.endpoint`: `ipv4-address-list` → `union { ipv4-address-list | ipv6-address-list }`
- Updated all invalid-value tests for union leaves (`nexthop`, `endpoint`, `prefix`) from `Pattern` to `InvalidValue` with the failing leaf name
- Added 8 new tests covering valid/invalid IPv6 prefixes, nexthops, and endpoints
- Updated `doc/Configuration.md` and `tests/files/sample_config_db.json` with IPv6 examples

#### How to verify it
Run the YANG model tests:
```bash
cd src/sonic-yang-models
python3 -m pytest tests/yang_model_tests/test_yang_model.py -v
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202506

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

