### PR TITLE
[202512][Broadcom][SAI] Upgrade Broadcom XGS SAI 14.3.0.0.0.0.31.0 -> 14.3.0.0.0.0.35.0

### DIFF
--- a/platform/broadcom/sai-xgs.mk
+++ b/platform/broadcom/sai-xgs.mk
@@ -1,5 +1,5 @@
 # Broadcom XGS SAI definitions
-LIBSAIBCM_XGS_VERSION = 14.3.0.0.0.0.31.0
+LIBSAIBCM_XGS_VERSION = 14.3.0.0.0.0.35.0
 LIBSAIBCM_XGS_BRANCH_NAME = SAI_14.3.0_GA
 
 LIBSAIBCM_XGS_URL_PREFIX = "https://packages.trafficmanager.net/public/sai/sai-broadcom/$(LIBSAIBCM_XGS_BRANCH_NAME)/$(LIBSAIBCM_XGS_VERSION)/xgs"


### PR DESCRIPTION
### Description of PR
Cherry-pick of sonic-net/sonic-buildimage#29259 to the `202512` branch.

Summary:
Bump the Broadcom XGS SAI on the `202512` branch from `14.3.0.0.0.0.31.0` to `14.3.0.0.0.0.35.0`. Changes since `.31.0`:
- `14.3.0.0.0.0.32.0`: Add `sai_query_attribute_capability` support for `SAI_PORT_ATTR_INGRESS_MIRROR_SESSION` and `SAI_PORT_ATTR_EGRESS_MIRROR_SESSION` (SONIC-117724).
- `14.3.0.0.0.0.33.0`: Improve SAI 14.3 router-interface create/remove/set performance through the corresponding SDK update.
- `14.3.0.0.0.0.34.0`: Honor custom PFC class profiles on Tomahawk 6 when `Sai_pfc_dlr_init_capability=2` (SONIC-124044).
- `14.3.0.0.0.0.35.0`: Include Broadcom field-alert fix SDK-448354 for KNET transmission suspension. The CMICr packet-I/O configuration now reserves 2 TX and 12 RX DMA channels.

Microsoft ADO (number only): 39487567

Note: The source PR sonic-net/sonic-buildimage#29259 is still open (not yet merged upstream) at the time of this cherry-pick, per explicit request.

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Approach
#### What is the motivation for this PR?
Cherry-pick sonic-net/sonic-buildimage#29259 onto `202512` to pick up the Broadcom XGS SAI bump to `14.3.0.0.0.0.35.0`.

#### How did you do it?
`git cherry-pick -x` of commit a24bceb510ffc5382ebb7ebbcde0f95568154efa onto `202512`.

#### How did you verify/test it?
Clean cherry-pick with no conflicts; single-line version bump in `platform/broadcom/sai-xgs.mk`.

Signed-off-by: bingwang <bingwang@microsoft.com>