### PR TITLE
[ci]: Automate release pipeline branch matching

### DIFF
--- a/.github/workflows/align-release-pipeline-refs.yml
+++ b/.github/workflows/align-release-pipeline-refs.yml
@@ -1,0 +1,212 @@
+name: Align release pipeline references
+
+on:
+  create:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Release branch to align
+        required: true
+        type: string
+  pull_request:
+    branches:
+      - master
+  pull_request_target:
+    branches:
+      - '20*'
+
+jobs:
+  self-test:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          path: target
+      - name: Exercise alignment and check modes
+        run: |
+          set +e
+          python3 target/scripts/align_release_pipeline_refs.py \
+            --root target --branch 202608 --scope internal --check
+          check_status=$?
+          set -e
+          if [[ "${check_status}" -ne 1 ]]; then
+            echo "Expected mismatch exit code 1, received ${check_status}"
+            exit 1
+          fi
+          python3 target/scripts/align_release_pipeline_refs.py \
+            --root target --branch 202608 --scope internal
+          python3 target/scripts/align_release_pipeline_refs.py \
+            --root target --branch 202608 --scope internal --check
+          git -C target diff --check
+
+  release-pipeline-refs:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      RELEASE_BRANCH: ${{ github.base_ref }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Checkout trusted alignment logic
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: master
+          path: automation
+          persist-credentials: false
+      - name: Fetch pull request merge as data
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir target
+          git -C target init
+          gh auth setup-git
+          git -C target remote add origin \
+            "https://github.com/${GITHUB_REPOSITORY}.git"
+          git -C target fetch --depth=1 origin "refs/pull/${PR_NUMBER}/merge"
+          git -C target checkout --detach FETCH_HEAD
+          git -C target remote remove origin
+      - name: Verify matching sonic-mgmt branch exists
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          gh api "repos/Azure/sonic-mgmt.msft/branches/${RELEASE_BRANCH}" --silent
+      - name: Verify release pipeline references
+        run: |
+          python3 automation/scripts/align_release_pipeline_refs.py \
+            --root target --branch "${RELEASE_BRANCH}" --scope internal --check
+
+  open-alignment-pr:
+    if: >-
+      (github.event_name == 'create' &&
+       github.event.ref_type == 'branch' &&
+       startsWith(github.event.ref, '20')) ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Normalize release branch
+        id: release
+        env:
+          RAW_RELEASE_BRANCH: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.event.ref }}
+        run: |
+          release_branch="${RAW_RELEASE_BRANCH#refs/heads/}"
+          if [[ ! "${release_branch}" =~ ^20[0-9]{4}$ ]]; then
+            echo "::error::Unsupported release branch ${RAW_RELEASE_BRANCH}"
+            exit 1
+          fi
+          echo "branch=${release_branch}" >> "${GITHUB_OUTPUT}"
+          echo "pr_branch=automation/align-pipeline-refs-${release_branch}" >> "${GITHUB_OUTPUT}"
+      - name: Require automation token
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          if [[ -z "${GH_TOKEN}" ]]; then
+            echo "::error::TOKEN must allow branch pushes and pull request creation"
+            exit 1
+          fi
+      - name: Checkout trusted alignment logic
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: master
+          path: automation
+          persist-credentials: false
+      - name: Checkout release branch
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ steps.release.outputs.branch }}
+          path: target
+          fetch-depth: 0
+          token: ${{ secrets.TOKEN }}
+      - name: Verify matching sonic-mgmt branch exists
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN }}
+          RELEASE_BRANCH: ${{ steps.release.outputs.branch }}
+        run: |
+          gh api "repos/Azure/sonic-mgmt.msft/branches/${RELEASE_BRANCH}" --silent
+      - name: Align release pipeline references
+        id: alignment
+        env:
+          RELEASE_BRANCH: ${{ steps.release.outputs.branch }}
+        run: |
+          python3 automation/scripts/align_release_pipeline_refs.py \
+            --root target --branch "${RELEASE_BRANCH}" --scope internal
+          if git -C target diff --quiet; then
+            echo "changed=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "changed=true" >> "${GITHUB_OUTPUT}"
+          fi
+      - name: Check for existing automation branch or pull request
+        if: steps.alignment.outputs.changed == 'true'
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN }}
+          PR_BRANCH: ${{ steps.release.outputs.pr_branch }}
+          RELEASE_BRANCH: ${{ steps.release.outputs.branch }}
+        run: |
+          pr_url="$(gh pr list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --head "${PR_BRANCH}" \
+            --base "${RELEASE_BRANCH}" \
+            --state open \
+            --json url \
+            --jq '.[0].url // ""')"
+          if [[ -n "${pr_url}" ]]; then
+            echo "pr_exists=true" >> "${GITHUB_OUTPUT}"
+            echo "::notice::Alignment pull request already exists: ${pr_url}"
+          else
+            echo "pr_exists=false" >> "${GITHUB_OUTPUT}"
+          fi
+          if git -C target ls-remote --exit-code origin \
+              "refs/heads/${PR_BRANCH}" >/dev/null 2>&1; then
+            echo "branch_exists=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "branch_exists=false" >> "${GITHUB_OUTPUT}"
+          fi
+      - name: Reject stale automation branch
+        if: >-
+          steps.alignment.outputs.changed == 'true' &&
+          steps.existing.outputs.pr_exists != 'true' &&
+          steps.existing.outputs.branch_exists == 'true'
+        env:
+          PR_BRANCH: ${{ steps.release.outputs.pr_branch }}
+        run: |
+          echo "::error::${PR_BRANCH} exists without an open pull request"
+          exit 1
+      - name: Commit and push alignment branch
+        if: >-
+          steps.alignment.outputs.changed == 'true' &&
+          steps.existing.outputs.pr_exists != 'true' &&
+          steps.existing.outputs.branch_exists != 'true'
+        env:
+          PR_BRANCH: ${{ steps.release.outputs.pr_branch }}
+          RELEASE_BRANCH: ${{ steps.release.outputs.branch }}
+        run: |
+          git -C target config user.name mssonicbld
+          git -C target config user.email sonicbld@microsoft.com
+          git -C target switch -c "${PR_BRANCH}"
+          git -C target add -u
+          git -C target commit --signoff \
+            -m "[ci][${RELEASE_BRANCH}]: Align pipeline resources with release branch"
+          git -C target push origin "HEAD:refs/heads/${PR_BRANCH}"
+      - name: Open alignment pull request
+        if: >-
+          steps.alignment.outputs.changed == 'true' &&
+          steps.existing.outputs.pr_exists != 'true' &&
+          steps.existing.outputs.branch_exists != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN }}
+          PR_BRANCH: ${{ steps.release.outputs.pr_branch }}
+          RELEASE_BRANCH: ${{ steps.release.outputs.branch }}
+        run: |
+          gh pr create \
+            --repo "${GITHUB_REPOSITORY}" \
+            --head "${PR_BRANCH}" \
+            --base "${RELEASE_BRANCH}" \
+            --title "[ci][${RELEASE_BRANCH}]: Align pipeline resources with release branch" \
+            --body "Automatically aligns PR and baseline pipeline resources with release branch \`${RELEASE_BRANCH}\`."

--- a/scripts/align_release_pipeline_refs.py
+++ b/scripts/align_release_pipeline_refs.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+PIPELINE_PATHS = (
+    Path("azure-pipelines.yml"),
+    Path(".azure-pipelines/azure-pipelines-build-vs-and-test.yml"),
+    Path(".azure-pipelines/official-build-vs-with-test.yml"),
+    Path(".azure-pipelines/baseline_test/baseline.test.buildimage.yml"),
+)
+
+REPOSITORIES = {
+    "public": {
+        "sonic-mgmt": "sonic-net/sonic-mgmt",
+        "buildimage": "sonic-net/sonic-buildimage",
+    },
+    "internal": {
+        "sonic-mgmt": "Azure/sonic-mgmt.msft",
+        "buildimage": "Azure/sonic-buildimage-msft",
+    },
+}
+
+
+class AlignmentError(RuntimeError):
+    pass
+
+
+def _line_ending(line):
+    return "\r\n" if line.endswith("\r\n") else "\n"
+
+
+def _replace_property(line, key, value):
+    match = re.match(rf"^(?P<indent>\s*){re.escape(key)}\s*:", line)
+    if not match:
+        raise AlignmentError(f"Unable to replace {key!r} in {line!r}")
+    return f"{match.group('indent')}{key}: {value}{_line_ending(line)}"
+
+
+def _align_repository(text, alias, repository_name, branch, required):
+    lines = text.splitlines(keepends=True)
+    resource_pattern = re.compile(
+        rf"^(?P<indent>\s*)-\s+repository:\s*{re.escape(alias)}\s*$"
+    )
+    start = next(
+        (index for index, line in enumerate(lines) if resource_pattern.match(line.rstrip("\r\n"))),
+        None,
+    )
+    if start is None:
+        if required:
+            raise AlignmentError(f"Missing repository resource {alias!r}")
+        return text
+
+    resource_indent = len(resource_pattern.match(lines[start].rstrip("\r\n")).group("indent"))
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        content = lines[index].rstrip("\r\n")
+        stripped = content.lstrip()
+        indent = len(content) - len(stripped)
+        if re.match(r"^-\s+repository\s*:", stripped) and indent <= resource_indent:
+            end = index
+            break
+        if stripped and not stripped.startswith("#") and indent < resource_indent:
+            end = index
+            break
+
+    name_index = next(
+        (index for index in range(start + 1, end) if re.match(r"^\s*name\s*:", lines[index])),
+        None,
+    )
+    if name_index is None:
+        raise AlignmentError(f"Repository resource {alias!r} has no name")
+    lines[name_index] = _replace_property(lines[name_index], "name", repository_name)
+
+    ref_index = next(
+        (index for index in range(start + 1, end) if re.match(r"^\s*ref\s*:", lines[index])),
+        None,
+    )
+    if ref_index is None:
+        indent = re.match(r"^(?P<indent>\s*)name\s*:", lines[name_index]).group("indent")
+        lines.insert(name_index + 1, f"{indent}ref: {branch}{_line_ending(lines[name_index])}")
+    else:
+        lines[ref_index] = _replace_property(lines[ref_index], "ref", branch)
+
+    return "".join(lines)
+
+
+def _align_mgmt_branch_default(text):
+    lines = text.splitlines(keepends=True)
+    parameter_pattern = re.compile(r"^(?P<indent>\s*)-\s+name:\s*MGMT_BRANCH\s*$")
+    start = next(
+        (index for index, line in enumerate(lines) if parameter_pattern.match(line.rstrip("\r\n"))),
+        None,
+    )
+    if start is None:
+        return text
+
+    parameter_indent = len(parameter_pattern.match(lines[start].rstrip("\r\n")).group("indent"))
+    for index in range(start + 1, len(lines)):
+        content = lines[index].rstrip("\r\n")
+        stripped = content.lstrip()
+        indent = len(content) - len(stripped)
+        if re.match(r"^-\s+name\s*:", stripped) and indent <= parameter_indent:
+            break
+        if re.match(r"^\s*default\s*:", lines[index]):
+            lines[index] = _replace_property(lines[index], "default", "'$(BUILD_BRANCH)'")
+            return "".join(lines)
+
+    raise AlignmentError("MGMT_BRANCH parameter has no default")
+
+
+def align_file(path, branch, scope):
+    text = path.read_text(encoding="utf-8")
+    repositories = REPOSITORIES[scope]
+    updated = _align_repository(
+        text,
+        "sonic-mgmt",
+        repositories["sonic-mgmt"],
+        branch,
+        required=True,
+    )
+    updated = _align_repository(
+        updated,
+        "buildimage",
+        repositories["buildimage"],
+        branch,
+        required=False,
+    )
+    if path.name == "azure-pipelines-build-vs-and-test.yml":
+        updated = _align_mgmt_branch_default(updated)
+    return text, updated
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Align PR and baseline pipeline resources with a release branch."
+    )
+    parser.add_argument("--branch", required=True)
+    parser.add_argument("--scope", choices=sorted(REPOSITORIES), required=True)
+    parser.add_argument("--root", type=Path, default=Path("."))
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Report mismatches without modifying files.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    branch = args.branch.removeprefix("refs/heads/")
+    if not re.fullmatch(r"20\d{4}", branch):
+        raise AlignmentError(f"Unsupported release branch {args.branch!r}")
+
+    root = args.root.resolve()
+    if not (root / PIPELINE_PATHS[0]).is_file():
+        raise AlignmentError(f"Missing required pipeline file {PIPELINE_PATHS[0]}")
+
+    mismatches = []
+    for relative_path in PIPELINE_PATHS:
+        path = root / relative_path
+        if not path.is_file():
+            continue
+        original, updated = align_file(path, branch, args.scope)
+        if original == updated:
+            continue
+        mismatches.append(str(relative_path))
+        if not args.check:
+            path.write_text(updated, encoding="utf-8")
+
+    if args.check and mismatches:
+        print("Release pipeline references are not branch-aligned:", file=sys.stderr)
+        for path in mismatches:
+            print(f"  {path}", file=sys.stderr)
+        return 1
+
+    action = "Checked" if args.check else "Aligned"
+    print(f"{action} release pipeline references for {branch} ({args.scope})")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except AlignmentError as error:
+        print(f"error: {error}", file=sys.stderr)
+        sys.exit(2)


### PR DESCRIPTION
#### Why I did it

Microsoft-internal release branches inherit pipeline files from `master`, but their PR and baseline pipelines must consume the corresponding internal sonic-mgmt and buildimage release branches. A stale public `master` or older release reference can import a different checker set. If a checker later disappears, GitHub PR CI can retain a status that is no longer updated.

Internal release branches such as `202606`, `202607`, and `202608` must consistently use the matching internal repositories and branch names without requiring one-off pipeline fixes.

##### Work item tracking
- Microsoft ADO **(number only)**: 39415360

#### How I did it

Added `scripts/align_release_pipeline_refs.py` to align these four PR and baseline entry points when they exist:

- `azure-pipelines.yml`
- `.azure-pipelines/azure-pipelines-build-vs-and-test.yml`
- `.azure-pipelines/official-build-vs-with-test.yml`
- `.azure-pipelines/baseline_test/baseline.test.buildimage.yml`

For an internal release branch such as `202608`, the script enforces:

- `Azure/sonic-mgmt.msft`, branch `202608`
- `Azure/sonic-buildimage-msft`, branch `202608`
- `MGMT_BRANCH` defaults to `$(BUILD_BRANCH)` where applicable

Added a master-owned workflow that:

- Aligns a newly created `20????` branch.
- Supports manual dispatch for existing release branches.
- Verifies that the matching internal sonic-mgmt branch exists and fails instead of falling back to public `master`.
- Uses trusted master logic in a `pull_request_target` check for every release PR, without executing code from the PR checkout.
- Self-tests write and check modes on PRs targeting `master`.

The dedicated Docker pipelines are intentionally outside this scope.

#### How to verify it

- Confirmed internal sonic-mgmt branches `202606`, `202607`, and `202608` exist.
- Exercised check and write modes against the real `202607` and `202608` buildimage trees.
- Confirmed both branches are corrected by changing only the four PR and baseline entry points.
- Confirmed unsupported branch names are rejected.
- Confirmed workflow YAML parses and `git diff --check` passes.

#### Which release branch to backport (provide reason below if selected)

None. This change belongs on `master` so future internal release branches inherit the alignment automation.

#### Tested branch (Please provide the tested image version)

- [x] master, with static validation against 202607 and 202608

#### Description for the changelog

N/A

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

N/A
