### PR TITLE
[202506] Backport FRR IPv6 RA crash fix and align submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -56,7 +56,7 @@
 [submodule "src/sonic-frr/frr"]
 	path = src/sonic-frr/frr
 	url = https://github.com/sonic-net/sonic-frr.git
-	branch = frr-10.4.1
+	branch = frr-10.3
 [submodule "platform/p4/p4-hlir/p4-hlir-v1.1"]
 	path = platform/p4/p4-hlir/p4-hlir-v1.1
 	url = https://github.com/p4lang/p4-hlir.git

--- a/src/sonic-frr/patch/0062-zebra-fix-crash-with-v6-RA.patch
+++ b/src/sonic-frr/patch/0062-zebra-fix-crash-with-v6-RA.patch
@@ -1,0 +1,50 @@
+From d019ad49382553f1f01711d435f3473b3848be90 Mon Sep 17 00:00:00 2001
+From: soumyar-roy <souroy@nvidia.com>
+Date: Tue, 10 Jun 2025 21:14:16 +0000
+Subject: [PATCH] zebra: fix crash with v6 RA
+
+An interface can be added to the RA wheel more than once when
+rtadv_start_interface_events() is called for an interface already present in
+the advertised-interface list. Removing the interface then removes only one
+wheel entry, leaving a stale pointer that can crash process_rtadv().
+
+Do not add a duplicate wheel entry, and delete and free the advertised-
+interface record when stopping RA.
+
+Backport of FRR commit d019ad49382553f1f01711d435f3473b3848be90.
+
+Signed-off-by: Soumya Roy <souroy@nvidia.com>
+---
+ zebra/rtadv.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/zebra/rtadv.c b/zebra/rtadv.c
+--- a/zebra/rtadv.c
++++ b/zebra/rtadv.c
+@@ -1333,7 +1333,6 @@ static void rtadv_start_interface_events(struct zebra_vrf *zvrf,
+ 	adv_if = adv_if_add(zvrf, zif->ifp->name);
+ 	if (adv_if != NULL) {
+ 		rtadv_send_packet(zvrf->rtadv.sock, zif->ifp, RA_ENABLE);
+-		wheel_add_item(zrouter.ra_wheel, zif->ifp);
+ 		return; /* Already added */
+ 	}
+ 
+@@ -1519,12 +1518,16 @@ void rtadv_stop_ra(struct interface *ifp, bool if_down_event)
+ {
+ 	struct zebra_if *zif;
+ 	struct zebra_vrf *zvrf;
++	struct adv_if *adv_if = NULL;
+ 
+ 	/*Try to delete from ra wheels */
+ 	wheel_remove_item(zrouter.ra_wheel, ifp);
+ 
+ 	zif = ifp->info;
+ 	zvrf = rtadv_interface_get_zvrf(ifp);
++	adv_if = adv_if_del(zvrf, ifp->name);
++	if (adv_if != NULL)
++		adv_if_free(adv_if);
+ 
+ 	/*Turn off event for ICMPv6 join*/
+ 	EVENT_OFF(zif->icmpv6_join_timer);
+-- 
+2.39.5

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -59,3 +59,4 @@
 0059-zebra-Ensure-that-the-dplane-can-send-the-full-packe.patch
 0060-zebra-if-speed-change-check-fix.patch
 0061-bgpd-Fix-JSON-wrapper-brace-consistency-in-neighbor.patch
+0062-zebra-fix-crash-with-v6-RA.patch


### PR DESCRIPTION
#### Why I did it

Zebra can crash in `process_rtadv()` after an IPv6 router-advertisement interface is added to the RA wheel more than once and subsequently deleted. The remaining wheel entry points to freed interface memory.

This backports FRR commit https://github.com/FRRouting/frr/commit/d019ad49382553f1f01711d435f3473b3848be90 from https://github.com/FRRouting/frr/pull/19000 to the FRR 10.3 patch stack used by the 202506 branch.

The PR also restores the sonic-frr submodule metadata and gitlink to FRR 10.3. The previous pointer to FRR 10.4.1 was inconsistent with `rules/frr.mk`, which explicitly builds FRR 10.3 and applies the local patch series.

#### How I did it

- Stop adding a duplicate RA wheel entry when the advertised-interface record already exists.
- Delete and free the advertised-interface record in `rtadv_stop_ra()`.
- Add the backport to `src/sonic-frr/patch/series`.
- Change the `.gitmodules` sonic-frr branch from `frr-10.4.1` back to `frr-10.3`.
- Restore the sonic-frr gitlink to FRR 10.3 commit `85cf1ed576deed121751e16a64970f8a652a9e1e`.

#### How to verify it

- Build a 202506 SONiC image containing this change.
- Repeatedly create and enable IPv6 link-local/RA on the affected subinterfaces, bring the VNET up, and delete the interfaces.
- Confirm zebra does not restart or generate a core and that RA resumes after an interface down/up cycle.
- Confirm the FRR package reports version 10.3 and the complete patch series applies during the build.

#### Which release branch to backport

- [x] 202506

#### Description for the changelog

Backport the FRR IPv6 RA crash fix and align the FRR submodule with the 202506 build version.