### PR TITLE
[msft-202503] Prevent audio kernel modules from running on `Arista-7280DR3AM`

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -683,6 +683,7 @@ write_platform_specific_cmdline() {
         cmdline_add reassign_prefmem
     fi
     if in_array "$platform" "cormorant"; then
+        cmdline_add modprobe.blacklist=snd_hda_intel,hdaudio
         read_system_eeprom
     fi
     if in_array "$platform" "rook" "sprucefish"; then


### PR DESCRIPTION
#### Why I did it
We've seen these audio kernel modules can sometimes cause CPU lockups on bootup  of Arista-7280DR3AM requiring a power flap to restore. Since we don't use audio h/w on any of our SKUs blacklist these kernel modules on our Arista-7280DR3AM SKU.

#### How I did it
Use the modprobe.blacklist kernel argument to prevent booting of these kernel modules when enumerating the H/W.

#### How to verify it
I ran upgrade_path/test_upgrade_path.py 50 times on our Arista-7280DR3AM SKU and didn't see the OS fail to boot once.
Previously we'd usually see the boot fail every ~10 boots.

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
Blacklist audio kernel modules from running on the Arista-7280DR3AM SKU

