### PR TITLE
[ci][202607]: Align pipeline resources with internal branches

### DIFF
--- a/.azure-pipelines/azure-pipelines-build-vs-and-test.yml
+++ b/.azure-pipelines/azure-pipelines-build-vs-and-test.yml
@@ -8,14 +8,14 @@ resources:
   repositories:
   - repository: sonic-mgmt
     type: github
-    name: sonic-net/sonic-mgmt
-    ref: master
+    name: Azure/sonic-mgmt.msft
+    ref: 202607
     endpoint: sonic-net
   - repository: buildimage
     type: github
-    name: sonic-net/sonic-buildimage
+    name: Azure/sonic-buildimage-msft
     endpoint: sonic-net
-    ref: master
+    ref: 202607
 
 
 variables:
@@ -43,7 +43,7 @@ parameters:
 
   - name: MGMT_BRANCH
     type: string
-    default: 'master'
+    default: '$(BUILD_BRANCH)'
 
   - name: TOPOLOGY
     type: string

--- a/.azure-pipelines/baseline_test/baseline.test.buildimage.yml
+++ b/.azure-pipelines/baseline_test/baseline.test.buildimage.yml
@@ -15,14 +15,14 @@ resources:
   repositories:
   - repository: sonic-mgmt
     type: github
-    name: sonic-net/sonic-mgmt
-    ref: master
+    name: Azure/sonic-mgmt.msft
+    ref: 202607
     endpoint: sonic-net
   - repository: buildimage
     type: github
-    name: sonic-net/sonic-buildimage
+    name: Azure/sonic-buildimage-msft
     endpoint: sonic-net
-    ref: master
+    ref: 202607
 
 parameters:
   - name: BUILD_REASON

--- a/.azure-pipelines/official-build-vs-with-test.yml
+++ b/.azure-pipelines/official-build-vs-with-test.yml
@@ -32,14 +32,14 @@ resources:
   repositories:
     - repository: sonic-mgmt
       type: github
-      name: sonic-net/sonic-mgmt
-      ref: master
+      name: Azure/sonic-mgmt.msft
+      ref: 202607
       endpoint: sonic-net
     - repository: buildimage
       type: github
-      name: sonic-net/sonic-buildimage
+      name: Azure/sonic-buildimage-msft
       endpoint: sonic-net
-      ref: master
+      ref: 202607
 
 variables:
   - template: .azure-pipelines/azure-pipelines-repd-build-variables.yml@buildimage

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,14 +27,14 @@ resources:
   repositories:
   - repository: sonic-mgmt
     type: github
-    name: sonic-net/sonic-mgmt
-    ref: master
+    name: Azure/sonic-mgmt.msft
+    ref: 202607
     endpoint: sonic-net
   - repository: buildimage
     type: github
-    name: sonic-net/sonic-buildimage
+    name: Azure/sonic-buildimage-msft
     endpoint: sonic-net
-    ref: master
+    ref: 202607
 
 parameters:
 - name: TIMEOUT_IN_MINUTES_PR_TEST


### PR DESCRIPTION
#### Why I did it

The Microsoft-internal `202607` PR and baseline pipelines were importing their pipeline and test resources from the public `master` branches. This can introduce master-only checker jobs into the release branch. GitHub PR CI has a known status gap when an imported job is later removed, which can leave existing PRs requiring manual merge.

##### Work item tracking
- Microsoft ADO **(number only)**: 39415360

#### How I did it

Updated the pipeline repository resources to use the matching Microsoft-internal release branches:

- `Azure/sonic-mgmt.msft`, branch `202607`
- `Azure/sonic-buildimage-msft`, branch `202607`

Applied the change to these four PR and baseline pipeline entry points:

- `azure-pipelines.yml`
- `.azure-pipelines/azure-pipelines-build-vs-and-test.yml`
- `.azure-pipelines/official-build-vs-with-test.yml`
- `.azure-pipelines/baseline_test/baseline.test.buildimage.yml`

The standalone VS-and-test pipeline now also defaults `MGMT_BRANCH` to `$(BUILD_BRANCH)` instead of `master`. The dedicated Docker pipelines are intentionally unchanged.

#### How to verify it

- Confirmed both internal `202607` branches exist.
- Confirmed all four pipeline entry points reference the internal `202607` repositories.
- Confirmed only the four PR and baseline entry points changed.
- `git diff --check` passes.

#### Which release branch to backport (provide reason below if selected)

- [x] 202607

This PR directly targets the internal `202607` branch and aligns its pipeline resources with the corresponding release branches.

#### Tested branch (Please provide the tested image version)

- [x] 202607, static pipeline configuration validation

#### Description for the changelog

N/A

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

N/A
