### PR TITLE
[ci][202608]: Align pipeline resources with internal branches

### DIFF
--- a/.azure-pipelines/azure-pipelines-build-vs-and-test.yml
+++ b/.azure-pipelines/azure-pipelines-build-vs-and-test.yml
@@ -8,14 +8,14 @@ resources:
   repositories:
   - repository: sonic-mgmt
     type: github
-    name: sonic-net/sonic-mgmt
-    ref: master
+    name: Azure/sonic-mgmt.msft
+    ref: 202608
     endpoint: sonic-net
   - repository: buildimage
     type: github
-    name: sonic-net/sonic-buildimage
+    name: Azure/sonic-buildimage-msft
     endpoint: sonic-net
-    ref: master
+    ref: 202608
 
 
 variables:
@@ -43,7 +43,7 @@ parameters:
 
   - name: MGMT_BRANCH
     type: string
-    default: 'master'
+    default: '$(BUILD_BRANCH)'
 
   - name: TOPOLOGY
     type: string

--- a/.azure-pipelines/baseline_test/baseline.test.buildimage.yml
+++ b/.azure-pipelines/baseline_test/baseline.test.buildimage.yml
@@ -15,14 +15,14 @@ resources:
   repositories:
   - repository: sonic-mgmt
     type: github
-    name: sonic-net/sonic-mgmt
-    ref: master
+    name: Azure/sonic-mgmt.msft
+    ref: 202608
     endpoint: sonic-net
   - repository: buildimage
     type: github
-    name: sonic-net/sonic-buildimage
+    name: Azure/sonic-buildimage-msft
     endpoint: sonic-net
-    ref: master
+    ref: 202608
 
 parameters:
   - name: BUILD_REASON

--- a/.azure-pipelines/official-build-vs-with-test.yml
+++ b/.azure-pipelines/official-build-vs-with-test.yml
@@ -32,14 +32,14 @@ resources:
   repositories:
     - repository: sonic-mgmt
       type: github
-      name: sonic-net/sonic-mgmt
-      ref: master
+      name: Azure/sonic-mgmt.msft
+      ref: 202608
       endpoint: sonic-net
     - repository: buildimage
       type: github
-      name: sonic-net/sonic-buildimage
+      name: Azure/sonic-buildimage-msft
       endpoint: sonic-net
-      ref: master
+      ref: 202608
 
 variables:
   - template: .azure-pipelines/azure-pipelines-repd-build-variables.yml@buildimage

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,14 +27,14 @@ resources:
   repositories:
   - repository: sonic-mgmt
     type: github
-    name: sonic-net/sonic-mgmt
-    ref: master
+    name: Azure/sonic-mgmt.msft
+    ref: 202608
     endpoint: sonic-net
   - repository: buildimage
     type: github
-    name: sonic-net/sonic-buildimage
+    name: Azure/sonic-buildimage-msft
     endpoint: sonic-net
-    ref: master
+    ref: 202608
 
 parameters:
 - name: TIMEOUT_IN_MINUTES_PR_TEST


### PR DESCRIPTION
#### Why I did it

The Microsoft-internal `202608` build pipeline was importing its pipeline and PR-test templates from the public `master` branches. `sonic-mgmt/master` includes the master-only `t0-vpp_checker`, while `Azure/sonic-mgmt.msft/202608` does not.

Kusto shows that all 12 `t0-vpp` PR test plans on `202608` failed between August 14 and August 25 across eight PRs. The failures were unrelated to most of the changes under test, so the master-only checker was incorrectly blocking `202608` PRs.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

Updated the pipeline repository resources to use the matching Microsoft-internal release branches:

- `Azure/sonic-mgmt.msft`, branch `202608`
- `Azure/sonic-buildimage-msft`, branch `202608`

Applied the change to these four pipeline entry points:

- `azure-pipelines.yml`
- `.azure-pipelines/azure-pipelines-build-vs-and-test.yml`
- `.azure-pipelines/official-build-vs-with-test.yml`
- `.azure-pipelines/baseline_test/baseline.test.buildimage.yml`

The standalone VS-and-test pipeline now also defaults `MGMT_BRANCH` to `$(BUILD_BRANCH)` instead of `master`.

#### How to verify it

- Confirmed both internal `202608` branches exist.
- Confirmed `Azure/sonic-mgmt.msft/202608` contains `t1-lag-vpp_checker` but does not contain `t0-vpp_checker`.
- Confirmed all four pipeline entry points reference the internal `202608` repositories.
- `git diff --check` passes.

#### Which release branch to backport (provide reason below if selected)

- [x] 202608

This PR directly targets the internal `202608` branch and fixes a pipeline configuration regression.

#### Tested branch (Please provide the tested image version)

- [x] 202608, static pipeline configuration validation

#### Description for the changelog

N/A

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

N/A
