### PR TITLE
Backport 2 fixes from sonic-net/sonic-buildimage 202511 to 202512

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -2932,7 +2932,7 @@ def parse_chassis_hwsku(root,chassis_hostname):
         if child.tag == str(QName(ns, "PngDec")):
             devices = child.find(str(QName(ns, "Devices")))
             for device in devices.findall(str(QName(ns, "Device"))):
-                if chassis_hostname.lower() ==  device.find(str(QName(ns, "Hostname"))).text.lower():
+                if chassis_hostname and (chassis_hostname.lower() ==  device.find(str(QName(ns, "Hostname"))).text.lower()):
                     hwsku =  device.find(str(QName(ns, "HwSku"))).text
                     return hwsku
     return None

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -5,6 +5,8 @@ import ipaddress
 import tests.common_utils as utils
 import minigraph
 
+from lxml import etree as ET
+from lxml.etree import QName
 from unittest import TestCase
 
 TOR_ROUTER = 'ToRRouter'
@@ -575,3 +577,30 @@ class TestCfgGenCaseInsensitive(TestCase):
         # TC2: For other minigraph, result should not contain FLEX_COUNTER_TABLE
         result = minigraph.parse_xml(self.sample_graph, port_config_file=self.port_config)
         self.assertNotIn('FLEX_COUNTER_TABLE', result)
+
+
+class TestParseChassisHwsku(TestCase):
+    def build_root(self, devices):
+        ns = minigraph.ns
+        root = ET.Element(QName(ns, "root"))
+        png = ET.SubElement(root, QName(ns, "PngDec"))
+        devices_node = ET.SubElement(png, QName(ns, "Devices"))
+        for hostname, hwsku in devices:
+            device = ET.SubElement(devices_node, QName(ns, "Device"))
+            ET.SubElement(device, QName(ns, "Hostname")).text = hostname
+            ET.SubElement(device, QName(ns, "HwSku")).text = hwsku
+        return root
+
+    def test_parse_chassis_hwsku_matching_hostname(self):
+        root = self.build_root([('str-sonic', 'Sonic-chassis-sku')])
+        self.assertEqual(minigraph.parse_chassis_hwsku(root, 'str-sonic'), 'Sonic-chassis-sku')
+
+    def test_parse_chassis_hwsku_no_match(self):
+        root = self.build_root([('str-sonic', 'Sonic-chassis-sku')])
+        self.assertIsNone(minigraph.parse_chassis_hwsku(root, 'other-host'))
+
+    def test_parse_chassis_hwsku_none_hostname(self):
+        # VOQ pizzabox: chassis-type minigraph with no ParentRouter, so chassis_hostname is None.
+        # parse_chassis_hwsku must return None instead of raising AttributeError.
+        root = self.build_root([('str-sonic', 'Sonic-chassis-sku')])
+        self.assertIsNone(minigraph.parse_chassis_hwsku(root, None))

--- a/src/sonic-supervisord-utilities-rs/Cargo.lock
+++ b/src/sonic-supervisord-utilities-rs/Cargo.lock
@@ -160,15 +160,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "deranged"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
-dependencies = [
- "powerfmt",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,15 +173,6 @@ checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "version_check",
 ]
 
 [[package]]
@@ -234,17 +216,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hostname"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
-dependencies = [
- "libc",
- "match_cfg",
- "winapi",
-]
 
 [[package]]
 name = "injectorpp"
@@ -308,12 +279,6 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-
-[[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
@@ -380,21 +345,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,12 +367,6 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -620,9 +564,12 @@ dependencies = [
  "scopeguard",
  "serde_json",
  "swss-common",
- "syslog",
+ "syslog-tracing",
  "tempfile",
  "thiserror",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -655,16 +602,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "syslog"
-version = "6.1.1"
+name = "syslog-tracing"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc7e95b5b795122fafe6519e27629b5ab4232c73ebb2428f568e82b1a457ad3"
+checksum = "d349bc2df408b4bf656709a29643641cef7f1795d708f88b105c626a8f64f6e4"
 dependencies = [
- "error-chain",
- "hostname",
  "libc",
- "log",
- "time",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -710,46 +655,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
-dependencies = [
- "deranged",
- "itoa",
- "libc",
- "num-conv",
- "num_threads",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
-
-[[package]]
-name = "time-macros"
-version = "0.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
-dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -809,12 +733,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/src/sonic-supervisord-utilities-rs/Cargo.toml
+++ b/src/sonic-supervisord-utilities-rs/Cargo.toml
@@ -16,7 +16,10 @@ path = "src/bin/supervisor_proc_exit_listener.rs"
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }
 log = "0.4"
-syslog = "6.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt"] }
+tracing-log = "0.2"
+syslog-tracing = "0.3"
 nix = { version = "0.27", features = ["signal", "process"] }
 thiserror = "1.0"
 mio = { version = "0.8", features = ["os-poll", "os-ext"] }

--- a/src/sonic-supervisord-utilities-rs/src/proc_exit_listener.rs
+++ b/src/sonic-supervisord-utilities-rs/src/proc_exit_listener.rs
@@ -3,19 +3,17 @@
 
 use crate::childutils;
 use clap::Parser;
-use log::{error, info, warn, Level, LevelFilter, Log, Metadata, Record};
+use log::{error, info, warn, Level};
 use mio::{Events, Token};
 use nix::sys::signal::{self, Signal};
 use nix::unistd::getppid;
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{self, BufRead, BufReader, Read, Write};
+use std::io::{self, BufRead, BufReader, Read};
 use std::os::unix::io::AsRawFd;
 use std::process;
-use std::sync::Mutex;
 use std::time::{Duration, Instant};
 use swss_common::{ConfigDBConnector, EventPublisher};
-use syslog::Severity;
 use thiserror::Error;
 
 // File paths
@@ -156,7 +154,7 @@ pub fn get_group_and_process_list(process_file: &str) -> Result<(Vec<String>, Ve
 }
 
 /// Generate alerting message
-pub fn generate_alerting_message(process_name: &str, status: &str, dead_minutes: u64, priority: Severity) {
+pub fn generate_alerting_message(process_name: &str, status: &str, dead_minutes: u64, priority: Level) {
     let namespace_prefix = std::env::var("NAMESPACE_PREFIX").unwrap_or_default();
     let namespace_id = std::env::var("NAMESPACE_ID").unwrap_or_default();
 
@@ -171,12 +169,11 @@ pub fn generate_alerting_message(process_name: &str, status: &str, dead_minutes:
         process_name, status, namespace, dead_minutes
     );
 
-    // Log with appropriate severity (matching syslog levels)
     match priority {
-        Severity::LOG_ERR => error!("{}", message),
-        Severity::LOG_WARNING => warn!("{}", message),
-        Severity::LOG_INFO => info!("{}", message),
-        _ => error!("{}", message),
+        Level::Error => error!("{}", message),
+        Level::Warn  => warn!("{}", message),
+        Level::Info  => info!("{}", message),
+        _            => error!("{}", message),
     }
 }
 
@@ -257,83 +254,25 @@ pub fn get_current_time() -> f64 {
     start.elapsed().as_secs_f64()
 }
 
-/// Dual logger: always writes to stderr (supervisord captures it), and connects
-/// to syslog lazily on each write. This matches the behaviour of Python's syslog
-/// module, which also reconnects on every call. A not-yet-ready /dev/log at
-/// startup never causes init failure or startretries/FATAL; once /dev/log
-/// appears (rsyslogd starts), the next write picks it up automatically.
-struct DualLogger {
-    level: LevelFilter,
-    syslog: Mutex<Option<syslog::Logger<syslog::LoggerBackend, syslog::Formatter3164>>>,
-}
-
-impl DualLogger {
-    fn make_syslog() -> Option<syslog::Logger<syslog::LoggerBackend, syslog::Formatter3164>> {
-        syslog::unix(syslog::Formatter3164 {
-            facility: syslog::Facility::LOG_USER,
-            ..Default::default()
-        }).ok()
-    }
-}
-
-impl Log for DualLogger {
-    fn enabled(&self, metadata: &Metadata) -> bool {
-        metadata.level() <= self.level
-    }
-
-    fn log(&self, record: &Record) {
-        if !self.enabled(record.metadata()) {
-            return;
-        }
-        // stderr is always available; supervisord captures and routes it.
-        let _ = writeln!(io::stderr(), "{}: {}", record.level(), record.args());
-        // syslog: lazy-connect on each write so /dev/log not being ready at
-        // startup is non-fatal and self-healing (matches Python syslog behaviour).
-        if let Ok(mut guard) = self.syslog.lock() {
-            if guard.is_none() {
-                *guard = Self::make_syslog();
-            }
-            if let Some(ref mut l) = *guard {
-                let msg = record.args().to_string();
-                let result = match record.level() {
-                    Level::Error => l.err(msg),
-                    Level::Warn  => l.warning(msg),
-                    Level::Info  => l.info(msg),
-                    Level::Debug | Level::Trace => l.debug(msg),
-                };
-                // If the write fails (e.g. /dev/log closed), drop the handle so
-                // the next call retries the connection.
-                if result.is_err() {
-                    *guard = None;
-                }
-            }
-        }
-    }
-
-    fn flush(&self) {}
-}
-
-/// Initialize logging to both stderr and syslog. Syslog init failure is
-/// non-fatal: the logger connects lazily on first write and retries on every
-/// subsequent write until /dev/log is available. This prevents the /dev/log-
-/// not-ready race at container startup that caused startretries exhaustion and
-/// FATAL state, while ensuring syslog alerting resumes as soon as rsyslogd is up.
-fn init_logging() {
-    let logger = DualLogger {
-        level: LevelFilter::Info,
-        syslog: Mutex::new(DualLogger::make_syslog()),
-    };
-    if log::set_boxed_logger(Box::new(logger)).is_ok() {
-        log::set_max_level(LevelFilter::Info);
-    }
-}
-
 /// Main function with testable parameters
 pub fn main_with_args(args: Option<Vec<String>>) -> Result<()> {
-    // Best-effort logging init: stderr always works, syslog is optional.
-    // This prevents the /dev/log-not-ready race at container startup that
-    // caused startretries exhaustion and FATAL state.
-    init_logging();
+    // Initialize syslog via libc openlog/syslog. libc defers the /dev/log socket
+    // open until the first syslog() call and reconnects transparently on error,
+    // so there is no startup race and no reconnect logic needed in application code.
+    let _ = tracing_log::LogTracer::init();
+    let syslog = syslog_tracing::Syslog::new(
+        std::ffi::CStr::from_bytes_with_nul(b"supervisor-proc-exit-listener\0")
+            .expect("literal CStr is valid"),
+        syslog_tracing::Options::LOG_PID,
+        syslog_tracing::Facility::Daemon,
+    ).ok_or_else(|| SupervisorError::Parse("Failed to initialize syslog".into()))?;
+    tracing_subscriber::fmt()
+        .with_writer(syslog)
+        .with_ansi(false)
+        .with_target(false)
+        .without_time()
+        .try_init()
+        .ok(); // ignore "already initialized" in test contexts
 
     // Parse command line arguments
     let parsed_args = if let Some(args) = args {
@@ -544,7 +483,7 @@ pub fn main_with_parsed_args_and_stdin<S: Read + AsRawFd, P: Poller>(args: Args,
                     let new_dead_minutes = current_dead_minutes + elapsed_mins as f64;
                     process_info.insert("dead_minutes".to_string(), new_dead_minutes);
 
-                    generate_alerting_message(process_name, "not running", new_dead_minutes as u64, Severity::LOG_ERR);
+                    generate_alerting_message(process_name, "not running", new_dead_minutes as u64, Level::Error);
                 }
             }
         }
@@ -556,7 +495,7 @@ pub fn main_with_parsed_args_and_stdin<S: Read + AsRawFd, P: Poller>(args: Args,
                 let threshold = get_heartbeat_alert_interval(process, &heartbeat_intervals);
                 if threshold > 0.0 && elapsed_secs >= threshold {
                     let elapsed_mins = (elapsed_secs / 60.0) as u64;
-                    generate_alerting_message(process, "stuck", elapsed_mins, Severity::LOG_WARNING);
+                    generate_alerting_message(process, "stuck", elapsed_mins, Level::Warn);
                 }
             }
         }
@@ -585,54 +524,51 @@ mod tests {
         assert!(time2 > time1);
     }
 
-    /// DualLogger must not panic when /dev/log is absent (syslog slot is None).
-    /// This is the core property that prevents startretries exhaustion.
+    /// Syslog::new() returns None when a global subscriber is already installed
+    /// (libc syslog is process-global). Calling try_init().ok() on the second
+    /// Syslog must not panic — this is the core property that allows multiple
+    /// calls to main_with_args() in the same test process without crashing.
     #[test]
-    fn test_dual_logger_no_panic_without_syslog() {
-        let logger = DualLogger {
-            level: LevelFilter::Info,
-            syslog: Mutex::new(None), // simulate /dev/log absent
-        };
-        // log() must not panic with a None syslog slot
-        let record = log::Record::builder()
-            .level(Level::Info)
-            .args(format_args!("test: /dev/log absent"))
-            .module_path(Some("test"))
-            .file(Some("test"))
-            .line(Some(1))
-            .build();
-        logger.log(&record); // must not panic
+    fn test_syslog_init_idempotent_no_panic() {
+        let ident = std::ffi::CStr::from_bytes_with_nul(b"test-idempotent\0").unwrap();
+        // First init — may succeed or fail depending on test ordering; either is fine.
+        let first = syslog_tracing::Syslog::new(
+            ident,
+            syslog_tracing::Options::LOG_PID,
+            syslog_tracing::Facility::Daemon,
+        );
+        if let Some(syslog) = first {
+            let _ = tracing_subscriber::fmt()
+                .with_writer(syslog)
+                .with_ansi(false)
+                .with_target(false)
+                .without_time()
+                .try_init()
+                .ok();
+        }
+        // Second attempt: Syslog::new() must return None (singleton), not panic.
+        let second = syslog_tracing::Syslog::new(
+            ident,
+            syslog_tracing::Options::LOG_PID,
+            syslog_tracing::Facility::Daemon,
+        );
+        assert!(second.is_none(), "Syslog::new() should return None when already initialised");
     }
 
-    /// DualLogger::enabled() must respect the level filter.
+    /// generate_alerting_message must not panic for any Level variant,
+    /// including the catch-all arm (e.g. Trace).
     #[test]
-    fn test_dual_logger_enabled_respects_level_filter() {
-        let logger = DualLogger {
-            level: LevelFilter::Info,
-            syslog: Mutex::new(None),
-        };
-        let info_meta = log::Metadata::builder().level(Level::Info).target("test").build();
-        let debug_meta = log::Metadata::builder().level(Level::Debug).target("test").build();
-        assert!(logger.enabled(&info_meta), "Info should be enabled at Info filter");
-        assert!(!logger.enabled(&debug_meta), "Debug should be disabled at Info filter");
+    fn test_generate_alerting_message_all_levels() {
+        for level in &[Level::Error, Level::Warn, Level::Info, Level::Debug, Level::Trace] {
+            // Must not panic
+            generate_alerting_message("test_proc", "not running", 5, *level);
+        }
     }
 
-    /// A record below the level filter must be silently dropped — no syslog
-    /// slot access, no panic.
+    /// generate_alerting_message must not panic with edge-case inputs.
     #[test]
-    fn test_dual_logger_below_level_silently_dropped() {
-        let logger = DualLogger {
-            level: LevelFilter::Info,
-            syslog: Mutex::new(None),
-        };
-        let record = log::Record::builder()
-            .level(Level::Debug)
-            .args(format_args!("should be dropped"))
-            .module_path(Some("test"))
-            .file(Some("test"))
-            .line(Some(1))
-            .build();
-        logger.log(&record); // must be a no-op — no panic, no side effect
+    fn test_generate_alerting_message_edge_cases() {
+        generate_alerting_message("", "", 0, Level::Error);
+        generate_alerting_message("very_long_process_name_exceeding_normal_length_by_a_lot", "some status", u64::MAX, Level::Warn);
     }
-
 }

--- a/src/sonic-supervisord-utilities-rs/tests/integration_tests.rs
+++ b/src/sonic-supervisord-utilities-rs/tests/integration_tests.rs
@@ -1,11 +1,11 @@
 //! Integration tests for sonic-supervisord-utilities-rs
 
+use log::Level;
 use sonic_supervisord_utilities_rs::{
     childutils,
     proc_exit_listener::*,
 };
 use swss_common::ConfigDBConnector;
-use syslog::Severity;
 use std::io::Write;
 use tempfile::NamedTempFile;
 use std::time::Duration;
@@ -69,13 +69,13 @@ fn test_generate_alerting_message() {
     // Test generate_alerting_message function
     // This function should log the message (we can't easily test the actual logging)
     // but we can test that it doesn't panic and follows the expected format
-    generate_alerting_message("test_process", "not running", 5, Severity::LOG_ERR);
-    generate_alerting_message("heartbeat_process", "stuck", 2, Severity::LOG_WARNING);
+    generate_alerting_message("test_process", "not running", 5, Level::Error);
+    generate_alerting_message("heartbeat_process", "stuck", 2, Level::Warn);
 
     // Test with namespace environment variables
     std::env::set_var("NAMESPACE_PREFIX", "asic");
     std::env::set_var("NAMESPACE_ID", "0");
-    generate_alerting_message("test_process", "not running", 10, Severity::LOG_ERR);
+    generate_alerting_message("test_process", "not running", 10, Level::Error);
     
     // Clean up
     std::env::remove_var("NAMESPACE_PREFIX");
@@ -155,17 +155,17 @@ fn test_namespace_detection() {
     // Test default namespace (host) - should not panic
     std::env::remove_var("NAMESPACE_PREFIX");
     std::env::remove_var("NAMESPACE_ID");
-    generate_alerting_message("test_process", "not running", 5, Severity::LOG_ERR);
+    generate_alerting_message("test_process", "not running", 5, Level::Error);
 
     // Test asic namespace - should not panic
     std::env::set_var("NAMESPACE_PREFIX", "asic");
     std::env::set_var("NAMESPACE_ID", "0");
-    generate_alerting_message("test_process", "not running", 5, Severity::LOG_ERR);
+    generate_alerting_message("test_process", "not running", 5, Level::Error);
 
     // Test partial namespace (should fallback to host) - should not panic
     std::env::set_var("NAMESPACE_PREFIX", "asic");
     std::env::remove_var("NAMESPACE_ID");
-    generate_alerting_message("test_process", "not running", 5, Severity::LOG_ERR);
+    generate_alerting_message("test_process", "not running", 5, Level::Error);
 
     // Cleanup
     std::env::remove_var("NAMESPACE_PREFIX");
@@ -194,10 +194,10 @@ fn test_autorestart_state_checking() {
 fn test_alerting_message_generation() {
     // Test different message types and priorities - function logs but doesn't return string
     // Main test is that it doesn't panic with various inputs
-    generate_alerting_message("orchagent", "not running", 5, Severity::LOG_ERR);
-    generate_alerting_message("portsyncd", "stuck", 10, Severity::LOG_WARNING);
-    generate_alerting_message("test", "status", 0, Severity::LOG_INFO);
-    generate_alerting_message("", "", 999, Severity::LOG_ALERT); // Edge case
+    generate_alerting_message("orchagent", "not running", 5, Level::Error);
+    generate_alerting_message("portsyncd", "stuck", 10, Level::Warn);
+    generate_alerting_message("test", "status", 0, Level::Info);
+    generate_alerting_message("", "", 999, Level::Warn); // Edge case
 }
 
 #[test]
@@ -280,9 +280,9 @@ fn test_function_robustness() {
     // Test that functions handle edge cases without panicking
 
     // Test generate_alerting_message with various inputs
-    generate_alerting_message("test", "status", 0, Severity::LOG_ERR);
-    generate_alerting_message("", "", 999, Severity::LOG_DEBUG);
-    generate_alerting_message("very_long_process_name_that_should_work", "some status", 60, Severity::LOG_WARNING);
+    generate_alerting_message("test", "status", 0, Level::Info);
+    generate_alerting_message("", "", 999, Level::Warn);
+    generate_alerting_message("very_long_process_name_that_should_work", "some status", 60, Level::Warn);
     
     // Test get_current_time multiple calls
     let times: Vec<f64> = (0..5).map(|_| {


### PR DESCRIPTION
### Description of PR
Summary:
Backport two fixes from `sonic-net/sonic-buildimage` `202511` branch that are not yet present on `202512`.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
1. `[sonic-config-engine] Fix minigraph parsing bug on voq pizzabox` (community #29046): `parse_chassis_hwsku()` in `minigraph.py` crashes with `AttributeError` when a VOQ-pizzabox chassis-type minigraph has no `ParentRouter` (i.e. `chassis_hostname` is `None`), because it calls `.lower()` unconditionally. Confirmed this bug is still present, unpatched, in `202512`.
2. `supervisor-proc-exit-listener-rs: replace DualLogger with syslog-tracing` (community #29141): follow-up to community PR #28827 (already cherry-picked into this branch as #3003), which fixed a `/dev/log` startup race with a custom `DualLogger` workaround. This commit replaces that workaround with the `syslog-tracing` crate (already used by `sonic-host-services`, `sonic-ctrmgrd-rs`, `sonic-dash-ha`, `sonic-swss-common`), which delegates to `libc::openlog()`/`syslog()` and handles reconnects automatically, removing ~130 lines of bespoke logger code.

#### How did you do it?
Straight cherry-picks (`git cherry-pick -x`) of the two upstream commits onto `202512`; both applied cleanly with no conflicts.

#### How did you verify/test it?
- `python3 -m py_compile` on the modified Python files passes.
- Upstream commit message reports `cargo test` 40/40 passing on master for the Rust change.

#### Any platform specific information?
The minigraph fix specifically addresses VOQ pizzabox chassis parsing.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
