### PR TITLE
[azure-pipelines]: Align branch and image-tag references with 202608

### DIFF
--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -8,14 +8,14 @@ schedules:
 - cron: "0 8 * * *"
   branches:
     include:
-    - 202605
+    - 202608
   always: true
 
 trigger: none
 pr:
   branches:
     include:
-    - 202605
+    - 202608
   paths:
     include:
     - dockers/docker-sonic-mgmt
@@ -70,20 +70,20 @@ stages:
     - bash: |
         set -ex
         docker load -i $(Build.ArtifactStagingDirectory)/target/docker-sonic-mgmt.gz
-        docker tag docker-sonic-mgmt:latest $REGISTRY_SERVER/docker-sonic-mgmt:202605-lastbuild
+        docker tag docker-sonic-mgmt:latest $REGISTRY_SERVER/docker-sonic-mgmt:202608-lastbuild
         docker images
       env:
         REGISTRY_SERVER: ${{ parameters.registry_url }}
-      displayName: 'Load and tag docker-sonic-mgmt as 202605-lastbuild'
+      displayName: 'Load and tag docker-sonic-mgmt as 202608-lastbuild'
 
     - task: Docker@2
-      displayName: 'Push docker-sonic-mgmt:202605-lastbuild to registry'
+      displayName: 'Push docker-sonic-mgmt:202608-lastbuild to registry'
       condition: succeeded()
       inputs:
         containerRegistry: ${{ parameters.registry_conn }}
         repository: docker-sonic-mgmt
         command: push
-        tags: 202605-lastbuild
+        tags: 202608-lastbuild
 
 - stage: Test
   dependsOn: Build
@@ -157,7 +157,7 @@ stages:
       INCLUDE_JOBS: "all"
       OVERRIDE_PARAMS:
         REPO_NAME: "sonic-mgmt"
-        SETUP_CONTAINER_PARAMS: "-i ${{ parameters.registry_url }}/docker-sonic-mgmt:202605-lastbuild"
+        SETUP_CONTAINER_PARAMS: "-i ${{ parameters.registry_url }}/docker-sonic-mgmt:202608-lastbuild"
 
 - stage: Publish
   dependsOn: Test
@@ -174,17 +174,17 @@ stages:
     - bash: |
         set -ex
         docker load -i $(Pipeline.Workspace)/docker-sonic-mgmt/target/docker-sonic-mgmt.gz
-        docker tag docker-sonic-mgmt:latest $REGISTRY_SERVER/docker-sonic-mgmt:202605
+        docker tag docker-sonic-mgmt:latest $REGISTRY_SERVER/docker-sonic-mgmt:202608
         docker images
       env:
         REGISTRY_SERVER: ${{ parameters.registry_url }}
-      displayName: 'Load and tag docker-sonic-mgmt as 202605'
+      displayName: 'Load and tag docker-sonic-mgmt as 202608'
 
     - task: Docker@2
-      displayName: 'Push docker-sonic-mgmt:202605 to registry'
+      displayName: 'Push docker-sonic-mgmt:202608 to registry'
       condition: succeeded()
       inputs:
         containerRegistry: ${{ parameters.registry_conn }}
         repository: docker-sonic-mgmt
         command: push
-        tags: 202605
+        tags: 202608

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -140,7 +140,7 @@ stages:
   - name: PTF_IMAGE_TAG
     # Branch-aligned docker-ptf image tag used for PR test. PR builds only.
     ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-      value: '202605'
+      value: '202608'
     ${{ else }}:
       value: ''
 


### PR DESCRIPTION
#### Why I did it

The `202608` branch was cut from `202605`, and the pipeline definitions still carry hardcoded `202605` references:

1. **`azure-pipelines.yml` — `PTF_IMAGE_TAG`**
   The variable is documented in-file as *"Branch-aligned docker-ptf image tag used for PR test"*, but it was pinned to `'202605'`. `.azure-pipelines/docker-ptf.yml` derives its published tag from `Build.SourceBranchName`, so on this branch it publishes `docker-ptf:202608` while PR test was still pulling `docker-ptf:202605`.

2. **`.azure-pipelines/docker-sonic-mgmt.yml` — triggers**
   Both the `schedules` and `pr` trigger blocks listed only `202605`, so this pipeline never ran on the `202608` branch at all.

3. **`.azure-pipelines/docker-sonic-mgmt.yml` — image tags**
   The Build/Test/Publish stages tag and push `docker-sonic-mgmt:202605` and `docker-sonic-mgmt:202605-lastbuild`. Had the pipeline run on this branch it would have clobbered the 202605 images with 202608 content.

##### Work item tracking
- Microsoft ADO: N/A

#### How I did it

- `azure-pipelines.yml`: `PTF_IMAGE_TAG` `202605` -> `202608`.
- `.azure-pipelines/docker-sonic-mgmt.yml`: schedule + PR trigger branch `202605` -> `202608`; image tags `202605` -> `202608` and `202605-lastbuild` -> `202608-lastbuild` (Build tag/push, `SETUP_CONTAINER_PARAMS`, Publish tag/push).

**Intentionally left unchanged:** the `sonic-net/sonic-mgmt` repository resources in both `.azure-pipelines/docker-ptf.yml` (line 23) and `.azure-pipelines/docker-sonic-mgmt.yml` (line 29) remain at `ref: 202605`. Upstream `sonic-net/sonic-mgmt` has no `202608` branch, so bumping those would break the checkout.

#### How to verify it

```bash
# only the sonic-mgmt repository resources should remain on 202605
git grep -n 202605 -- azure-pipelines.yml .azure-pipelines/
```

- Confirm `docker-sonic-mgmt` pipeline now triggers on PRs targeting `202608` and on the nightly schedule for that branch.
- Confirm the Publish stage pushes `sonicdev-microsoft.azurecr.io/docker-sonic-mgmt:202608` and the Test stage consumes `:202608-lastbuild` produced earlier in the same run.
- Confirm PR test on this branch pulls `docker-ptf:202608`.

YAML validated with `yaml.safe_load` on all three touched/inspected pipeline files.

#### Which release branch to backport (provide reason below if selected)

N/A — branch-specific alignment. `202606` and `202607` have the same stale references and would each need their own equivalent fix.

#### Tested branch (Please provide the tested image version)

N/A — pipeline definition change; validated by inspection and YAML parse. CI on this PR exercises the change.

#### Description for the changelog

Align azure-pipelines branch triggers and docker image tags with the 202608 branch.
