### PR TITLE
[202512][Broadcom][SAI] Upgrade Broadcom XGS SAI 14.3.0.0.0.0.30.0 -> 14.3.0.0.0.0.31.0

### DIFF
--- a/platform/broadcom/sai-xgs.mk
+++ b/platform/broadcom/sai-xgs.mk
@@ -1,5 +1,5 @@
 # Broadcom XGS SAI definitions
-LIBSAIBCM_XGS_VERSION = 14.3.0.0.0.0.30.0
+LIBSAIBCM_XGS_VERSION = 14.3.0.0.0.0.31.0
 LIBSAIBCM_XGS_BRANCH_NAME = SAI_14.3.0_GA
 
 LIBSAIBCM_XGS_URL_PREFIX = "https://packages.trafficmanager.net/public/sai/sai-broadcom/$(LIBSAIBCM_XGS_BRANCH_NAME)/$(LIBSAIBCM_XGS_VERSION)/xgs"


### PR DESCRIPTION
### Description of PR
Summary:
Cherry-pick of sonic-net/sonic-buildimage#28683 to the `202512` branch.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Approach
#### What is the motivation for this PR?
Bump the Broadcom XGS SAI on the 202512 branch from `14.3.0.0.0.0.30.0` to `14.3.0.0.0.0.31.0`, matching the upgrade already merged to 202511 in sonic-net/sonic-buildimage#28683.

#### How did you do it?
Cherry-picked the single-line change to `LIBSAIBCM_XGS_VERSION` in `platform/broadcom/sai-xgs.mk` (merge commit c073a6893db5f93ef76566816923046ae057e9f7 from PR sonic-net/sonic-buildimage#28683).

#### How did you verify/test it?
See qualification results in sonic-net/sonic-buildimage#28683 (Elastictest A/B smoke + 12-script SAI qualification on Broadcom XGS hardware, no dataplane regressions).

#### Any platform specific information?
Broadcom XGS platforms only.

### Documentation
N/A
